### PR TITLE
Improve handling of interrupts for non-Haskeline frontends

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -40,35 +40,37 @@ flag server
 library
   Default-language:
     Haskell98
-  Build-depends:       base             >= 4.7 && < 5,
-                       base-compat      >= 0.6,
-                       array            >= 0.4,
-                       async            >= 2.0,
-                       containers       >= 0.5,
-                       deepseq          >= 1.3,
-                       deepseq-generics >= 0.1,
-                       directory        >= 1.2,
-                       filepath         >= 1.3,
-                       gitrev           >= 1.0,
-                       generic-trie     >= 0.3.0.1,
-                       GraphSCC         >= 1.0.4,
-                       heredoc          >= 0.2,
-                       monadLib         >= 3.7.2,
-                       old-time         >= 1.1,
-                       presburger       >= 1.3,
-                       pretty           >= 1.1,
-                       process          >= 1.2,
-                       QuickCheck       >= 2.7,
-                       random           >= 1.0.1,
-                       sbv              >= 5.5,
-                       smtLib           >= 1.0.7,
-                       simple-smt       >= 0.6.0,
-                       syb              >= 0.4,
-                       text             >= 1.1,
+  Build-depends:       base              >= 4.7 && < 5,
+                       base-compat       >= 0.6,
+                       array             >= 0.4,
+                       async             >= 2.0,
+                       containers        >= 0.5,
+                       deepseq           >= 1.3,
+                       deepseq-generics  >= 0.1,
+                       directory         >= 1.2,
+                       filepath          >= 1.3,
+                       gitrev            >= 1.0,
+                       generic-trie      >= 0.3.0.1,
+                       GraphSCC          >= 1.0.4,
+                       heredoc           >= 0.2,
+                       monad-control     >= 1.0,
+                       monadLib          >= 3.7.2,
+                       old-time          >= 1.1,
+                       presburger        >= 1.3,
+                       pretty            >= 1.1,
+                       process           >= 1.2,
+                       QuickCheck        >= 2.7,
+                       random            >= 1.0.1,
+                       sbv               >= 5.5,
+                       smtLib            >= 1.0.7,
+                       simple-smt        >= 0.6.0,
+                       syb               >= 0.4,
+                       text              >= 1.1,
                        template-haskell,
-                       tf-random        >= 0.5,
-                       transformers     >= 0.3,
-                       utf8-string      >= 0.3
+                       tf-random         >= 0.5,
+                       transformers      >= 0.3,
+                       transformers-base >= 0.4,
+                       utf8-string       >= 0.3
 
   Build-tools:         alex, happy
   hs-source-dirs:      src
@@ -192,6 +194,7 @@ executable cryptol
                      , filepath
                      , haskeline
                      , monadLib
+                     , monad-control
                      , process
                      , random
                      , sbv
@@ -213,21 +216,22 @@ executable cryptol-server
   ghc-prof-options:    -auto-all -prof -rtsopts
   if os(linux) && flag(static)
       ld-options:      -static -pthread
-  if flag(server)
-      build-depends:   aeson >= 0.10
-                     , aeson-pretty >= 0.7
-                     , base
-                     , base-compat
-                     , bytestring >= 0.10
-                     , containers
-                     , cryptol
-                     , filepath
-                     , text
-                     , transformers
-                     , unordered-containers >= 0.2
-                     , zeromq4-haskell >= 0.6
-  else
-      buildable: False
+--  if flag(server)
+  build-depends:   aeson >= 0.10
+                 , aeson-pretty >= 0.7
+                 , base
+                 , base-compat
+                 , bytestring >= 0.10
+                 , containers
+                 , cryptol
+                 , filepath
+                 , monad-control
+                 , text
+                 , transformers
+                 , unordered-containers >= 0.2
+                 , zeromq4-haskell >= 0.6
+--  else
+--      buildable: False
 
 benchmark cryptol-bench
   type:                exitcode-stdio-1.0

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -216,22 +216,24 @@ executable cryptol-server
   ghc-prof-options:    -auto-all -prof -rtsopts
   if os(linux) && flag(static)
       ld-options:      -static -pthread
---  if flag(server)
-  build-depends:   aeson >= 0.10
-                 , aeson-pretty >= 0.7
-                 , base
-                 , base-compat
-                 , bytestring >= 0.10
-                 , containers
-                 , cryptol
-                 , filepath
-                 , monad-control
-                 , text
-                 , transformers
-                 , unordered-containers >= 0.2
-                 , zeromq4-haskell >= 0.6
---  else
---      buildable: False
+  if flag(server)
+     build-depends: aeson >= 0.10
+                  , aeson-pretty >= 0.7
+                  , base
+                  , base-compat
+                  , bytestring >= 0.10
+                  , containers
+                  , cryptol
+                  , filepath
+                  , monad-control
+                  , optparse-applicative
+                  , text
+                  , transformers
+                  , unix
+                  , unordered-containers >= 0.2
+                  , zeromq4-haskell >= 0.6
+  else
+      buildable: False
 
 benchmark cryptol-bench
   type:                exitcode-stdio-1.0

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -31,6 +31,9 @@ import           System.Directory ( doesFileExist
                                   , getCurrentDirectory)
 import           System.FilePath ((</>))
 
