### PR TITLE
Setup.hs: unbreak 'runhaskell Setup configure' building mode

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -7,4 +7,4 @@
 -- Portability :  portable
 
 import Distribution.Simple
-main = defaultMain
+main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
Otherwise default hook won't generate src/GitRev.hs file.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
