### PR TITLE
Use tf-random for higher-quality randoms.

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -37,6 +37,7 @@ library
                        process         >= 1.2,
                        QuickCheck      >= 2.7,
                        random          >= 1.0.1,
+                       tf-random       >= 0.5,
                        smtLib          >= 1.0.7,
                        syb             >= 0.4,
                        text            >= 1.1,
@@ -179,6 +180,7 @@ executable cryptol
                        monadLib,
                        process,
                        random,
+                       tf-random,
                        transformers
   GHC-options:         -Wall -O2
 
@@ -202,6 +204,7 @@ executable cryptolnb
                        monadLib,
                        process,
                        random,
+                       tf-random,
                        transformers
   GHC-options:         -Wall -O2
 

--- a/cryptol/REPL/Command.hs
+++ b/cryptol/REPL/Command.hs
@@ -67,7 +67,7 @@ import System.Directory(getHomeDirectory,setCurrentDirectory,doesDirectoryExist)
 import qualified Data.Map as Map
 import qualified Data.IntMap as IntMap
 import System.IO(hFlush,stdout)
-import System.Random(newStdGen)
+import System.Random.TF(newTFGen)
 import Numeric (showFFloat)
 
 #if __GLASGOW_HASKELL__ < 706
@@ -266,7 +266,7 @@ qcCmd str =
               Just gens ->
                 do io $ putStrLn "Using random testing."
                    prt testingMsg
-                   g <- io newStdGen
+                   g <- io newTFGen
                    ok <- go (TestR.runTest val gens) testNum 0 g
                    when ok $
                      case n of

--- a/src/Cryptol/Prims/Eval.hs
+++ b/src/Cryptol/Prims/Eval.hs
@@ -7,7 +7,7 @@
 -- Portability :  portable
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE PatternGuards #-}
@@ -30,7 +30,7 @@ import Data.List (sortBy,transpose,genericTake,genericReplicate,genericSplitAt)
 import Data.Ord (comparing)
 import Data.Bits (Bits(..))
 
-import System.Random (mkStdGen)
+import System.Random.TF (mkTFGen)
 
 
 -- Utilities -------------------------------------------------------------------
@@ -767,7 +767,7 @@ randomV :: TValue -> Integer -> Value
 randomV ty seed =
   case randomValue (tValTy ty) of
     Nothing -> zeroV ty
-    Just gen -> fst $ gen 100 $ mkStdGen (fromIntegral seed)
+    Just gen -> fst $ gen 100 $ mkTFGen (fromIntegral seed)
 
 
 -- Miscellaneous ---------------------------------------------------------------


### PR DESCRIPTION
Notice the randoms from StdGen are well-known to be quite bad.  For
example, see comments in issue #86.