+import           Prelude ()
+import           Prelude.Compat
+
 -- | Haskeline-specific repl implementation.
 repl :: Cryptolrc -> Maybe FilePath -> REPL () -> IO ()
 repl cryrc mbBatch begin =

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -18,8 +18,9 @@ import           Cryptol.REPL.Trie
 import           Cryptol.Utils.PP
 
 import qualified Control.Exception as X
-import           Control.Monad (guard, when)
+import           Control.Monad (guard, join, when)
 import qualified Control.Monad.Trans.Class as MTL
+import           Control.Monad.Trans.Control
 import           Data.Char (isAlphaNum, isSpace)
 import           Data.Function (on)
 import           Data.List (isPrefixOf,nub,sortBy)
@@ -133,11 +134,8 @@ data Cryptolrc =
 -- Utilities -------------------------------------------------------------------
 
 instance MonadException REPL where
-  controlIO branchIO = REPL $ \ ref -> do
-    runBody <- branchIO $ RunIO $ \ m -> do
-      a <- unREPL m ref
-      return (return a)
-    unREPL runBody ref
+  controlIO f = join $ liftBaseWith $ \f' ->
+    f $ RunIO $ \m -> restoreM <$> (f' m)
 
 -- Titles ----------------------------------------------------------------------
 

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -9,14 +9,14 @@
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE DeriveGeneric #-}
-module Cryptol.Utils.PP where
+module Cryptol.Utils.PP (module Cryptol.Utils.PP, (<>)) where
 
 import           Cryptol.Utils.Ident
 
 import           Control.DeepSeq.Generics
 import           Control.Monad (mplus)
 import           Data.Maybe (fromMaybe)
-import qualified Data.Monoid as M
+import           Data.Monoid
 import           Data.String (IsString(..))
 import qualified Data.Text as T
 import           GHC.Generics (Generic)
@@ -36,7 +36,7 @@ instance NFData NameDisp where rnf = genericRnf
 instance Show NameDisp where
   show _ = "<NameDisp>"
 
-instance M.Monoid NameDisp where
+instance Monoid NameDisp where
   mempty = EmptyNameDisp
 
   mappend (NameDisp f)  (NameDisp g)  = NameDisp (\m n -> f m n `mplus` g m n)
@@ -70,7 +70,7 @@ fmtModName mn NotInScope     = mn
 -- | Compose two naming environments, preferring names from the left
 -- environment.
 extend :: NameDisp -> NameDisp -> NameDisp
-extend  = M.mappend
+extend  = mappend
 
 -- | Get the format for a name. When 'Nothing' is returned, the name is not
 -- currently in scope.
@@ -91,19 +91,23 @@ fixNameDisp disp (Doc f) = Doc (\ _ -> f disp)
 
 newtype Doc = Doc (NameDisp -> PJ.Doc) deriving (Generic)
 
+instance Monoid Doc where
+  mempty = liftPJ PJ.empty
+  mappend = liftPJ2 (PJ.<>)
+
 instance NFData Doc where rnf = genericRnf
 
 runDoc :: NameDisp -> Doc -> PJ.Doc
 runDoc names (Doc f) = f names
 
 instance Show Doc where
-  show d = show (runDoc M.mempty d)
+  show d = show (runDoc mempty d)
 
 instance IsString Doc where
   fromString = text
 
 render :: Doc -> String
-render d = PJ.render (runDoc M.mempty d)
+render d = PJ.render (runDoc mempty d)
 
 class PP a where
   ppPrec :: Int -> a -> Doc
@@ -196,9 +200,6 @@ liftPJ2 f (Doc a) (Doc b) = Doc (\e -> f (a e) (b e))
 
 liftSep :: ([PJ.Doc] -> PJ.Doc) -> ([Doc] -> Doc)
 liftSep f ds = Doc (\e -> f [ d e | Doc d <- ds ])
-
-(<>) :: Doc -> Doc -> Doc
-(<>)  = liftPJ2 (PJ.<>)
 
 (<+>) :: Doc -> Doc -> Doc
 (<+>)  = liftPJ2 (PJ.<+>)


### PR DESCRIPTION
This notably adds a `MonadBaseControl` instance for the `REPL` monad so
that we can catch asynchronous exceptions in the middle of `REPL`
computations. Since this is a generalization of Haskeline's exception
support, that orphan instance for the console executable is now in terms
of this new instance.