### PR TITLE
Remove [x..] syntax.

### DIFF
--- a/bench/data/PreludeWithExtras.cry
+++ b/bench/data/PreludeWithExtras.cry
@@ -260,11 +260,6 @@ primitive (!) : {a, b, c} (fin a, fin c) => [a]b -> [c] -> b
  */
 primitive (!!) : {a, b, c, d} (fin a, fin d) => [a]b -> [c][d] -> [c]b
 
-primitive fromThen : {first, next, bits, len}
-                     ( fin first, fin next, fin bits
-                     , bits >= width first, bits >= width next
-                     , lengthFromThen first next bits == len) => [len][bits]
-
 primitive fromTo : {first, last, bits} (fin last, fin bits, last >= first,
                               bits >= width last) => [1 + (last - first)][bits]
 

--- a/docs/ProgrammingCryptol/appendices/README
+++ b/docs/ProgrammingCryptol/appendices/README
@@ -1,4 +1,4 @@
 % IMPORTANT: The file Syntax.tex is generated automatically from the
 % markdown in ../../Syntax.md.   If you make changes, please make them
-% there and then regenarte the .tex file using the Makefile.
+% there and then regenerate the .tex file using the Makefile.
 

--- a/docs/ProgrammingCryptol/appendices/Syntax.tex
+++ b/docs/ProgrammingCryptol/appendices/Syntax.tex
@@ -1,8 +1,9 @@
 % IMPORTANT: The file Syntax.tex is generated automatically from the
 % markdown in ../../Syntax.md.   If you make changes, please make them
-% there and then regenarte the .tex file using the Makefile.
+% there and then regenerate the .tex file using the Makefile.
 
-\section{Layout}\label{layout}
+\hypertarget{layout}{%
+\section{Layout}\label{layout}}
 
 Groups of declarations are organized based on indentation. Declarations
 with the same indentation belong to the same group. Lines of text that
@@ -32,7 +33,8 @@ containing \texttt{y} and \texttt{z}. This group ends just before
 \texttt{g}, because \texttt{g} is indented less than \texttt{y} and
 \texttt{z}.
 
-\section{Comments}\label{comments}
+\hypertarget{comments}{%
+\section{Comments}\label{comments}}
 
 Cryptol supports block comments, which start with \texttt{/*} and end
 with \texttt{*/}, and line comments, which start with \texttt{//} and
@@ -47,7 +49,8 @@ Examples:
 /* This is a /* Nested */ block comment */
 \end{verbatim}
 
-\section{Identifiers}\label{identifiers}
+\hypertarget{identifiers}{%
+\section{Identifiers}\label{identifiers}}
 
 Cryptol identifiers consist of one or more characters. The first
 character must be either an English letter or underscore (\texttt{\_}).
@@ -64,8 +67,9 @@ name    name1    name'    longer_name
 Name    Name2    Name''   longerName
 \end{verbatim}
 
-\hypertarget{keywords-and-built-in-operators}{\section{Keywords and
-Built-in Operators}\label{keywords-and-built-in-operators}}
+\hypertarget{keywords-and-built-in-operators}{%
+\section{Keywords and Built-in
+Operators}\label{keywords-and-built-in-operators}}
 
 The following identifiers have special meanings in Cryptol, and may not
 be used for programmer defined names:
@@ -116,8 +120,9 @@ left\tabularnewline
 \bottomrule
 \end{longtable}
 
+\hypertarget{built-in-type-level-operators}{%
 \section{Built-in Type-level
-Operators}\label{built-in-type-level-operators}
+Operators}\label{built-in-type-level-operators}}
 
 Cryptol includes a variety of operators that allow computations on the
 numeric types used to specify the sizes of sequences.
@@ -149,7 +154,8 @@ up)\tabularnewline
 \bottomrule
 \end{longtable}
 
-\section{Numeric Literals}\label{numeric-literals}
+\hypertarget{numeric-literals}{%
+\section{Numeric Literals}\label{numeric-literals}}
 
 Numeric literals may be written in binary, octal, decimal, or
 hexadecimal notation. The base of a literal is determined by its prefix:
@@ -182,7 +188,8 @@ is inferred from context in which the literal is used. Examples:
                     // a = Integer or [n] where n >= width 10
 \end{verbatim}
 
-\section{Bits}\label{bits}
+\hypertarget{bits}{%
+\section{Bits}\label{bits}}
 
 The type \texttt{Bit} has two inhabitants: \texttt{True} and
 \texttt{False}. These values may be combined using various logical
@@ -213,7 +220,8 @@ Operator & Associativity & Description\tabularnewline
 \bottomrule
 \end{longtable}
 
-\section{Multi-way Conditionals}\label{multi-way-conditionals}
+\hypertarget{multi-way-conditionals}{%
+\section{Multi-way Conditionals}\label{multi-way-conditionals}}
 
 The \texttt{if\ ...\ then\ ...\ else} construct can be used with
 multiple branches. For example:
@@ -227,7 +235,8 @@ x = if y % 2 == 0 then 1
      else 7
 \end{verbatim}
 
-\section{Tuples and Records}\label{tuples-and-records}
+\hypertarget{tuples-and-records}{%
+\section{Tuples and Records}\label{tuples-and-records}}
 
 Tuples and records are used for packaging multiple values together.
 Tuples are enclosed in parentheses, while records are enclosed in curly
@@ -297,7 +306,8 @@ f p = x + y where
     (x, y) = p
 \end{verbatim}
 
-\section{Sequences}\label{sequences}
+\hypertarget{sequences}{%
+\section{Sequences}\label{sequences}}
 
 A sequence is a fixed-length collection of elements of the same type.
 The type of a finite sequence of length \texttt{n}, with elements of
@@ -310,10 +320,8 @@ with elements of type \texttt{a} has type \texttt{{[}inf{]}\ a}, and
 \begin{verbatim}
 [e1,e2,e3]                        // A sequence with three elements
 
-[t .. ]                           // Sequence enumerations
-[t1, t2 .. ]                      // Step by t2 - t1
-[t1 .. t3 ]
-[t1, t2 .. t3 ]
+[t1 .. t3 ]                       // Sequence enumerations
+[t1, t2 .. t3 ]                   // Step by t2 - t1
 [e1 ... ]                         // Infinite sequence starting at e1
 [e1, e2 ... ]                     // Infinite sequence stepping by e2-e1
 
