### PR TITLE
Highlight the REPL prompt, errors, and test results with ANSI color.

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -89,6 +89,7 @@ library
                        Cryptol.Parser.Utils,
                        Cryptol.Parser.Unlit,
 
+                       Cryptol.Utils.Color,
                        Cryptol.Utils.Ident,
                        Cryptol.Utils.PP,
                        Cryptol.Utils.Panic,

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -41,6 +41,7 @@ library
   Default-language:
     Haskell98
   Build-depends:       base              >= 4.8 && < 5,
+                       ansi-terminal     >= 0.6,
                        base-compat       >= 0.6,
                        bytestring        >= 0.10,
                        array             >= 0.4,

--- a/cryptol/Main.hs
+++ b/cryptol/Main.hs
@@ -22,6 +22,7 @@ import REPL.Haskeline
 import REPL.Logo
 
 import Cryptol.Utils.PP
+import Cryptol.Utils.Color (warningMsg)
 import Cryptol.Version (commitHash, commitBranch, commitDirty)
 import Paths_cryptol (version)
 
@@ -197,7 +198,7 @@ setupCmdScript opts =
       hPutStr h (unlines cmds)
       hClose h
       when (isJust (optBatch opts)) $
-        putStrLn "[warning] --command argument specified; ignoring batch file"
+        putStrLn $ warningMsg ++ " --command argument specified; ignoring batch file"
       return (opts { optBatch = Just path }, Just path)
 
 setupREPL :: Options -> REPL ()

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -16,7 +16,7 @@ import           Cryptol.REPL.Command
 import           Cryptol.REPL.Monad
 import           Cryptol.REPL.Trie
 import           Cryptol.Utils.PP
-import           Cryptol.Utils.Color
+import           Cryptol.Utils.Color (colorPrompt)
 
 import qualified Control.Exception as X
 import           Control.Monad (guard, join, when)
@@ -67,7 +67,7 @@ repl cryrc mbBatch begin =
       Nothing -> return ()
 
   getInputLines prompt ls =
-    do mb <- getInputLine $ colorizeString Prompt prompt
+    do mb <- getInputLine $ colorPrompt prompt
        let newPropmpt = map (\_ -> ' ') prompt
        case mb of
           Nothing -> return Nothing

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Trans.Control
 import           Data.Char (isAlphaNum, isSpace)
 import           Data.Function (on)
 import           Data.List (isPrefixOf,nub,sortBy,sort)
