### PR TITLE
Fix up terminal title usage and color output

### DIFF
--- a/cryptol/Main.hs
+++ b/cryptol/Main.hs
@@ -210,7 +210,7 @@ setupREPL opts = do
                 4 (vcat (map pp smoke)))
       exitFailure
   displayLogo True
-  setUpdateREPLTitle setREPLTitle
+  setUpdateREPLTitle (shouldSetREPLTitle >>= \b -> when b setREPLTitle)
   updateREPLTitle
   mCryptolPath <- io $ lookupEnv "CRYPTOLPATH"
   case mCryptolPath of

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -153,12 +153,20 @@ setREPLTitle = do
   io (setTitle (mkTitle lm))
 
 -- | In certain environments like Emacs, we shouldn't set the terminal
--- title.  Note: this does not imply we can't use color output. We can
+-- title. Note: this does not imply we can't use color output. We can
 -- use ANSI color sequences in places like Emacs, but not terminal
--- codes. Rather, the lack of color output would imply this option, not the
--- other way around.
+-- codes.
+--
+-- This checks that @'stdout'@ is a proper terminal handle, and that the
+-- terminal mode is not @dumb@, which is set by Emacs and others.
 shouldSetREPLTitle :: REPL Bool
 shouldSetREPLTitle = io (hSupportsANSI stdout)
+
+-- | Whether we can display color titles. This checks that @'stdout'@
+-- is a proper terminal handle, and that the terminal mode is not
+-- @dumb@, which is set by Emacs and others.
+canDisplayColor :: REPL Bool
+canDisplayColor = io (hSupportsANSI stdout)
 
 -- Completion ------------------------------------------------------------------
 

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -24,7 +24,8 @@ import           Control.Monad.Trans.Control
 import           Data.Char (isAlphaNum, isSpace)
 import           Data.Function (on)
 import           Data.List (isPrefixOf,nub,sortBy,sort)
-import           System.Console.ANSI (setTitle)
+import           System.IO (stdout)
+import           System.Console.ANSI (setTitle, hSupportsANSI)
 import           System.Console.Haskeline
 import           System.Directory ( doesFileExist
                                   , getHomeDirectory
@@ -150,6 +151,14 @@ setREPLTitle :: REPL ()
 setREPLTitle = do
   lm <- getLoadedMod
   io (setTitle (mkTitle lm))
+
+-- | In certain environments like Emacs, we shouldn't set the terminal
+-- title.  Note: this does not imply we can't use color output. We can
+-- use ANSI color sequences in places like Emacs, but not terminal
+-- codes. Rather, the lack of color output would imply this option, not the
+-- other way around.
+shouldSetREPLTitle :: REPL Bool
+shouldSetREPLTitle = io (hSupportsANSI stdout)
 
 -- Completion ------------------------------------------------------------------
 

--- a/cryptol/REPL/Logo.hs
+++ b/cryptol/REPL/Logo.hs
@@ -49,4 +49,4 @@ logo useColor =
   lineLen   = length (head ls)
 
 displayLogo :: Bool -> REPL ()
-displayLogo useColor =unlessBatch (io (mapM_ putStrLn (logo useColor)))
+displayLogo useColor = unlessBatch (io (mapM_ putStrLn (logo useColor)))


### PR DESCRIPTION
This adds a `--color` command line option, which allows you to control how colors are output by the frontend. It has three settings: `none`, `always`, and `auto`.

This also adds a fix for the usage of `setTitle` in Cryptol, to set the terminal title. Previously this was always set no matter what, when the REPL was reloaded or a new module loaded, but this breaks inside Emacs, as it can't handle those values within the `ansi-terminal` mode, via `comint`. It can handle ANSI color escape codes, however.

Notably, while color can be controlled explicitly, the autodetection of whether to set the terminal title *cannot* be controlled explicitly. Mostly, I see no reason to support extra code for this. Also, while there may be cases like Emacs where color autodetection should be overridden, I think the general case of title autodetection -- checking if `stdout` is a terminal -- is perfectly adequate.

With both of these commits, Cryptol 2 works far better in `cryptol-mode` (I have some unreleased changes which polish it up a bit).

This does not add documentation, yet.