### PR TITLE
tweak for deepseq-generics-0.2

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -47,7 +47,7 @@ library
                        async             >= 2.0,
                        containers        >= 0.5,
                        deepseq           >= 1.3,
-                       deepseq-generics  >= 0.1 && < 0.2,
+                       deepseq-generics  >= 0.1 && < 0.3,
                        directory         >= 1.2,
                        filepath          >= 1.3,
                        gitrev            >= 1.0,

--- a/src/Cryptol/Eval/Env.hs
+++ b/src/Cryptol/Eval/Env.hs
@@ -20,6 +20,7 @@ import Cryptol.Utils.PP
 import qualified Data.Map as Map
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -29,6 +29,7 @@ import qualified Data.Text as T
 import Numeric (showIntAtBase)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 -- Utilities -------------------------------------------------------------------

--- a/src/Cryptol/ModuleSystem/Env.hs
+++ b/src/Cryptol/ModuleSystem/Env.hs
@@ -38,6 +38,7 @@ import System.FilePath ((</>), normalise, joinPath, splitPath, takeDirectory)
 import qualified Data.List as List
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/ModuleSystem/Interface.hs
+++ b/src/Cryptol/ModuleSystem/Interface.hs
@@ -28,6 +28,7 @@ import           Cryptol.Utils.Ident (ModName)
 import qualified Data.Map as Map
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/ModuleSystem/Monad.hs
+++ b/src/Cryptol/ModuleSystem/Monad.hs
@@ -34,6 +34,7 @@ import Data.Maybe (isJust)
 import MonadLib
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/ModuleSystem/Name.hs
+++ b/src/Cryptol/ModuleSystem/Name.hs
@@ -47,6 +47,7 @@ import           Cryptol.Utils.Ident
 import           Cryptol.Utils.Panic
 import           Cryptol.Utils.PP
 
+import           Control.DeepSeq
 import           Control.DeepSeq.Generics
 import           Control.Monad.Fix (MonadFix(mfix))
 import qualified Data.Map as Map

--- a/src/Cryptol/ModuleSystem/NamingEnv.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv.hs
@@ -31,6 +31,7 @@ import qualified Data.Set as Set
 import MonadLib (runId,Id)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -42,6 +42,7 @@ import qualified Data.Sequence as Seq
 import           MonadLib hiding (mapM)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -81,6 +81,7 @@ import           Data.Maybe (catMaybes)
 import           Numeric(showIntAtBase)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/Parser/LexerUtils.hs
+++ b/src/Cryptol/Parser/LexerUtils.hs
@@ -23,6 +23,7 @@ import qualified Data.Text.Lazy as T
 import           Data.Word(Word8)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 data Config = Config

--- a/src/Cryptol/Parser/NoInclude.hs
+++ b/src/Cryptol/Parser/NoInclude.hs
@@ -35,6 +35,7 @@ import qualified Control.Exception as X
 import           System.FilePath (takeDirectory,(</>),isAbsolute)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import System.Directory (getCurrentDirectory)

--- a/src/Cryptol/Parser/NoPat.hs
+++ b/src/Cryptol/Parser/NoPat.hs
@@ -30,6 +30,7 @@ import           Data.Either(partitionEithers)
 import qualified Data.Map as Map
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/Parser/ParserUtils.hs
+++ b/src/Cryptol/Parser/ParserUtils.hs
@@ -27,6 +27,7 @@ import qualified Data.Text.Lazy as T
 
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/Parser/Position.hs
+++ b/src/Cryptol/Parser/Position.hs
@@ -16,6 +16,7 @@ import           Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy as T
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Cryptol.Utils.PP

--- a/src/Cryptol/Prims/Syntax.hs
+++ b/src/Cryptol/Prims/Syntax.hs
@@ -18,6 +18,7 @@ import           Cryptol.Utils.PP
 import qualified Data.Map as Map
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 -- | Built-in types.

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -37,6 +37,7 @@ import Cryptol.TypeCheck.PP
 import Cryptol.TypeCheck.Solver.InfNat
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import           Data.Map    (Map)

--- a/src/Cryptol/TypeCheck/InferTypes.hs
+++ b/src/Cryptol/TypeCheck/InferTypes.hs
@@ -31,6 +31,7 @@ import qualified Data.Map as Map
 import qualified Data.IntMap as IntMap
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 data SolverConfig = SolverConfig

--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -36,6 +36,7 @@ import           Data.Function(on)
 import           MonadLib hiding (mapM)
 
 import GHC.Generics (Generic)
+import Control.DeepSeq
 import Control.DeepSeq.Generics
 
 import Prelude ()

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -12,7 +12,7 @@
 module Cryptol.Utils.PP where
 
 import           Cryptol.Utils.Ident
-
+import           Control.DeepSeq
 import           Control.DeepSeq.Generics
 import           Control.Monad (mplus)
 import           Data.Maybe (fromMaybe)


### PR DESCRIPTION
deepseq-generics-0.2 stopped reexporting NFData from deepseq.
Patch imports it explicitly.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>