-import           System.Console.ANSI (setTitle)
+import           System.Console.ANSI
 import           System.Console.Haskeline
 import           System.Directory ( doesFileExist
                                   , getHomeDirectory
@@ -66,13 +66,19 @@ repl cryrc mbBatch begin =
       Nothing -> return ()
 
   getInputLines prompt ls =
-    do mb <- getInputLine prompt
+    do mb <- getInputLine $ colorPrompt prompt
        let newPropmpt = map (\_ -> ' ') prompt
        case mb of
           Nothing -> return Nothing
           Just l | not (null l) && last l == '\\' ->
                                       getInputLines newPropmpt (init l : ls)
                  | otherwise -> return $ Just $ unlines $ reverse $ l : ls
+
+  colorPrompt prompt = prefix ++ prompt ++ suffix where
+    sgr | isBatch   = const ""
+        | otherwise = setSGRCode
+    prefix = sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
+    suffix = sgr [Reset]
 
   evalCryptolrc =
     case cryrc of

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Trans.Control
 import           Data.Char (isAlphaNum, isSpace)
 import           Data.Function (on)
 import           Data.List (isPrefixOf,nub,sortBy,sort)
-import           System.Console.ANSI
+import           System.Console.ANSI (setTitle)
 import           System.Console.Haskeline
 import           System.Directory ( doesFileExist
                                   , getHomeDirectory
@@ -66,19 +66,13 @@ repl cryrc mbBatch begin =
       Nothing -> return ()
 
   getInputLines prompt ls =
-    do mb <- getInputLine $ colorPrompt prompt
+    do mb <- getInputLine $ colorizeString Prompt prompt
        let newPropmpt = map (\_ -> ' ') prompt
        case mb of
           Nothing -> return Nothing
           Just l | not (null l) && last l == '\\' ->
                                       getInputLines newPropmpt (init l : ls)
                  | otherwise -> return $ Just $ unlines $ reverse $ l : ls
-
-  colorPrompt prompt = prefix ++ prompt ++ suffix where
-    sgr | isBatch   = const ""
-        | otherwise = setSGRCode
-    prefix = sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
-    suffix = sgr [Reset]
 
   evalCryptolrc =
     case cryrc of

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -16,6 +16,7 @@ import           Cryptol.REPL.Command
 import           Cryptol.REPL.Monad
 import           Cryptol.REPL.Trie
 import           Cryptol.Utils.PP
+import           Cryptol.Utils.Color
 
 import qualified Control.Exception as X
 import           Control.Monad (guard, join, when)

--- a/src/Cryptol/ModuleSystem/Monad.hs
+++ b/src/Cryptol/ModuleSystem/Monad.hs
@@ -28,6 +28,7 @@ import qualified Cryptol.TypeCheck.AST as T
 import           Cryptol.Parser.Position (Range)
 import           Cryptol.Utils.Ident (interactiveName)
 import           Cryptol.Utils.PP
+import           Cryptol.Utils.Color (errorMsg)
 
 import Control.Exception (IOException)
 import Data.Function (on)
@@ -109,7 +110,7 @@ instance PP ModuleError where
   ppPrec _ e = case e of
 
     ModuleNotFound src path ->
-      text "[error]" <+>
+      text errorMsg <+>
       text "Could not find module" <+> pp src
       $$
       hang (text "Searched paths:")
@@ -118,18 +119,18 @@ instance PP ModuleError where
       text "Set the CRYPTOLPATH environment variable to search more directories"
 
     CantFindFile path ->
-      text "[error]" <+>
+      text errorMsg <+>
       text "can't find file:" <+> text path
 
     OtherIOError path exn ->
-      hang (text "[error]" <+>
+      hang (text errorMsg <+>
             text "IO error while loading file:" <+> text path <> colon)
          4 (text (show exn))
 
     ModuleParseError _source err -> Parser.ppError err
 
     RecursiveModules mods ->
-      hang (text "[error] module imports form a cycle:")
+      hang (text $ errorMsg ++ " module imports form a cycle:")
          4 (vcat (map pp (reverse mods)))
 
     RenamerErrors _src errs -> vcat (map pp errs)
@@ -141,14 +142,14 @@ instance PP ModuleError where
     TypeCheckingFailed _src errs -> vcat (map T.ppError errs)
 
     ModuleNameMismatch expected found ->
-      hang (text "[error]" <+> pp (P.srcRange found) <> char ':')
+      hang (text errorMsg <+> pp (P.srcRange found) <> char ':')
          4 (vcat [ text "File name does not match module name:"
                  , text "Saw:"      <+> pp (P.thing found)
                  , text "Expected:" <+> pp expected
                  ])
 
     DuplicateModuleName name path1 path2 ->
-      hang (text "[error] module" <+> pp name <+>
+      hang (text (errorMsg ++ " module") <+> pp name <+>
             text "is defined in multiple files:")
          4 (vcat [text path1, text path2])
 

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -34,7 +34,7 @@ import Cryptol.Parser.Position
 import Cryptol.Utils.Ident (packIdent,packInfix)
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.PP
-import Cryptol.Utils.Color (errorMsg,errorAtMsg)
+import Cryptol.Utils.Color (errorMsg,errorAtMsg,warningAtMsg)
 
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
@@ -143,7 +143,7 @@ data RenamerWarning
 
 instance PP RenamerWarning where
   ppPrec _ (SymbolShadowed new originals disp) = fixNameDisp disp $
-    hang (text "[warning] at" <+> loc)
+    hang (text warningAtMsg <+> loc)
        4 $ fsep [ text "This binding for" <+> sym
                 , (text "shadows the existing binding" <> plural) <+> text "from" ]
         $$ vcat (map ppLocName originals)

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -34,6 +34,7 @@ import Cryptol.Parser.Position
 import Cryptol.Utils.Ident (packIdent,packInfix)
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.PP
+import Cryptol.Utils.Color (errorMsg,errorAtMsg)
 
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
@@ -86,46 +87,46 @@ instance PP RenamerError where
   ppPrec _ e = case e of
 
     MultipleSyms lqn qns disp -> fixNameDisp disp $
-      hang (text "[error] at" <+> pp (srcRange lqn))
+      hang (text errorAtMsg <+> pp (srcRange lqn))
          4 $ (text "Multiple definitions for symbol:" <+> pp (thing lqn))
           $$ vcat (map ppLocName qns)
 
     UnboundExpr lqn disp -> fixNameDisp disp $
-      hang (text "[error] at" <+> pp (srcRange lqn))
+      hang (text errorAtMsg <+> pp (srcRange lqn))
          4 (text "Value not in scope:" <+> pp (thing lqn))
 
     UnboundType lqn disp -> fixNameDisp disp $
-      hang (text "[error] at" <+> pp (srcRange lqn))
+      hang (text errorAtMsg <+> pp (srcRange lqn))
          4 (text "Type not in scope:" <+> pp (thing lqn))
 
     OverlappingSyms qns disp -> fixNameDisp disp $
-      hang (text "[error]")
+      hang (text errorMsg)
          4 $ text "Overlapping symbols defined:"
           $$ vcat (map ppLocName qns)
 
     ExpectedValue lqn disp -> fixNameDisp disp $
-      hang (text "[error] at" <+> pp (srcRange lqn))
+      hang (text errorAtMsg <+> pp (srcRange lqn))
          4 (fsep [ text "Expected a value named", quotes (pp (thing lqn))
                  , text "but found a type instead"
                  , text "Did you mean `(" <> pp (thing lqn) <> text")?" ])
 
     ExpectedType lqn disp -> fixNameDisp disp $
-      hang (text "[error] at" <+> pp (srcRange lqn))
+      hang (text errorAtMsg <+> pp (srcRange lqn))
          4 (fsep [ text "Expected a type named", quotes (pp (thing lqn))
                  , text "but found a value instead" ])
 
     FixityError o1 o2 disp -> fixNameDisp disp $
-      hang (text "[error]")
+      hang (text errorMsg)
          4 (fsep [ text "The fixities of", pp o1, text "and", pp o2
                  , text "are not compatible.  "
                  , text "You may use explicit parenthesis to disambiguate" ])
 
     InvalidConstraint ty disp -> fixNameDisp disp $
-      hang (text "[error]" <+> maybe empty (\r -> text "at" <+> pp r) (getLoc ty))
+      hang (text errorMsg <+> maybe empty (\r -> text "at" <+> pp r) (getLoc ty))
          4 (fsep [ pp ty, text "is not a valid constraint" ])
 
     MalformedBuiltin ty pn disp -> fixNameDisp disp $
-      hang (text "[error]" <+> maybe empty (\r -> text "at" <+> pp r) (getLoc ty))
+      hang (text errorMsg <+> maybe empty (\r -> text "at" <+> pp r) (getLoc ty))
          4 (fsep [ text "invalid use of built-in type", pp pn
                  , text "in type", pp ty ])
 

--- a/src/Cryptol/Parser/NoPat.hs
+++ b/src/Cryptol/Parser/NoPat.hs
@@ -24,6 +24,7 @@ import Cryptol.Parser.Position(Range(..),emptyRange,start,at)
 import Cryptol.Parser.Names (namesP)
 import Cryptol.Utils.PP
 import Cryptol.Utils.Panic(panic)
+import Cryptol.Utils.Color(errorMsg,errorAtMsg)
 
 import           MonadLib hiding (mapM)
 import           Data.Maybe(maybeToList)
@@ -487,28 +488,28 @@ instance PP Error where
   ppPrec _ err =
     case err of
       MultipleSignatures x ss ->
-        text "Multiple type signatures for" <+> quotes (pp x)
+        text (errorMsg ++ "Multiple type signatures for") <+> quotes (pp x)
         $$ nest 2 (vcat (map pp ss))
 
       SignatureNoBind x s ->
-        text "At" <+> pp (srcRange x) <> colon <+>
+        text errorAtMsg <+> pp (srcRange x) <> colon <+>
         text "Type signature without a matching binding:"
          $$ nest 2 (pp s)
 
       PragmaNoBind x s ->
-        text "At" <+> pp (srcRange x) <> colon <+>
+        text errorAtMsg <+> pp (srcRange x) <> colon <+>
         text "Pragma without a matching binding:"
          $$ nest 2 (pp s)
 
       MultipleFixities n locs ->
-        text "Multiple fixity declarations for" <+> quotes (pp n)
+        text (errorMsg ++ "Multiple fixity declarations for") <+> quotes (pp n)
         $$ nest 2 (vcat (map pp locs))
 
       FixityNoBind n ->
-        text "At" <+> pp (srcRange n) <> colon <+>
+        text errorAtMsg <+> pp (srcRange n) <> colon <+>
         text "Fixity declaration without a matching binding for:" <+>
          pp (thing n)
 
       MultipleDocs n locs ->
-        text "Multiple documentation blocks given for:" <+> pp n
+        text (errorMsg ++ "Multiple documentation blocks given for:") <+> pp n
         $$ nest 2 (vcat (map pp locs))

--- a/src/Cryptol/Parser/ParserUtils.hs
+++ b/src/Cryptol/Parser/ParserUtils.hs
@@ -20,6 +20,7 @@ import Cryptol.Parser.Position
 import Cryptol.Parser.Utils (translateExprToNumT,widthIdent)
 import Cryptol.Utils.PP
 import Cryptol.Utils.Panic
+import Cryptol.Utils.Color (errorMsg)
 
 import Data.Maybe(listToMaybe,fromMaybe)
 import Data.Bits(testBit,setBit)
@@ -80,14 +81,14 @@ instance PP ParseError where
 
 ppError :: ParseError -> Doc
 ppError (HappyError path pos (Just tok))
-  | Err _ <- tokenType tok = text "Parse error at" <+>
+  | Err _ <- tokenType tok = text (errorMsg ++ " Parsing failed at") <+>
                               text path <> char ':' <> pp pos <> comma <+>
                               pp tok
 ppError e@(HappyError path pos _) =
-                               text "Parse error at" <+>
+                               text (errorMsg ++ " Parsing failed at") <+>
                                text path <> char ':' <> pp pos <> comma <+>
                                text "unexpected" <+> pp e
-ppError (HappyErrorMsg p x)  = text "Parse error at" <+> pp p $$ nest 2 (text x)
+ppError (HappyErrorMsg p x)  = text (errorMsg ++ " Parsing failed at") <+> pp p $$ nest 2 (text x)
 
 instance Monad ParseM where
   return a  = P (\_ _ s -> Right (a,s))

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -779,7 +779,7 @@ runShellCmd cmd
             return ()
 
 cdCmd :: FilePath -> REPL ()
-cdCmd f | null f = rPutStrLn $ "[error] :cd requires a path argument"
+cdCmd f | null f = rPutStrLn $ errorMsg ++ " :cd requires a path argument"
         | otherwise = do
   exists <- io $ doesDirectoryExist f
   if exists

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -56,7 +56,7 @@ import qualified Cryptol.ModuleSystem.NamingEnv as M
 import qualified Cryptol.ModuleSystem.Renamer as M (RenamerWarning(SymbolShadowed))
 import qualified Cryptol.Utils.Ident as M
 
-import Cryptol.Utils.Color
+import Cryptol.Utils.Color (errorMsg, testPassedMsg, testFailedMsg, testErrorMsg)
 
 import qualified Cryptol.Eval.Value as E
 import Cryptol.Testing.Concrete
@@ -297,7 +297,7 @@ qcCmd qcMode str =
                   , testRptFailure = ppFailure
                   , testRptSuccess = do
                       delTesting
-                      prtLn $ colorizeString Passed "Passed " ++ show sz ++ " tests."
+                      prtLn $ testPassedMsg ++ " " ++ show sz ++ " tests."
                       rPutStrLn "Q.E.D."
                   }
             prt testingMsg
@@ -318,7 +318,7 @@ qcCmd qcMode str =
                       , testRptFailure = ppFailure
                       , testRptSuccess = do
                           delTesting
-                          prtLn $ colorizeString Passed "Passed " ++ show testNum ++ " tests."
+                          prtLn $ testPassedMsg ++ " " ++ show testNum ++ " tests."
                       }
                 prt testingMsg
                 g <- io newTFGen
@@ -366,15 +366,15 @@ qcCmd qcMode str =
     opts <- getPPValOpts
     case failure of
       FailFalse [] -> do
-        prtLn $ colorizeString Failed "FAILED"
+        prtLn testFailedMsg
       FailFalse vs -> do
-        prtLn $ colorizeString Failed "FAILED" ++ " for the following inputs:"
+        prtLn $ testFailedMsg ++ " for the following inputs:"
         mapM_ (rPrint . pp . E.WithBase opts) vs
       FailError err [] -> do
-        prtLn $ colorizeString Failed "ERROR"
+        prtLn testErrorMsg
         rPrint (pp err)
       FailError err vs -> do
-        prtLn $ colorizeString Failed "ERROR" ++ " for the following inputs:"
+        prtLn $ testErrorMsg ++ " for the following inputs:"
         mapM_ (rPrint . pp . E.WithBase opts) vs
         rPrint (pp err)
       Pass -> panic "Cryptol.REPL.Command" ["unexpected Test.Pass"]

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -357,7 +357,7 @@ qcCmd qcMode str =
         pad     = replicate (totProgressWidth - width) ' '
     in prt (pad ++ percent)
 
-  del n       = unlessBatch $ prt (replicate n '\BS')
+  del n       = unlessBatch $ prt (concat $ replicate n "\BS \BS")
   delTesting  = del (length testingMsg)
   delProgress = del totProgressWidth
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -40,7 +40,6 @@ module Cryptol.REPL.Command (
     -- Misc utilities
   , handleCtrlC
   , sanitize
-  , colorizeString, OutputColor(..)
 
     -- To support Notebook interface (might need to refactor)
   , replParse
@@ -56,6 +55,8 @@ import qualified Cryptol.ModuleSystem.Name as M
 import qualified Cryptol.ModuleSystem.NamingEnv as M
 import qualified Cryptol.ModuleSystem.Renamer as M (RenamerWarning(SymbolShadowed))
 import qualified Cryptol.Utils.Ident as M
+
+import Cryptol.Utils.Color
 
 import qualified Cryptol.Eval.Value as E
 import Cryptol.Testing.Concrete
@@ -96,7 +97,6 @@ import qualified Data.Set as Set
 import qualified Data.IntMap as IntMap
 import System.IO(hFlush,stdout)
 import System.Random.TF(newTFGen)
-import System.Console.ANSI
 import Numeric (showFFloat)
 import qualified Data.Text as ST
 import qualified Data.Text.Lazy as T
@@ -926,18 +926,6 @@ replReadFile :: FilePath -> (X.SomeException -> REPL (Maybe BS.ByteString)) -> R
 replReadFile fp handler =
  do x <- io $ X.catch (Right `fmap` BS.readFile fp) (\e -> return $ Left e)
     either handler (return . Just) x
-
-data OutputColor = Failed | Passed | Prompt deriving (Enum, Eq)
-colorizeString :: OutputColor -> String -> String
-colorizeString color msg = prefix ++ msg ++ suffix where
-    -- sgr | eIsBatch  = setSGRCode
-    --     | otherwise = const ""
-    sgr = setSGRCode
-    prefix = case color of
-                  Failed -> sgr [SetColor Foreground Vivid Red]
-                  Passed -> sgr [SetColor Foreground Vivid Green]
-                  Prompt -> sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
-    suffix = sgr [Reset]
 
 -- | Creates a fresh binding of "it" to the expression given, and adds
 -- it to the current dynamic environment

--- a/src/Cryptol/TypeCheck.hs
+++ b/src/Cryptol/TypeCheck.hs
@@ -41,6 +41,7 @@ import           Cryptol.TypeCheck.Solve(simplifyAllConstraints)
 import           Cryptol.Utils.Ident (packModName,packIdent)
 import           Cryptol.Utils.PP
 import           Cryptol.Utils.Panic(panic)
+import           Cryptol.Utils.Color (errorAtMsg)
 
 tcModule :: P.Module Name -> InferInput -> IO (InferOutput Module)
 tcModule m inp = runInferM inp
@@ -102,6 +103,6 @@ ppWarning :: (Range,Warning) -> Doc
 ppWarning (r,w) = text "[warning] at" <+> pp r <> colon $$ nest 2 (pp w)
 
 ppError :: (Range,Error) -> Doc
-ppError (r,w) = text "[error] at" <+> pp r <> colon $$ nest 2 (pp w)
+ppError (r,w) = text errorAtMsg <+> pp r <> colon $$ nest 2 (pp w)
 
 

--- a/src/Cryptol/TypeCheck.hs
+++ b/src/Cryptol/TypeCheck.hs
@@ -41,7 +41,7 @@ import           Cryptol.TypeCheck.Solve(simplifyAllConstraints)
 import           Cryptol.Utils.Ident (packModName,packIdent)
 import           Cryptol.Utils.PP
 import           Cryptol.Utils.Panic(panic)
-import           Cryptol.Utils.Color (errorAtMsg)
+import           Cryptol.Utils.Color (errorAtMsg, warningAtMsg)
 
 tcModule :: P.Module Name -> InferInput -> IO (InferOutput Module)
 tcModule m inp = runInferM inp
@@ -100,7 +100,7 @@ tcDecls ds inp = runInferM inp $ inferDs ds $ \dgs -> do
                    return dgs
 
 ppWarning :: (Range,Warning) -> Doc
-ppWarning (r,w) = text "[warning] at" <+> pp r <> colon $$ nest 2 (pp w)
+ppWarning (r,w) = text warningAtMsg <+> pp r <> colon $$ nest 2 (pp w)
 
 ppError :: (Range,Error) -> Doc
 ppError (r,w) = text errorAtMsg <+> pp r <> colon $$ nest 2 (pp w)

--- a/src/Cryptol/Utils/Color.hs
+++ b/src/Cryptol/Utils/Color.hs
@@ -1,0 +1,17 @@
+module Cryptol.Utils.Color (colorizeString, OutputColor(..)) where
+
+import System.Console.ANSI
+
+data OutputColor = Failed | Passed | Prompt deriving (Enum, Eq)
+colorizeString :: OutputColor -> String -> String
+colorizeString color msg = prefix ++ msg ++ suffix where
+    -- sgr | isBatch  = setSGRCode
+    --     | otherwise = const ""
+    sgr = setSGRCode
+    prefix = case color of
+                  Failed -> sgr [SetColor Foreground Vivid Red]
+                  Passed -> sgr [SetColor Foreground Vivid Green]
+                  Prompt -> sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
+    suffix = sgr [Reset]
+
+

--- a/src/Cryptol/Utils/Color.hs
+++ b/src/Cryptol/Utils/Color.hs
@@ -1,4 +1,8 @@
-module Cryptol.Utils.Color (colorizeString, OutputColor(..), errorMsg, errorAtMsg) where
+module Cryptol.Utils.Color (
+    colorizeString, OutputColor(..)
+  , errorMsg, errorAtMsg
+  , warningMsg, warningAtMsg
+  ) where
 
 import System.Console.ANSI
 
@@ -19,3 +23,9 @@ errorMsg = colorizeString Failed "[error]"
 
 errorAtMsg :: String
 errorAtMsg = errorMsg ++ " at"
+
+warningMsg :: String
+warningMsg = colorizeString Failed "[warning]"
+
+warningAtMsg :: String
+warningAtMsg = warningMsg ++ " at"

--- a/src/Cryptol/Utils/Color.hs
+++ b/src/Cryptol/Utils/Color.hs
@@ -1,4 +1,4 @@
-module Cryptol.Utils.Color (colorizeString, OutputColor(..)) where
+module Cryptol.Utils.Color (colorizeString, OutputColor(..), errorMsg, errorAtMsg) where
 
 import System.Console.ANSI
 
@@ -14,4 +14,8 @@ colorizeString color msg = prefix ++ msg ++ suffix where
                   Prompt -> sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
     suffix = sgr [Reset]
 
+errorMsg :: String
+errorMsg = colorizeString Failed "[error]"
 
+errorAtMsg :: String
+errorAtMsg = errorMsg ++ " at"

--- a/src/Cryptol/Utils/Color.hs
+++ b/src/Cryptol/Utils/Color.hs
@@ -1,31 +1,44 @@
 module Cryptol.Utils.Color (
-    colorizeString, OutputColor(..)
+    colorPrompt
   , errorMsg, errorAtMsg
   , warningMsg, warningAtMsg
+  , testPassedMsg, testFailedMsg, testErrorMsg
   ) where
 
 import System.Console.ANSI
 
-data OutputColor = Failed | Passed | Prompt deriving (Enum, Eq)
+data OutputColor = BadColor | GoodColor | PromptColor deriving (Enum, Eq)
 colorizeString :: OutputColor -> String -> String
 colorizeString color msg = prefix ++ msg ++ suffix where
     -- sgr | isBatch  = setSGRCode
     --     | otherwise = const ""
     sgr = setSGRCode
     prefix = case color of
-                  Failed -> sgr [SetColor Foreground Vivid Red]
-                  Passed -> sgr [SetColor Foreground Vivid Green]
-                  Prompt -> sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
+                  BadColor -> sgr [SetColor Foreground Vivid Red]
+                  GoodColor -> sgr [SetColor Foreground Vivid Green]
+                  PromptColor -> sgr [SetColor Foreground Vivid Blue] ++ sgr [SetConsoleIntensity BoldIntensity]
     suffix = sgr [Reset]
 
+colorPrompt :: String -> String
+colorPrompt prompt = colorizeString PromptColor prompt
+
 errorMsg :: String
-errorMsg = colorizeString Failed "[error]"
+errorMsg = colorizeString BadColor "[error]"
 
 errorAtMsg :: String
 errorAtMsg = errorMsg ++ " at"
 
 warningMsg :: String
-warningMsg = colorizeString Failed "[warning]"
+warningMsg = colorizeString BadColor "[warning]"
 
 warningAtMsg :: String
 warningAtMsg = warningMsg ++ " at"
+
+testPassedMsg :: String
+testPassedMsg = colorizeString GoodColor "Passed"
+
+testFailedMsg :: String
+testFailedMsg = colorizeString BadColor "FAILED"
+
+testErrorMsg :: String
+testErrorMsg = colorizeString BadColor "ERROR"

--- a/tests/issues/issue094.icry.stdout
+++ b/tests/issues/issue094.icry.stdout
@@ -1,7 +1,7 @@
 Loading module Cryptol
 Using random testing.
-testing...passed 100 tests.
+testing...Passed 100 tests.
 Coverage: 39.06% (100 of 256 values)
 Using exhaustive testing.
-testing...passed 256 tests.
+testing...Passed 256 tests.
 Q.E.D.

--- a/tests/issues/issue128.icry.stdout
+++ b/tests/issues/issue128.icry.stdout
@@ -2,6 +2,6 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module Main
 Using exhaustive testing.
-testing...passed 1 tests.
+testing...Passed 1 tests.
 Q.E.D.
 Q.E.D.

--- a/tests/issues/issue130.icry.stdout
+++ b/tests/issues/issue130.icry.stdout
@@ -2,6 +2,6 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module Main
 Using exhaustive testing.
-testing...passed 8 tests.
+testing...Passed 8 tests.
 Q.E.D.
 Q.E.D.

--- a/tests/issues/issue133.icry.stdout
+++ b/tests/issues/issue133.icry.stdout
@@ -2,6 +2,6 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module Main
 Using exhaustive testing.
-testing...passed 256 tests.
+testing...Passed 256 tests.
 Q.E.D.
 Q.E.D.

--- a/tests/issues/issue306.icry.stdout
+++ b/tests/issues/issue306.icry.stdout
@@ -1,19 +1,19 @@
 Loading module Cryptol
 Using exhaustive testing.
-testing...passed 64 tests.
+testing...Passed 64 tests.
 Q.E.D.
 Using exhaustive testing.
-testing...passed 64 tests.
+testing...Passed 64 tests.
 Q.E.D.
 Using exhaustive testing.
-testing...passed 256 tests.
+testing...Passed 256 tests.
 Q.E.D.
 Using exhaustive testing.
-testing...passed 256 tests.
+testing...Passed 256 tests.
 Q.E.D.
 Using exhaustive testing.
-testing...passed 256 tests.
+testing...Passed 256 tests.
 Q.E.D.
 Using exhaustive testing.
-testing...passed 256 tests.
+testing...Passed 256 tests.
 Q.E.D.

--- a/tests/regression/EvenMansour.icry.stdout
+++ b/tests/regression/EvenMansour.icry.stdout
@@ -2,11 +2,11 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module Main
 Using exhaustive testing.
-testing...passed 1 tests.
+testing...Passed 1 tests.
 Q.E.D.
 Using exhaustive testing.
-testing...passed 1 tests.
+testing...Passed 1 tests.
 Q.E.D.
 Using random testing.
-testing...passed 100 tests.
+testing...Passed 100 tests.
 Coverage: 0.00% (100 of 2^^30 values)


### PR DESCRIPTION
Hi, this PR implements colorization of various things in the Cryptol REPL, so that they're more easily seen amongst user input and Cryptol output:
- the REPL prompt, 
- errors (non-exhaustive, since there isn't a common error reporting mechanism in the codebase),
- test results (pass/fail)

(Note that I'm a Haskell newbie, so feedback very welcome!).

I imagine that this colorization won't be to everyone's taste, so I could try to hide this behind a `cryptolrc` flag if you want, but I think it's sufficiently unobtrusive to leave on. Let me know.

Not tested on Windows, but because of the way it uses [ansi-terminal](https://hackage.haskell.org/package/ansi-terminal), it unfortunately will have no effect on Windows.

Here's how it looks:
<img width="473" alt="screen shot 2016-05-11 at 6 13 13 pm" src="https://cloud.githubusercontent.com/assets/208043/15189786/8bf79a7a-17a4-11e6-9a5d-ff67e37150de.png">
