### PR TITLE
#210 Add install location prompt

### DIFF
--- a/win32/cryptol.wxs
+++ b/win32/cryptol.wxs
@@ -62,9 +62,9 @@
 
     <Icon Id="crypto.ico" SourceFile="win32/crypto.ico" />
 
-    <UI>
-      <UIRef Id="WixUI_Minimal" />
-    </UI>
+	<Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+    <UIRef Id="WixUI_InstallDir" />
 
     <WixVariable Id="WixUILicenseRtf" Value="LICENSE.rtf" />
 


### PR DESCRIPTION
Letting the user pick the installation directory for Cryptol could
potentially help ease a few issues and headaches sometimes encountered
when doing a Windows install. Seems like such a customization option is
pretty standard in most installers.

*User now sees one additional page in the install wizard after the
license agreement screen.