### PR TITLE
Perform more careful handling of divide-by-0 conditions.

### DIFF
--- a/src/Cryptol/Eval/Monad.hs
+++ b/src/Cryptol/Eval/Monad.hs
@@ -188,8 +188,8 @@ typeCannotBeDemoted :: Type -> a
 typeCannotBeDemoted t = X.throw (TypeCannotBeDemoted t)
 
 -- | For division by 0.
-divideByZero :: a
-divideByZero = X.throw DivideByZero
+divideByZero :: Eval a
+divideByZero = Thunk (X.throwIO DivideByZero)
 
 -- | For when we know that a word is too wide and will exceed gmp's
 -- limits (though words approaching this size will probably cause the

--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -634,8 +634,10 @@ Cryptol primitives fall into several groups:
 >                       Right i ->
 >                         case fromVWord y of
 >                           Left e -> vWordError a e
->                           Right j -> vWordValue a
->                                      (fst (divModPoly i (fromInteger a) j (fromInteger b))))
+>                           Right j
+>                             | j == 0 -> vWordError a DivideByZero
+>                             | otherwise ->
+>                                   vWordValue a (fst (divModPoly i (fromInteger a) j (fromInteger b))))
 >
 >   , ("pmod"       , vFinPoly $ \a ->
 >                     vFinPoly $ \b ->
@@ -646,8 +648,10 @@ Cryptol primitives fall into several groups:
 >                       Right i ->
 >                         case fromVWord y of
 >                           Left e -> vWordError b e
->                           Right j -> vWordValue b
->                                      (snd (divModPoly i (fromInteger a) j (fromInteger b + 1))))
+>                           Right j
+>                             | j == 0 -> vWordError a DivideByZero
+>                             | otherwise ->
+>                                   vWordValue a (fst (divModPoly i (fromInteger a) j (fromInteger b))))
 >
 >   -- Miscellaneous:
 >   , ("error"      , VPoly $ \a ->


### PR DESCRIPTION
Make values lazier with respect to when they produce divide-by-0
errors.  Divide-by-0 should now propigate in the same way that
user errors do.

In addition, fix a bug in the reference evaluator with respect to
divide-by-0 handling of pmod and pdiv.  Previously, the `polyDivMod`
function would raise a division by zero error, in contravariance
to the reference implementation invariant that errors may only
occur when forcing values at type `Bit`.