### PR TITLE
Changes required to compile Cryptol with SBV 8.1; and model-validation support

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -59,7 +59,7 @@ library
                        pretty            >= 1.1,
                        process           >= 1.2,
                        random            >= 1.0.1,
-                       sbv               >= 8.0,
+                       sbv               >= 8.1,
                        simple-smt        >= 0.7.1,
                        strict,
                        text              >= 1.1,
@@ -266,5 +266,5 @@ benchmark cryptol-bench
                      , deepseq
                      , directory
                      , filepath
-                     , sbv >= 8.0
+                     , sbv >= 8.1
                      , text

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -574,6 +574,7 @@ onlineProveSat isSat str mfile = do
   proverName <- getKnownUser "prover"
   verbose <- getKnownUser "debug"
   satNum <- getUserSatNum
+  modelValidate <- getUserProverValidate
   parseExpr <- replParseExpr str
   (_, expr, schema) <- replCheckExpr parseExpr
   validEvalContext expr
@@ -584,6 +585,7 @@ onlineProveSat isSat str mfile = do
           pcQueryType    = if isSat then SatQuery satNum else ProveQuery
         , pcProverName   = proverName
         , pcVerbose      = verbose
+        , pcValidate     = modelValidate
         , pcProverStats  = timing
         , pcExtraDecls   = decls
         , pcSmtFile      = mfile
@@ -597,6 +599,7 @@ onlineProveSat isSat str mfile = do
 offlineProveSat :: Bool -> String -> Maybe FilePath -> REPL (Either String String)
 offlineProveSat isSat str mfile = do
   verbose <- getKnownUser "debug"
+  modelValidate <- getUserProverValidate
   parseExpr <- replParseExpr str
   (_, expr, schema) <- replCheckExpr parseExpr
   decls <- fmap M.deDecls getDynEnv
@@ -605,6 +608,7 @@ offlineProveSat isSat str mfile = do
           pcQueryType    = if isSat then SatQuery (SomeSat 0) else ProveQuery
         , pcProverName   = "offline"
         , pcVerbose      = verbose
+        , pcValidate     = modelValidate
         , pcProverStats  = timing
         , pcExtraDecls   = decls
         , pcSmtFile      = mfile

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -62,6 +62,7 @@ module Cryptol.REPL.Monad (
   , userOptions
   , getUserSatNum
   , getUserShowProverStats
+  , getUserProverValidate
 
     -- ** Configurable Output
   , getPutStr
@@ -709,6 +710,9 @@ badIsEnv x = panic "fromEnvVal" [ "[REPL] Expected a `" ++ x ++ "` value." ]
 getUserShowProverStats :: REPL Bool
 getUserShowProverStats = getKnownUser "prover-stats"
 
+getUserProverValidate :: REPL Bool
+getUserProverValidate = getKnownUser "prover-validate"
+
 -- Environment Options ---------------------------------------------------------
 
 type OptionMap = Trie OptionDescr
@@ -795,6 +799,9 @@ userOptions  = mkOptionMap
 
   , simpleOpt "prover-stats" (EnvBool True) noCheck
     "Enable prover timing statistics."
+
+  , simpleOpt "prover-validate" (EnvBool False) noCheck
+    "Validate :sat examples and :prove counter-examples for correctness."
   ]
 
 

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -120,7 +120,7 @@ satSMTResults :: SBV.SatResult -> [SBV.SMTResult]
 satSMTResults (SBV.SatResult r) = [r]
 
 allSatSMTResults :: SBV.AllSatResult -> [SBV.SMTResult]
-allSatSMTResults (SBV.AllSatResult (_, _, rs)) = rs
+allSatSMTResults (SBV.AllSatResult (_, _, _, rs)) = rs
 
 thmSMTResults :: SBV.ThmResult -> [SBV.SMTResult]
 thmSMTResults (SBV.ThmResult r) = [r]
