### PR TITLE
Issue 167

### DIFF
--- a/src/Cryptol/Parser/LexerUtils.hs
+++ b/src/Cryptol/Parser/LexerUtils.hs
@@ -245,6 +245,9 @@ layout cfg ts0 = loop implicitScope [] ts0
 
     -- add any block start tokens, and push a level on the stack
     (startToks,stack')
+      | startBlock && ty == EOF = ( [ virt cfg (to pos) VCurlyR
+                                    , virt cfg (to pos) VCurlyL ]
+                                  , offStack )
       | startBlock = ( [ virt cfg (to pos) VCurlyL ], Virtual (col (from pos)) : offStack )
       | otherwise  = ( [], offStack )
 

--- a/tests/issues/issue167.cry
+++ b/tests/issues/issue167.cry
@@ -1,0 +1,1 @@
+module M where

--- a/tests/issues/issue167.icry
+++ b/tests/issues/issue167.icry
@@ -1,0 +1,1 @@
+:l issue167.cry

--- a/tests/issues/issue167.icry.stdout
+++ b/tests/issues/issue167.icry.stdout
@@ -1,0 +1,3 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module M


### PR DESCRIPTION
This pull request fixes #167.

Part of the problem is that `Cryptol.Parser.LexerUtils.layout` never has a chance to insert a matching `VCurlR` to a `VCurlL` inserted immediately an EOF:

```
*Main> mapM_ print . map thing . fst $ lexer defaultConfig "module M where"
Token {tokenType = KW KW_module, tokenText = "module"}
Token {tokenType = Ident "M", tokenText = "M"}
Token {tokenType = KW KW_where, tokenText = "where"}
Token {tokenType = Virt VCurlyL, tokenText = "beginning of layout block"}
Token {tokenType = EOF, tokenText = "end of file"}
```