@@ -321,9 +329,9 @@ with elements of type \texttt{a} has type \texttt{{[}inf{]}\ a}, and
     | p21 <- e21, p22 <- e22 ]
 \end{verbatim}
 
-Note: the bounds in finite unbounded (those with ..) sequences are type
-expressions, while the bounds in bounded-finite and infinite sequences
-are value expressions.
+Note: the bounds in finite sequences (those with \texttt{..}) are type
+expressions, while the bounds in infinite sequences are value
+expressions.
 
 \begin{longtable}[]{@{}ll@{}}
 \caption{Sequence operations.}\tabularnewline
@@ -360,14 +368,16 @@ There are also lifted pointwise operations.
 p1 # p2                   // Split sequence pattern
 \end{verbatim}
 
-\section{Functions}\label{functions}
+\hypertarget{functions}{%
+\section{Functions}\label{functions}}
 
 \begin{verbatim}
 \p1 p2 -> e              // Lambda expression
 f p1 p2 = e              // Function definition
 \end{verbatim}
 
-\section{Local Declarations}\label{local-declarations}
+\hypertarget{local-declarations}{%
+\section{Local Declarations}\label{local-declarations}}
 
 \begin{verbatim}
 e where ds
@@ -377,7 +387,9 @@ Note that by default, any local declarations without type signatures are
 monomorphized. If you need a local declaration to be polymorphic, use an
 explicit type signature.
 
-\section{Explicit Type Instantiation}\label{explicit-type-instantiation}
+\hypertarget{explicit-type-instantiation}{%
+\section{Explicit Type
+Instantiation}\label{explicit-type-instantiation}}
 
 If \texttt{f} is a polymorphic value with type:
 
@@ -392,8 +404,9 @@ you can evaluate \texttt{f}, passing it a type parameter:
 f `{ tyParam = 13 }
 \end{verbatim}
 
+\hypertarget{demoting-numeric-types-to-values}{%
 \section{Demoting Numeric Types to
-Values}\label{demoting-numeric-types-to-values}
+Values}\label{demoting-numeric-types-to-values}}
 
 The value corresponding to a numeric type may be accessed using the
 following notation:
@@ -410,7 +423,8 @@ accommodate the value of the type:
 `t : {n} (fin n, n >= width t) => [n]
 \end{verbatim}
 
-\section{Explicit Type Annotations}\label{explicit-type-annotations}
+\hypertarget{explicit-type-annotations}{%
+\section{Explicit Type Annotations}\label{explicit-type-annotations}}
 
 Explicit type annotations may be added on expressions, patterns, and in
 argument definitions.
@@ -423,19 +437,22 @@ p : t
 f (x : t) = ...
 \end{verbatim}
 
-\section{Type Signatures}\label{type-signatures}
+\hypertarget{type-signatures}{%
+\section{Type Signatures}\label{type-signatures}}
 
 \begin{verbatim}
 f,g : {a,b} (fin a) => [a] b
 \end{verbatim}
 
-\section{Type Synonym Declarations}\label{type-synonym-declarations}
+\hypertarget{type-synonym-declarations}{%
+\section{Type Synonym Declarations}\label{type-synonym-declarations}}
 
 \begin{verbatim}
 type T a b = [a] b
 \end{verbatim}
 
-\section{Modules}\label{modules}
+\hypertarget{modules}{%
+\section{Modules}\label{modules}}
 
 A \textbf{\emph{module}} is used to group some related definitions.
 
@@ -448,7 +465,8 @@ f : [8]
 f = 10
 \end{verbatim}
 
-\section{Hierarchical Module Names}\label{hierarchical-module-names}
+\hypertarget{hierarchical-module-names}{%
+\section{Hierarchical Module Names}\label{hierarchical-module-names}}
 
 Module may have either simple or \textbf{\emph{hierarchical}} names.
 Hierarchical names are constructed by gluing together ordinary
@@ -467,7 +485,8 @@ when searching for module \texttt{Hash::SHA256}, Cryptol will look for a
 file named \texttt{SHA256.cry} in a directory called \texttt{Hash},
 contained in one of the directories specified by \texttt{CRYPTOLPATH}.
 
-\section{Module Imports}\label{module-imports}
+\hypertarget{module-imports}{%
+\section{Module Imports}\label{module-imports}}
 
 To use the definitions from one module in another module, we use
 \texttt{import} declarations:
@@ -488,7 +507,8 @@ import M  // import all definitions from `M`
 g = f   // `f` was imported from `M`
 \end{verbatim}
 
-\section{Import Lists}\label{import-lists}
+\hypertarget{import-lists}{%
+\section{Import Lists}\label{import-lists}}
 
 Sometimes, we may want to import only some of the definitions from a
 module. To do so, we use an import declaration with an
@@ -512,7 +532,8 @@ Using explicit import lists helps reduce name collisions. It also tends
 to make code easier to understand, because it makes it easy to see the
 source of definitions.
 
-\section{Hiding Imports}\label{hiding-imports}
+\hypertarget{hiding-imports}{%
+\section{Hiding Imports}\label{hiding-imports}}
 
 Sometimes a module may provide many definitions, and we want to use most
 of them but with a few exceptions (e.g., because those would result to a
@@ -535,7 +556,8 @@ import M hiding (h) // Import everything but `h`
 x = f + g
 \end{verbatim}
 
-\section{Qualified Module Imports}\label{qualified-module-imports}
+\hypertarget{qualified-module-imports}{%
+\section{Qualified Module Imports}\label{qualified-module-imports}}
 
 Another way to avoid name collisions is by using a
 \textbf{\emph{qualified}} import.
@@ -578,7 +600,8 @@ Such declarations will introduces all definitions from \texttt{A} and
 \texttt{X} but to use them, you would have to qualify using the prefix
 \texttt{B:::}.
 
-\section{Private Blocks}\label{private-blocks}
+\hypertarget{private-blocks}{%
+\section{Private Blocks}\label{private-blocks}}
 
 In some cases, definitions in a module might use helper functions that
 are not intended to be used outside the module. It is good practice to
@@ -619,7 +642,8 @@ private
   helper2 = 3
 \end{verbatim}
 
-\section{Parameterized Modules}\label{parameterized-modules}
+\hypertarget{parameterized-modules}{%
+\section{Parameterized Modules}\label{parameterized-modules}}
 
 \begin{verbatim}
 module M where
@@ -637,7 +661,9 @@ f : [n]
 f = 1 + x
 \end{verbatim}
 
-\section{Named Module Instantiations}\label{named-module-instantiations}
+\hypertarget{named-module-instantiations}{%
+\section{Named Module
+Instantiations}\label{named-module-instantiations}}
 
 One way to use a parameterized module is through a named instantiation:
 
@@ -674,8 +700,9 @@ Note that the only purpose of the body of \texttt{N} (the declarations
 after the \texttt{where} keyword) is to define the parameters for
 \texttt{M}.
 
+\hypertarget{parameterized-instantiations}{%
 \section{Parameterized
-Instantiations}\label{parameterized-instantiations}
+Instantiations}\label{parameterized-instantiations}}
 
 It is possible for a module instantiations to be itself parameterized.
 This could be useful if we need to define some of a module's parameters
