### PR TITLE
Import Bits Bool orphan instance from base-orphans

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -43,6 +43,7 @@ library
   Build-depends:       base            >= 4.6 && < 5,
                        array           >= 0.4,
                        async           >= 2.0,
+                       base-orphans    >= 0.1,
                        containers      >= 0.5,
                        deepseq         >= 1.3,
                        directory       >= 1.2,

--- a/src/Cryptol/Prims/Eval.hs
+++ b/src/Cryptol/Prims/Eval.hs
@@ -29,6 +29,7 @@ import Cryptol.Utils.Panic (panic)
 
 import Data.List (sortBy,transpose,genericTake,genericReplicate,genericSplitAt,genericIndex)
 import Data.Ord (comparing)
+import Data.Orphans ()
 import Data.Bits (Bits(..))
 
 import System.Random.TF (mkTFGen)
@@ -47,34 +48,6 @@ instance Num Bool where
   abs _         = noNum
   signum _      = noNum
   fromInteger _ = noNum
-#endif
-
-#if __GLASGOW_HASKELL__ < 708
-instance Bits Bool where
-  (.&.) = (&&)
-
-  (.|.) = (||)
-
-  xor = (/=)
-
-  complement = not
-
-  shift a 0 = a
-  shift _ _ = False
-
-  rotate a _ = a
-
-  bitSize _ = 1
-
-  isSigned _ = False
-
-  testBit a 1 = a
-  testBit _ _ = False
-
-  bit 0 = True
-  bit _ = False
-
-  popCount a = if a then 1 else 0
 #endif
 
 


### PR DESCRIPTION
This pull request replaces `cryptol`'s orphan `Bits Bool` instance with one exported from the `base-orphans` library. This helps mitigate the possibility of other libraries defining a `Bits Bool` instance and failing to compile if used together with `cryptol` on GHC 7.6 or earlier.