### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+*\#*
+*~
+.DS_Store
+.cabal-sandbox
+cabal.sandbox.config
+dist
+results.xml
+dist-newstyle
+.stack-work
+.ghc.environment.x86_64-darwin-8.2.2
+
+# don't check in generated documentation
+#docs/CryptolPrims.pdf
+#docs/ProgrammingCryptol.pdf
+#docs/Syntax.pdf
+#docs/Version2Changes.pdf
+
+# don't check in distribution files
+cryptol-2.*
+
+# temporary notebook stuff until we split out the repo
+/ICryptol/ICryptol-2.*
+/ICryptol/profile.tar
+/ICryptol/profile_cryptol/security/
+/ICryptol/profile_cryptol/startup/
+/bench*.xml
+
+# vim swap files
+.*.swp
+.*.swo
+
+Dockerfile*
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:edge AS build
+RUN adduser -D cryptol \
+    && apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing z3 \
+    && rm /usr/lib/libz3.so* \
+    && apk add build-base cabal ghc wget ncurses-dev \
+    && su -c 'cabal update' cryptol
+COPY --chown=cryptol:cryptol . /cryptol
+USER cryptol
+WORKDIR /cryptol
+ARG CRYPTOLPATH="/home/cryptol/.cryptol"
+ARG TESTS="modsys parser issues regression renamer mono-binds"
+ARG DIFF="diff"
+ARG IGNORE_EXPECTED="--ignore-expected"
+ARG CABAL_BUILD_FLAGS="-j"
+ARG CABAL_INSTALL_FLAGS="${CABAL_BUILD_FLAGS}"
+RUN make tarball
+RUN make test
+RUN mkdir -p rootfs/"${CRYPTOLPATH}" \
+    && cp -r lib/* rootfs/"${CRYPTOLPATH}" \
+    && mkdir -p rootfs/usr/local \
+    && rm -r cryptol-*-Linux-*_unknown/share/doc \
+    && mv cryptol-*-Linux-*_unknown/* rootfs/usr/local
+USER root
+RUN chown -R root:root /cryptol/rootfs
+
+FROM alpine:edge
+COPY --from=build /cryptol/rootfs /
+RUN adduser -D cryptol \
+    && chown -R cryptol:cryptol /home/cryptol \
+    && apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing z3 \
+    && rm /usr/lib/libz3.so* \
+    && apk add gmp libffi musl ncurses-libs \
+    && rm -r /var/cache/apk/*
+USER cryptol
+ENTRYPOINT ["/usr/local/bin/cryptol"]


### PR DESCRIPTION
Addresses issue #508

To build the Docker image (in repo root):
```
docker build -t galoisinc/cryptol .
```
To pass build arguments to make, use `--build-args`:
```
docker build --build-args TESTS= --build-args DIFF=meld -t galoisinc/cryptol .
```

To pull the current development image:
```
docker pull lemmarathon/cryptol
```

To run cryptol:
```
docker run -it lemmarathon/cryptol
```

**Tasks:**
- [x] Pass all tests
- [x] Build as unprivileged user
- [x] Pass options (e.g. DIFF, TESTS) to make via build-args
- [x] Remove unnecessary layers
- [x] ~Base runtime image on scratch image?~ Current (alpine-based) image is ~38~ ~24~ 17 MB compressed, ~74~ 54 MB uncompressed. Uncompressed size could be reduced to 40 MB (see output below), but it's probably not worth the extra build steps.

```
# du -csh $(echo $(ldd `which cryptol`) $(ldd `which z3`) | grep -o '/[^ ]*' | sort | uniq) /usr/local /home/cryptol /usr/bin/z3
552.0K  /lib/ld-musl-x86_64.so.1
4.0K    /usr/lib/libffi.so.6
72.0K   /usr/lib/libgcc_s.so.1
4.0K    /usr/lib/libgmp.so.10
4.0K    /usr/lib/libgomp.so.1
4.0K    /usr/lib/libncursesw.so.6
4.0K    /usr/lib/libstdc++.so.6
18.2M   /usr/local
28.0K   /home/cryptol
20.6M   /usr/bin/z3
39.5M   total
```