### PR TITLE
Put bench/data/*.cry in extra-source-files

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -12,6 +12,7 @@ Copyright:           2013-2016 Galois Inc.
 Category:            Language
 Build-type:          Simple
 Cabal-version:       >= 1.18
+extra-source-files:  bench/data/*.cry
 
 data-files:          *.cry Cryptol/*.cry
 data-dir:            lib


### PR DESCRIPTION
Previously, `cabal sdist` would fail to include these fails in a tarball when uploaded to Hackage, causing the benchmarks to fail to run when obtained from there. Explicitly listing them in `extra-source-files` ensures `cabal sdist` grabs them.

Fixes #332.