@@ -169,6 +169,7 @@ satProve ProverCommand {..} =
                    , [ SBV.ProofError
                          prover
                          [":sat with option prover=any requires option satNum=1"]
+                         Nothing
                      | prover <- provers ]
                    )
       runProvers fn tag e = do
@@ -228,10 +229,8 @@ satProve ProverCommand {..} =
                      [] -> return $ ThmResult (unFinType <$> ts)
                      -- otherwise something is wrong
                      _ -> return $ ProverError (rshow results)
-                            where rshow | isSat = show .  SBV.AllSatResult . (False,boom,)
+                            where rshow | isSat = show .  SBV.AllSatResult . (False,False,False,)
                                         | otherwise = show . SBV.ThmResult . head
-                                  boom = panic "Cryptol.Symbolic.sat"
-                                           [ "attempted to evaluate bogus boolean for pretty-printing" ]
                    return (firstProver, esatexprs)
 
 satProveOffline :: ProverCommand -> M.ModuleCmd (Either String String)

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -93,6 +93,8 @@ data ProverCommand = ProverCommand {
     -- ^ Which prover to use (one of the strings in 'proverConfigs')
   , pcVerbose :: Bool
     -- ^ Verbosity flag passed to SBV
+  , pcValidate :: Bool
+    -- ^ Model validation flag passed to SBV
   , pcProverStats :: !(IORef ProverStats)
     -- ^ Record timing information here
   , pcExtraDecls :: [DeclGroup]
@@ -148,7 +150,10 @@ satProve ProverCommand {..} =
                                                }]
 
 
-  let provers' = [ p { SBV.timing = SaveTiming pcProverStats, SBV.verbose = pcVerbose } | p <- provers ]
+  let provers' = [ p { SBV.timing = SaveTiming pcProverStats
+                     , SBV.verbose = pcVerbose
+                     , SBV.validateModel = pcValidate
+                     } | p <- provers ]
   let tyFn = if isSat then existsFinType else forallFinType
   let lPutStrLn = M.withLogger logPutStrLn
   let doEval :: MonadIO m => Eval.Eval a -> m a

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -20,7 +20,7 @@ import Control.Monad.IO.Class
 import Control.Monad (replicateM, when, zipWithM, foldM)
 import Control.Monad.Writer (WriterT, runWriterT, tell, lift)
 import Data.List (intercalate, genericLength)
-import Data.IORef(IORef,writeIORef)
+import Data.IORef(IORef)
 import qualified Control.Exception as X
 
 import qualified Data.SBV.Dynamic as SBV
@@ -177,9 +177,6 @@ satProve ProverCommand {..} =
           lPutStrLn $ "Trying proof with " ++
                   intercalate ", " (map (show . SBV.name . SBV.solver) provers)
         (firstProver, timeElapsed, res) <- M.io (fn provers' e)
-        -- NOTE: It would appear that the ref does not contain the elaspsed
-        -- time but rahter some sort of small value, so we write it here.
-        liftIO $ writeIORef pcProverStats timeElapsed
         when pcVerbose $
           lPutStrLn $ "Got result from " ++ show firstProver ++
                                             ", time: " ++ showTDiff timeElapsed


### PR DESCRIPTION
@brianhuffman @atomb @yav 

SBV 8.1 is out on hackage, and I'm afraid it'll be a while before another one comes out. Hopefully, it doesn't have any glaring bugs!

This pull request contains changes to Cryptol so:

1. You can compile with SBV 8.1
2. It fixes the "elapsed time printing" bug: https://github.com/GaloisInc/cryptol/issues/572
3. It fixes the "sharing" bug triggered for the uses of `svChangeSign`: https://github.com/GaloisInc/cryptol/issues/566
4. It adds support for barrel-rotations so you can implement faster rotates, discussed here: https://github.com/GaloisInc/cryptol/issues/573
5. It adds a model-validator feature to Cryptol, piggy backing on the same SBV 8.1 feature, that can help with issue reported in ticket: https://github.com/GaloisInc/cryptol/issues/558

And hopefully it doesn't break anything new! Give it a shot and please send patches if you find bugs.