@@ -710,8 +737,9 @@ In this case \texttt{N} has a single parameter \texttt{x}. The result of
 instantiating \texttt{N} would result in instantiating \texttt{M} using
 the value of \texttt{x} and \texttt{12} for the value of \texttt{y}.
 
+\hypertarget{importing-parameterized-modules}{%
 \section{Importing Parameterized
-Modules}\label{importing-parameterized-modules}
+Modules}\label{importing-parameterized-modules}}
 
 It is also possible to import a parameterized module without using a
 module instantiation:

--- a/docs/ProgrammingCryptol/prims/Primitives.tex
+++ b/docs/ProgrammingCryptol/prims/Primitives.tex
@@ -117,11 +117,6 @@ primsPlaceHolder=1;
 %    (/$) : {a} (Arith a) => a -> a -> a
 %    number : {val, rep} (Literal val rep) => rep
 %    elem : {n, a} (fin n, Cmp a) => a -> [n]a -> Bit
-%    fromThen :
-%      {first, next, bits, len} (fin first, fin next, fin bits,
-%                                bits >= width first, bits >= width next, first != next,
-%                                lengthFromThen first next bits == len) =>
-%        [len][bits]
 %    fromThenTo :
 %      {first, next, last, a, len} (fin first, fin next, fin last,
 %                                   Literal first a, Literal next a, Literal last a, first != next,

--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -282,19 +282,17 @@ an infinite stream of bits.
 
     [e1,e2,e3]                        // A sequence with three elements
 
-    [t .. ]                           // Sequence enumerations
-    [t1, t2 .. ]                      // Step by t2 - t1
-    [t1 .. t3 ]
-    [t1, t2 .. t3 ]
+    [t1 .. t3 ]                       // Sequence enumerations
+    [t1, t2 .. t3 ]                   // Step by t2 - t1
     [e1 ... ]                         // Infinite sequence starting at e1
     [e1, e2 ... ]                     // Infinite sequence stepping by e2-e1
 
     [ e | p11 <- e11, p12 <- e12      // Sequence comprehensions
         | p21 <- e21, p22 <- e22 ]
 
-Note: the bounds in finite unbounded (those with ..) sequences are
-type expressions, while the bounds in bounded-finite and infinite
-sequences are value expressions.
+Note: the bounds in finite sequences (those with `..`) are type
+expressions, while the bounds in infinite sequences are value
+expressions.
 
 Operator                       Description
 ---------------------------    -----------

--- a/examples/SIV-rfc5297.md
+++ b/examples/SIV-rfc5297.md
@@ -554,14 +554,14 @@ ctr32 : {n} (2^^39 - 128 >= n) => Key -> [128] -> [n] -> [n]
 ctr32 k iv pt = pt ^ take stream
  where
  stream = join [E(k,v) | v <- ivs]
- ivs    = [take `{96} iv # cnt + i | i <- [0,1..]]
+ ivs    = [take `{96} iv # cnt + i | i <- [0 ...]]
  cnt    = drop `{back=32} iv
 
 ctr64 : {n} (2^^71 - 128 >= n) => Key -> [128] -> [n] -> [n]
 ctr64 k iv pt = pt ^ take stream
  where
  stream = join [E(k,v) | v <- ivs]
- ivs    = [take `{64} iv # cnt + i | i <- [0,1..]]
+ ivs    = [take `{64} iv # cnt + i | i <- [0 ...]]
  cnt    = drop `{back=64} iv
 ```
 

--- a/examples/funstuff/FoxChickenCorn.cry
+++ b/examples/funstuff/FoxChickenCorn.cry
@@ -91,7 +91,7 @@ ppArray = [farmerString, chickenString, cornString, foxString]
 ppBits : [4] -> [4]StringRep
 ppBits s =  [ if b then ppArray!i else noString
             | b <- s
-            | i <- [0 .. ]:[_][4] ]
+            | i <- [0 ...]:[_][4] ]
 
 // takes a sequence of states and derives what moved, and in which direction for each transition
 extractMoves : {a} [a+1]BankState -> [a](DirRep, [4]StringRep)

--- a/examples/param_modules/AES/Round.cry
+++ b/examples/param_modules/AES/Round.cry
@@ -12,11 +12,11 @@ SubBytes : State -> State
 SubBytes state = [ [ SubByte b | b <- row ] | row <- state ]
 
 ShiftRows : State -> State
-ShiftRows state = [ row <<< i | row <- state | i : [2] <- [0 .. ] ]
+ShiftRows state = [ row <<< i | row <- state | i : [2] <- [0 .. 3] ]
 
 MixColumns : State -> State
 MixColumns state = gf28MatrixMult m state
-    where m = [ [2,3,1,1] >>> i | i <- [ 0 .. ] ]
+    where m = [ [2,3,1,1] >>> i | i <- [0 .. 3] ]
 
 /** The final AES round */
 AESFinalRound : RoundKey -> State -> State
@@ -33,12 +33,12 @@ InvSubBytes state = [ [ InvSubByte b | b <- row ] | row <- state ]
 
 InvShiftRows : State -> State
 InvShiftRows state = [ row >>> shiftAmount | row <- state
-                                           | shiftAmount : [2] <- [0 ..]
+                                           | shiftAmount : [2] <- [0 .. 3]
                      ]
 
 InvMixColumns : State -> State
 InvMixColumns state = gf28MatrixMult m state
-    where m = [[0x0e, 0x0b, 0x0d, 0x09] >>> i | i <- [ 0 .. ] ]
+    where m = [[0x0e, 0x0b, 0x0d, 0x09] >>> i | i <- [0 .. 3] ]
 
 /** The final inverted AES round */
 AESFinalInvRound : RoundKey -> State -> State

--- a/examples/param_modules/AES/SBox.cry
+++ b/examples/param_modules/AES/SBox.cry
@@ -6,8 +6,7 @@ import AES::SubBytePlain
 type SBox = [256] GF28
 
 sbox : SBox
-sbox = [ SubByte x | x <- [ 0 .. ] ]
+sbox = [ SubByte x | x <- [0 .. 255] ]
 
 sboxInv : SBox
-sboxInv = [ InvSubByte x | x <- [ 0 .. ] ]
-
+sboxInv = [ InvSubByte x | x <- [0 .. 255] ]

--- a/examples/param_modules/AES/TBox.cry
+++ b/examples/param_modules/AES/TBox.cry
@@ -31,7 +31,7 @@ tboxInv : TBox
 tboxInv = mkTBox [ 0x0e, 0x09, 0x0d, 0x0b ] sboxInv
 
 mkTBox : [4]GF28 -> SBox -> TBox
-mkTBox seed box = [ [ a >>> i | a <- t0 ] | i <- [ 0 .. ] ]
+mkTBox seed box = [ [ a >>> i | a <- t0 ] | i <- [0 .. 3] ]
   where
   t0 = [ [ gf28Mult c s | c <- seed ] | s <- box ]
 

--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -453,19 +453,6 @@ updatesEnd xs0 idxs vals = xss!0
          ]
 
 /**
- * A finite arithmetic sequence starting with 'first' and 'next',
- * stopping when the values would wrap around modulo '2^^bits'.
- *
- * '[a,b..]' is syntactic sugar for 'fromThen`{first=a,next=b}'.
- * '[a..]' is syntactic sugar for 'fromThen`{first=a,next=a+1}'.
- */
-primitive fromThen : {first, next, bits, len}
-                     ( fin first, fin next, fin bits
-                     , bits >= width first, bits >= width next
-                     , first != next
-                     , lengthFromThen first next bits == len) => [len][bits]
-
-/**
  * A finite sequence counting up from 'first' to 'last'.
  *
  * '[a..b]' is syntactic sugar for 'fromTo`{first=a,last=b}'.

--- a/lib/CryptolTC.z3
+++ b/lib/CryptolTC.z3
@@ -316,17 +316,6 @@
 )
 
 
-(define-fun cryLenFromThen ((x InfNat) (y InfNat) (z InfNat)) InfNat
-  (ite (or (isErr x) (not (isFin x))
-           (isErr y) (not (isFin y))
-           (isErr z) (not (isFin z))
-           (= (value x) (value y))) cryErr
-  (ite (< (value y) (value x)) (cryLenFromThenTo x y (cryNat 0))
-       (cryLenFromThenTo x y (cryNat (- (cryExpTable 2 (value z)) 1))))
-  )
-)
-
-
 ; ---
 
 

--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -543,7 +543,7 @@ Cryptol primitives fall into several groups:
 
 * Indexing: `@`, `@@`, `!`, `!!`, `update`, `updateEnd`
 
-* Enumerations: `fromThen`, `fromTo`, `fromThenTo`, `infFrom`, `infFromThen`
+* Enumerations: `fromTo`, `fromThenTo`, `infFrom`, `infFromThen`
 
 * Polynomials: `pmult`, `pdiv`, `pmod`
 
@@ -648,13 +648,6 @@ Cryptol primitives fall into several groups:
 >   , ("updateEnd"  , updatePrim updateBack)
 >
 >   -- Enumerations:
->   , ("fromThen"   , vFinPoly $ \first ->
->                     vFinPoly $ \next  ->
->                     vFinPoly $ \bits  ->
->                     vFinPoly $ \len   ->
->                     VList (Nat len)
->                     (map (vWordValue bits) (genericTake len [first, next ..])))
->
 >   , ("fromTo"     , vFinPoly $ \first ->
 >                     vFinPoly $ \lst   ->
 >                     VPoly    $ \ty  ->
@@ -732,21 +725,11 @@ error if any of the input bits contain an evaluation error.
 > signedBitsToInteger (b0 : bs) = foldl f (if b0 then -1 else 0) bs
 >   where f x b = if b then 2 * x + 1 else 2 * x
 
-Functions `vWord` and `vWordValue` convert from integers back to the
-big-endian bitvector representation. If an integer-producing function
-raises a run-time exception, then the output bitvector will contain
-the exception in all bit positions.
+Function `vWord` converts an integer back to the big-endian bitvector
+representation. If an integer-producing function raises a run-time
+exception, then the output bitvector will contain the exception in all
+bit positions.
 
-> -- | Convert an integer to big-endian binary value of the specified width.
-> vWordValue :: Integer -> Integer -> Value
-> vWordValue w x = VList (Nat w) (map (VBit . Right) (integerToBits w x))
->
-> -- | Convert an integer to a big-endian format of the specified width.
-> integerToBits :: Integer -> Integer -> [Bool]
-> integerToBits w x = go [] w x
->   where go bs 0 _ = bs
->         go bs n a = go (odd a : bs) (n - 1) $! (a `div` 2)
->
 > vWord :: Integer -> Either EvalError Integer -> Value
 > vWord w e = VList (Nat w) [ VBit (fmap (test i) e) | i <- [w-1, w-2 .. 0] ]
 >   where test i x = testBit x (fromInteger i)

--- a/src/Cryptol/Eval/Type.hs
+++ b/src/Cryptol/Eval/Type.hs
@@ -142,7 +142,6 @@ evalTF f vs
   | TCMax           <- f, [x,y]   <- vs  =      nMax x y
   | TCCeilDiv       <- f, [x,y]   <- vs  = mb $ nCeilDiv x y
   | TCCeilMod       <- f, [x,y]   <- vs  = mb $ nCeilMod x y
-  | TCLenFromThen   <- f, [x,y,z] <- vs  = mb $ nLenFromThen x y z
   | TCLenFromThenTo <- f, [x,y,z] <- vs  = mb $ nLenFromThenTo x y z
   | otherwise  = evalPanic "evalTF"
                         ["Unexpected type function:", show ty]

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -790,7 +790,7 @@ instance Rename Expr where
     EList es      -> EList   <$> traverse rename es
     EFromTo s n e'-> EFromTo <$> rename s
                              <*> traverse rename n
-                             <*> traverse rename e'
+                             <*> rename e'
     EInfFrom a b  -> EInfFrom<$> rename a  <*> traverse rename b
     EComp e' bs   -> do arms' <- traverse renameArm bs
                         let (envs,bs') = unzip arms'

--- a/src/Cryptol/Parser.y
+++ b/src/Cryptol/Parser.y
@@ -632,9 +632,8 @@ type                           :: { Type PName                                  
 
 app_type                       :: { Type PName }
   -- : 'lg2'   atype                 { at ($1,$2) $ TApp TCLg2   [$2]    }
-  -- | 'lengthFromThen' atype atype  { at ($1,$3) $ TApp TCLenFromThen [$2,$3] }
   -- | 'lengthFromThenTo' atype atype
-  --                      atype      { at ($1,$4) $ TApp TCLenFromThen [$2,$3,$4] }
+  --                      atype      { at ($1,$4) $ TApp TCLenFromThenTo [$2,$3,$4] }
   -- | 'min'   atype atype           { at ($1,$3) $ TApp TCMin   [$2,$3] }
   -- | 'max'   atype atype           { at ($1,$3) $ TApp TCMax   [$2,$3] }
 

--- a/src/Cryptol/Parser.y
+++ b/src/Cryptol/Parser.y
@@ -537,13 +537,11 @@ list_expr                      :: { Expr PName }
      is being parsed.  For this reason, we use `expr` temporarily and
      then convert it to the corresponding type in the AST. -}
 
-  | expr          '..'            {% eFromTo $2 $1 Nothing   Nothing    }
-  | expr          '..' expr       {% eFromTo $2 $1 Nothing   (Just $3)  }
-  | expr ',' expr '..'            {% eFromTo $4 $1 (Just $3) Nothing    }
-  | expr ',' expr '..' expr       {% eFromTo $4 $1 (Just $3) (Just $5)  }
+  | expr          '..' expr       {% eFromTo $2 $1 Nothing   $3 }
+  | expr ',' expr '..' expr       {% eFromTo $4 $1 (Just $3) $5 }
 
-  | expr '...'                    { EInfFrom $1 Nothing                 }
-  | expr ',' expr '...'           { EInfFrom $1 (Just $3)               }
+  | expr '...'                    { EInfFrom $1 Nothing         }
+  | expr ',' expr '...'           { EInfFrom $1 (Just $3)       }
 
 
 list_alts                      :: { [[Match PName]] }

--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -267,7 +267,7 @@ data Expr n   = EVar n                          -- ^ @ x @
               | ESel (Expr n) Selector          -- ^ @ e.l @
               | EUpd (Maybe (Expr n)) [ UpdField n ]  -- ^ @ { r | x = e } @
               | EList [Expr n]                  -- ^ @ [1,2,3] @
-              | EFromTo (Type n) (Maybe (Type n)) (Maybe (Type n)) -- ^ @[1, 5 ..  117 ] @
+              | EFromTo (Type n) (Maybe (Type n)) (Type n) -- ^ @[1, 5 ..  117 ] @
               | EInfFrom (Expr n) (Maybe (Expr n))-- ^ @ [1, 3 ...] @
               | EComp (Expr n) [[Match n]]      -- ^ @ [ 1 | x <- xs ] @
               | EApp (Expr n) (Expr n)          -- ^ @ f x @
@@ -688,9 +688,8 @@ instance (Show name, PPName name) => PP (Expr name) where
       ETuple es     -> parens (commaSep (map pp es))
       ERecord fs    -> braces (commaSep (map (ppNamed "=") fs))
       EList es      -> brackets (commaSep (map pp es))
-      EFromTo e1 e2 e3 -> brackets (pp e1 <.> step <+> text ".." <+> end)
+      EFromTo e1 e2 e3 -> brackets (pp e1 <.> step <+> text ".." <+> pp e3)
         where step = maybe empty (\e -> comma <+> pp e) e2
-              end  = maybe empty pp e3
       EInfFrom e1 e2 -> brackets (pp e1 <.> step <+> text "...")
         where step = maybe empty (\e -> comma <+> pp e) e2
       EComp e mss   -> brackets (pp e <+> vcat (map arm mss))

--- a/src/Cryptol/Parser/Names.hs
+++ b/src/Cryptol/Parser/Names.hs
@@ -236,7 +236,7 @@ tnamesE expr =
                      in Set.unions (e : map tnamesUF fs)
     EList es      -> Set.unions (map tnamesE es)
     EFromTo a b c -> Set.union (tnamesT a)
-                     (Set.union (maybe Set.empty tnamesT b) (maybe Set.empty tnamesT c))
+                     (Set.union (maybe Set.empty tnamesT b) (tnamesT c))
     EInfFrom e e' -> Set.union (tnamesE e) (maybe Set.empty tnamesE e')
     EComp e mss   -> Set.union (tnamesE e) (Set.unions (map tnamesM (concat mss)))
     EApp e1 e2    -> Set.union (tnamesE e1) (tnamesE e2)

--- a/src/Cryptol/Parser/ParserUtils.hs
+++ b/src/Cryptol/Parser/ParserUtils.hs
@@ -284,10 +284,11 @@ unOp f x = at (f,x) $ EApp f x
 binOp :: Expr PName -> Located PName -> Expr PName -> Expr PName
 binOp x f y = at (x,y) $ EInfix x f defaultFixity y
 
-eFromTo :: Range -> Expr PName -> Maybe (Expr PName) -> Maybe (Expr PName) -> ParseM (Expr PName)
+eFromTo :: Range -> Expr PName -> Maybe (Expr PName) -> Expr PName -> ParseM (Expr PName)
 eFromTo r e1 e2 e3 = EFromTo <$> exprToNumT r e1
                              <*> mapM (exprToNumT r) e2
-                             <*> mapM (exprToNumT r) e3
+                             <*> exprToNumT r e3
+
 exprToNumT :: Range -> Expr PName -> ParseM (Type PName)
 exprToNumT r expr =
   case translateExprToNumT expr of

--- a/src/Cryptol/Prims/Eval.hs
+++ b/src/Cryptol/Prims/Eval.hs
@@ -172,8 +172,6 @@ primTable = Map.fromList $ map (\(n, v) -> (mkIdent (T.pack n), v))
                     lam  $ \ x     ->
                        splitAtV front back a =<< x)
 
-  , ("fromThen"   , {-# SCC "Prelude::fromThen" #-}
-                    fromThenV)
   , ("fromTo"     , {-# SCC "Prelude::fromTo" #-}
                     fromToV)
   , ("fromThenTo" , {-# SCC "Prelude::fromThenTo" #-}
@@ -1405,24 +1403,6 @@ updatePrim updateWord updateSeq =
       VSeq l vs  -> VSeq l  <$> updateSeq len eltTy vs idx' val
       VStream vs -> VStream <$> updateSeq len eltTy vs idx' val
       _ -> evalPanic "Expected sequence value" ["updatePrim"]
-
--- @[ 0, 1 .. ]@
-fromThenV :: BitWord b w i
-          => GenValue b w i
-fromThenV  =
-  nlam $ \ first ->
-  nlam $ \ next  ->
-  nlam $ \ bits  ->
-  nlam $ \ len   ->
-    case (first, next, len, bits) of
-      (_         , _        , _       , Nat bits')
-        | bits' >= Arch.maxBigIntWidth -> wordTooWide bits'
-      (Nat first', Nat next', Nat len', Nat bits') ->
-        let diff = next' - first'
-         in VSeq len' $ IndexSeqMap $ \i ->
-                ready $ VWord bits' $ return $
-                  WordVal $ wordLit bits' (first' + i*diff)
-      _ -> evalPanic "fromThenV" ["invalid arguments"]
 
 -- @[ 0 .. 10 ]@
 fromToV :: BitWord b w i

--- a/src/Cryptol/Prims/Syntax.hs
+++ b/src/Cryptol/Prims/Syntax.hs
@@ -114,9 +114,6 @@ primTyList =
   , tInfix  "%^"               TF TCCeilMod    (l 90)
     "How much we need to add to make a proper multiple of the second argument."
 
-  , tPrefix "lengthFromThen"   TF TCLenFromThen
-    "The length of an enumeration."
-
   , tPrefix "lengthFromThenTo" TF TCLenFromThenTo
     "The length of an enumeration."
   ]
@@ -244,9 +241,7 @@ instance HasKind TFun where
       TCCeilDiv -> KNum :-> KNum :-> KNum
       TCCeilMod -> KNum :-> KNum :-> KNum
 
-      TCLenFromThen   -> KNum :-> KNum :-> KNum :-> KNum
       TCLenFromThenTo -> KNum :-> KNum :-> KNum :-> KNum
-
 
 
 
@@ -325,9 +320,6 @@ data TFun
   | TCCeilMod             -- ^ @ : Num -> Num -> Num @
 
   -- Computing the lengths of explicit enumerations
-  | TCLenFromThen         -- ^ @ : Num -> Num -> Num -> Num@
-    -- Example: @[ 1, 5 .. ] :: [lengthFromThen 1 5 b][b]@
-
   | TCLenFromThenTo       -- ^ @ : Num -> Num -> Num -> Num@
     -- Example: @[ 1, 5 .. 9 ] :: [lengthFromThenTo 1 5 9][b]@
 
@@ -449,6 +441,4 @@ instance PP TFun where
       TCMax             -> text "max"
       TCCeilDiv         -> text "/^"
       TCCeilMod         -> text "%^"
-
-      TCLenFromThen     -> text "lengthFromThen"
       TCLenFromThenTo   -> text "lengthFromThenTo"

--- a/src/Cryptol/Symbolic/Prims.hs
+++ b/src/Cryptol/Symbolic/Prims.hs
@@ -35,7 +35,7 @@ import Cryptol.Prims.Eval (binary, unary, arithUnary,
                            logicBinary, logicUnary, zeroV,
                            ccatV, splitAtV, joinV, ecSplitV,
                            reverseV, infFromV, infFromThenV,
-                           fromThenV, fromToV, fromThenToV,
+                           fromToV, fromThenToV,
                            transposeV, indexPrim,
                            ecToIntegerV, ecFromIntegerV,
                            ecNumberV, updatePrim, randomV, liftWord,
@@ -183,7 +183,6 @@ primTable  = Map.fromList $ map (\(n, v) -> (mkIdent (T.pack n), v))
                     tlam $ \c ->
                      lam $ \xs -> transposeV a b c =<< xs)
 
-  , ("fromThen"    , fromThenV)
   , ("fromTo"      , fromToV)
   , ("fromThenTo"  , fromThenToV)
   , ("infFrom"     , infFromV)

--- a/src/Cryptol/Transform/Specialize.hs
+++ b/src/Cryptol/Transform/Specialize.hs
@@ -310,7 +310,6 @@ freshName n _ =
 --         TCWidth         -> "width"
 --         TCMin           -> "min"
 --         TCMax           -> "max"
---         TCLenFromThen   -> "len_from_then"
 --         TCLenFromThenTo -> "len_from_then_to"
 --     showRecFld (nm,t) = showName nm : showT t
 

--- a/src/Cryptol/TypeCheck/InferTypes.hs
+++ b/src/Cryptol/TypeCheck/InferTypes.hs
@@ -296,7 +296,6 @@ ppUse expr =
       | identText prim == "number"       -> "literal or demoted expression"
       | identText prim == "infFrom"      -> "infinite enumeration"
       | identText prim == "infFromThen"  -> "infinite enumeration (with step)"
-      | identText prim == "fromThen"     -> "finite enumeration"
       | identText prim == "fromTo"       -> "finite enumeration"
       | identText prim == "fromThenTo"   -> "finite enumeration"
     _                                    -> "expression" <+> pp expr

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -3,7 +3,7 @@ module Cryptol.TypeCheck.SimpType where
 
 import Control.Applicative((<|>))
 import Cryptol.TypeCheck.Type hiding
-  (tSub,tMul,tDiv,tMod,tExp,tMin,tCeilDiv,tCeilMod,tLenFromThen,tLenFromThenTo)
+  (tSub,tMul,tDiv,tMod,tExp,tMin,tCeilDiv,tCeilMod,tLenFromThenTo)
 import Cryptol.TypeCheck.TypePat
 import Cryptol.TypeCheck.Solver.InfNat
 import Control.Monad(msum,guard)
@@ -41,7 +41,6 @@ tCon tc ts =
         (TCWidth, [x]) -> tWidth x
         (TCCeilDiv, [x, y]) -> tCeilDiv x y
         (TCCeilMod, [x, y]) -> tCeilMod x y
-        (TCLenFromThen, [x, y, z]) -> tLenFromThen x y z
         (TCLenFromThenTo, [x, y, z]) -> tLenFromThenTo x y z
         _ -> TCon tc ts
     _ -> TCon tc ts
@@ -282,12 +281,6 @@ tWidth :: Type -> Type
 tWidth x
   | Just t <- tOp TCWidth (total (op1 nWidth)) [x] = t
   | otherwise = tf1 TCWidth x
-
-tLenFromThen :: Type -> Type -> Type -> Type
-tLenFromThen x y z
-  | Just t <- tOp TCLenFromThen (op3 nLenFromThen) [x,y,z] = t
-  -- XXX: rules?
-  | otherwise = tf3 TCLenFromThen x y z
 
 tLenFromThenTo :: Type -> Type -> Type -> Type
 tLenFromThenTo x y z

--- a/src/Cryptol/TypeCheck/SimpleSolver.hs
+++ b/src/Cryptol/TypeCheck/SimpleSolver.hs
@@ -2,7 +2,7 @@
 module Cryptol.TypeCheck.SimpleSolver ( simplify , simplifyStep) where
 
 import Cryptol.TypeCheck.Type hiding
-  ( tSub, tMul, tDiv, tMod, tExp, tMin, tLenFromThen, tLenFromThenTo)
+  ( tSub, tMul, tDiv, tMod, tExp, tMin, tLenFromThenTo)
 import Cryptol.TypeCheck.Solver.Types
 import Cryptol.TypeCheck.Solver.Numeric.Fin(cryIsFinType)
 import Cryptol.TypeCheck.Solver.Numeric(cryIsEqual, cryIsNotEqual, cryIsGeq)

--- a/src/Cryptol/TypeCheck/Solve.hs
+++ b/src/Cryptol/TypeCheck/Solve.hs
@@ -58,8 +58,6 @@ wfTypeFunction :: TFun -> [Type] -> [Prop]
 wfTypeFunction TCSub [a,b]             = [ a >== b, pFin b]
 wfTypeFunction TCDiv [a,b]             = [ b >== tOne, pFin a ]
 wfTypeFunction TCMod [a,b]             = [ b >== tOne, pFin a ]
-wfTypeFunction TCLenFromThen   [a,b,w] =
-         [ pFin a, pFin b, pFin w, a =/= b, w >== tWidth a ]
 wfTypeFunction TCLenFromThenTo [a,b,c] = [ pFin a, pFin b, pFin c, a =/= b ]
 wfTypeFunction _ _                     = []
 

--- a/src/Cryptol/TypeCheck/Solver/InfNat.hs
+++ b/src/Cryptol/TypeCheck/Solver/InfNat.hs
@@ -159,28 +159,6 @@ nWidth Inf      = Inf
 nWidth (Nat n)  = Nat (widthInteger n)
 
 
-{- | @length ([ x, y .. ] : [_][w])@
-We don't check that the second element fits in `w` many bits as the
-second element may not be part of the list.
-For example, the length of @[ 0 .. ] : [_][0]@ is @nLenFromThen 0 1 0@,
-which should evaluate to 1. -}
-
-
-{- XXX: It would appear that the actual notation also requires `y` to fit in...
-It is not clear if that's a good idea.  Consider, for example,
-
-    [ 1, 4 .., 2 ]
-
-Cryptol infers that this list has one element, but it insists that the
-width of the elements be at least 3, to accommodate the 4.
--}
-nLenFromThen :: Nat' -> Nat' -> Nat' -> Maybe Nat'
-nLenFromThen a@(Nat x) b@(Nat y) wi@(Nat w)
-  | wi < nWidth a = Nothing
-  | y > x         = nLenFromThenTo a b (Nat (2^w - 1))
-  | y < x         = nLenFromThenTo a b (Nat 0)
-
-nLenFromThen _ _ _ = Nothing
 
 -- | @length [ x, y .. z ]@
 nLenFromThenTo :: Nat' -> Nat' -> Nat' -> Maybe Nat'
@@ -202,9 +180,6 @@ nLenFromThenTo _ _ _ = Nothing
   nLenFromThenTo x y z == 0
     case 1: x > y  && z > x
     case 2: x <= y && z < x
-
-  nLenFromThen x y w == 0
-    impossible
 -}
 
 {- Note [Sequences of Length 1]
@@ -242,14 +217,6 @@ nLenFromThenTo _ _ _ = Nothing
           (z < y)
 
   case 2 summary: y > z, z >= x
-
-------------------------
-
-  `nLenFromThen x y w == 1`
-    | y > x         = nLenFromThenTo x y (Nat (2^w - 1))
-    | y < x         = nLenFromThenTo x y (Nat 0)
-
-    y >= 2^w, y > x
 
 -}
 

--- a/src/Cryptol/TypeCheck/Solver/Numeric/Fin.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric/Fin.hs
@@ -88,7 +88,6 @@ cryIsFinType varInfo ty =
         (TCWidth, [t1])           -> SolvedIf [ pFin t1 ]
         (TCCeilDiv, [_,_])        -> SolvedIf []
         (TCCeilMod, [_,_])        -> SolvedIf []
-        (TCLenFromThen,[_,_,_])   -> SolvedIf []
         (TCLenFromThenTo,[_,_,_]) -> SolvedIf []
 
         _ -> Unsolved

--- a/src/Cryptol/TypeCheck/Solver/Numeric/Interval.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric/Interval.hs
@@ -42,8 +42,6 @@ typeInterval varInfo = go
           (TF TCWidth, [x])   -> iWidth (go x)
           (TF TCMin, [x,y])   -> iMin (go x) (go y)
           (TF TCMax, [x,y])   -> iMax (go x) (go y)
-          (TF TCLenFromThen, [x,y,z]) ->
-            iLenFromThen (go x) (go y) (go z)
 
           (TF TCLenFromThenTo, [x,y,z]) ->
             iLenFromThenTo (go x) (go y) (go z)
@@ -343,17 +341,6 @@ iWidth i = Interval { iLower = nWidth (iLower i)
                                  Nothing -> Nothing
                                  Just n  -> Just (nWidth n)
                     }
-
-iLenFromThen :: Interval -> Interval -> Interval -> Interval
-iLenFromThen i j w
-  | Just x <- iIsExact i, Just y <- iIsExact j, Just z <- iIsExact w
-  , Just r <- nLenFromThen x y z = iConst r
-  | otherwise =
-      case iUpper w of
-        Just (Nat n) ->
-                    Interval { iLower = Nat 0, iUpper = Just (Nat (2^n - 1)) }
-        _ -> iAnyFin
-
 
 iLenFromThenTo :: Interval -> Interval -> Interval -> Interval
 iLenFromThenTo i j k

--- a/src/Cryptol/TypeCheck/Solver/SMT.hs
+++ b/src/Cryptol/TypeCheck/Solver/SMT.hs
@@ -353,7 +353,6 @@ toSMT tvs ty = matchDefault (panic "toSMT" [ "Unexpected type", show ty ])
   , aWidth          ~> "cryWidth"
   , aCeilDiv        ~> "cryCeilDiv"
   , aCeilMod        ~> "cryCeilMod"
-  , aLenFromThen    ~> "cryLenFromThen"
   , aLenFromThenTo  ~> "cryLenFromThenTo"
 
   , anError KNum    ~> "cryErr"

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -542,13 +542,8 @@ tCeilDiv = tf2 TCCeilDiv
 tCeilMod :: Type -> Type -> Type
 tCeilMod = tf2 TCCeilMod
 
-tLenFromThen :: Type -> Type -> Type -> Type
-tLenFromThen = tf3 TCLenFromThen
-
 tLenFromThenTo :: Type -> Type -> Type -> Type
 tLenFromThenTo = tf3 TCLenFromThenTo
-
-
 
 
 

--- a/src/Cryptol/TypeCheck/TypePat.hs
+++ b/src/Cryptol/TypeCheck/TypePat.hs
@@ -5,7 +5,7 @@ module Cryptol.TypeCheck.TypePat
   , aMin, aMax
   , aWidth
   , aCeilDiv, aCeilMod
-  , aLenFromThen, aLenFromThenTo
+  , aLenFromThenTo
 
   , aLiteral, aLogic
 
@@ -111,9 +111,6 @@ aCeilDiv = tf TCCeilDiv ar2
 
 aCeilMod :: Pat Type (Type,Type)
 aCeilMod = tf TCCeilMod ar2
-
-aLenFromThen :: Pat Type (Type,Type,Type)
-aLenFromThen = tf TCLenFromThen ar3
 
 aLenFromThenTo :: Pat Type (Type,Type,Type)
 aLenFromThenTo = tf TCLenFromThenTo ar3

--- a/tests/issues/T146.icry.stdout
+++ b/tests/issues/T146.icry.stdout
@@ -3,14 +3,14 @@ Loading module Cryptol
 Loading module Main
 
 [error] at ./T146.cry:1:18--6:10:
-  The type ?fv`864 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`848
+  The type ?fv`860 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`844
   where
-  ?fv`864 is type argument 'fv' of 'Main::ec_v1' at ./T146.cry:4:19--4:24
-  fv`848 is signature variable 'fv' at ./T146.cry:11:10--11:12
+  ?fv`860 is type argument 'fv' of 'Main::ec_v1' at ./T146.cry:4:19--4:24
+  fv`844 is signature variable 'fv' at ./T146.cry:11:10--11:12
 [error] at ./T146.cry:5:19--5:24:
-  The type ?fv`866 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`848
+  The type ?fv`862 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`844
   where
-  ?fv`866 is type argument 'fv' of 'Main::ec_v2' at ./T146.cry:5:19--5:24
-  fv`848 is signature variable 'fv' at ./T146.cry:11:10--11:12
+  ?fv`862 is type argument 'fv' of 'Main::ec_v2' at ./T146.cry:5:19--5:24
+  fv`844 is signature variable 'fv' at ./T146.cry:11:10--11:12

--- a/tests/issues/issue226.icry.stdout
+++ b/tests/issues/issue226.icry.stdout
@@ -65,11 +65,6 @@ Symbols
     foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
     foo : {a} a -> a
     fromInteger : {a} (Arith a) => Integer -> a
-    fromThen :
-      {first, next, bits, len} (fin first, fin next, fin bits,
-                                bits >= width first, bits >= width next, first != next,
-                                lengthFromThen first next bits == len) =>
-        [len][bits]
     fromThenTo :
       {first, next, last, a, len} (fin first, fin next, fin last,
                                    Literal first a, Literal next a, Literal last a, first != next,

--- a/tests/issues/issue290v2.icry.stdout
+++ b/tests/issues/issue290v2.icry.stdout
@@ -4,9 +4,9 @@ Loading module Main
 
 [error] at ./issue290v2.cry:2:1--2:19:
   Unsolved constraints:
-    • n`845 == 1
+    • n`841 == 1
         arising from
         checking a pattern: type of 1st argument of Main::minMax
         at ./issue290v2.cry:2:8--2:11
   where
-  n`845 is signature variable 'n' at ./issue290v2.cry:1:11--1:12
+  n`841 is signature variable 'n' at ./issue290v2.cry:1:11--1:12

--- a/tests/regression/check11.cry
+++ b/tests/regression/check11.cry
@@ -1,5 +1,5 @@
 check11 = zz == ww
   where
     zz = [0 .. 99]
-    qq = zz @@ ([0 ..] : [_][32])
+    qq = zz @@ ([0 .. 0xffffffff] : [_][32])
     ww = qq @@ [0 .. 99]


### PR DESCRIPTION
This set of changes removes the `[x..]` and `[x,y..]` syntax, the `fromThen` primitive, and the `lengthFromThen` type operator.

Fixes #574.