### PR TITLE
Add a rule to the numeric solver for "linear unifiers"

### DIFF
--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -636,6 +636,8 @@ pError msg = TCon (TError KProp msg) []
 
 --------------------------------------------------------------------------------
 
+noFreeVariables :: FVS t => t -> Bool
+noFreeVariables = all (not . isFreeTV) . Set.toList . fvs
 
 class FVS t where
   fvs :: t -> Set TVar

--- a/src/Cryptol/TypeCheck/TypePat.hs
+++ b/src/Cryptol/TypeCheck/TypePat.hs
@@ -7,6 +7,7 @@ module Cryptol.TypeCheck.TypePat
   , aLenFromThen, aLenFromThenTo
 
   , aTVar
+  , aFreeTVar
   , aBit
   , aSeq
   , aWord
@@ -111,6 +112,12 @@ aTVar :: Pat Type TVar
 aTVar = \a -> case tNoUser a of
                 TVar x -> return x
                 _      -> mzero
+
+aFreeTVar :: Pat Type TVar
+aFreeTVar t =
+  do v <- aTVar t
+     guard (isFreeTV v)
+     return v
 
 aBit :: Pat Type ()
 aBit = tc TCBit ar0

--- a/tests/issues/issue212.icry.fails
+++ b/tests/issues/issue212.icry.fails
@@ -1,1 +1,0 @@
-Known tc failure.  See issue #212.

--- a/tests/issues/issue212.icry.stdout
+++ b/tests/issues/issue212.icry.stdout
@@ -1,0 +1,3 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main


### PR DESCRIPTION
Check for situations where a unification variable is involved in
a sum of terms not containing additional unification variables,
and replace it with a solution and an inequality.
`s1 = ?a + s2 ~~> (?a = s1 - s2, s1 >= s2)`

Fixes #212