### PR TITLE
Only require cryptol-server's build depends when it's being built.

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -208,7 +208,14 @@ executable cryptol-server
   main-is:             Main.hs
   hs-source-dirs:      cryptol-server
   other-modules:       Cryptol.Aeson
-  build-depends:       aeson >= 0.9
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+  GHC-options:         -Wall -O2
+  ghc-prof-options:    -auto-all -prof -rtsopts
+  if os(linux) && flag(static)
+      ld-options:      -static -pthread
+  if flag(server)
+      build-depends:   aeson >= 0.9
                      , aeson-pretty >= 0.7
                      , base
                      , bytestring >= 0.10
@@ -219,13 +226,5 @@ executable cryptol-server
                      , transformers
                      , unordered-containers >= 0.2
                      , zeromq4-haskell >= 0.6
-  default-language:    Haskell2010
-  default-extensions:  OverloadedStrings
-  GHC-options:         -Wall -O2
-  ghc-prof-options:    -auto-all -prof -rtsopts
-  if os(linux) && flag(static)
-      ld-options:      -static -pthread
-  if flag(server)
-      buildable: True
   else
       buildable: False


### PR DESCRIPTION
By moving `build-depends` under the `if flag(server)` check. The diff
is a little hard to read, because I did not change the indentation of
the dependencies. Thanks @elliottt for the fix!

See comments on https://github.com/GaloisInc/cryptol/commit/0d61ed14c33aaa25845d016215c146184334d22c for context.