### PR TITLE
Make Cryptol compile with SBV 8.0

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -58,7 +58,7 @@ library
                        pretty            >= 1.1,
                        process           >= 1.2,
                        random            >= 1.0.1,
-                       sbv               >= 7.7,
+                       sbv               >= 8.0,
                        simple-smt        >= 0.7.1,
                        strict,
                        text              >= 1.1,
@@ -264,5 +264,5 @@ benchmark cryptol-bench
                      , deepseq
                      , directory
                      , filepath
-                     , sbv >= 7.7
+                     , sbv >= 8.0
                      , text

--- a/src/Cryptol/Symbolic/Value.hs
+++ b/src/Cryptol/Symbolic/Value.hs
@@ -34,6 +34,7 @@ import Data.Bits (bit, complement)
 import Data.List (foldl')
 import qualified Data.Sequence as Seq
 
+import Data.SBV (symbolicEnv)
 import Data.SBV.Dynamic
 
 --import Cryptol.Eval.Monad
@@ -48,7 +49,6 @@ import Cryptol.Eval.Value  ( GenValue(..), BitWord(..), lam, tlam, toStream,
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.PP
 
-import Control.Monad.Reader (ask)
 import Control.Monad.Trans  (liftIO)
 
 -- SBool and SWord -------------------------------------------------------------
@@ -65,22 +65,22 @@ literalSWord :: Int -> Integer -> SWord
 literalSWord w i = svInteger (KBounded False w) i
 
 forallBV_ :: Int -> Symbolic SWord
-forallBV_ w = ask >>= liftIO . svMkSymVar (Just ALL) (KBounded False w) Nothing
+forallBV_ w = symbolicEnv >>= liftIO . svMkSymVar (Just ALL) (KBounded False w) Nothing
 
 existsBV_ :: Int -> Symbolic SWord
-existsBV_ w = ask >>= liftIO . svMkSymVar (Just EX) (KBounded False w) Nothing
+existsBV_ w = symbolicEnv >>= liftIO . svMkSymVar (Just EX) (KBounded False w) Nothing
 
 forallSBool_ :: Symbolic SBool
-forallSBool_ = ask >>= liftIO . svMkSymVar (Just ALL) KBool Nothing
+forallSBool_ = symbolicEnv >>= liftIO . svMkSymVar (Just ALL) KBool Nothing
 
 existsSBool_ :: Symbolic SBool
-existsSBool_ = ask >>= liftIO . svMkSymVar (Just EX) KBool Nothing
+existsSBool_ = symbolicEnv >>= liftIO . svMkSymVar (Just EX) KBool Nothing
 
 forallSInteger_ :: Symbolic SBool
-forallSInteger_ = ask >>= liftIO . svMkSymVar (Just ALL) KUnbounded Nothing
+forallSInteger_ = symbolicEnv >>= liftIO . svMkSymVar (Just ALL) KUnbounded Nothing
 
 existsSInteger_ :: Symbolic SBool
-existsSInteger_ = ask >>= liftIO . svMkSymVar (Just EX) KUnbounded Nothing
+existsSInteger_ = symbolicEnv >>= liftIO . svMkSymVar (Just EX) KUnbounded Nothing
 
 -- Values ----------------------------------------------------------------------
 


### PR DESCRIPTION
SBV 8.0 is now on hackage, with several backwards compatibility breaking changes. You'll need this patch to compile cryptol against it.