### PR TITLE
Command to dump generated tests

### DIFF
--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -317,8 +317,10 @@ dumpTestsCmd outFile str =
               do argOut <- mapM (rEval . E.ppValue ppopts) args
                  resOut <- rEval (E.ppValue ppopts x)
                  return (renderOneLine resOut ++ "\t" ++ intercalate "\t" (map renderOneLine argOut) ++ "\n")
-     io $ writeFile outFile (concat out)
-
+     io $ writeFile outFile (concat out) `X.catch` handler
+  where
+    handler :: X.SomeException -> IO ()
+    handler e = putStrLn (X.displayException e)
 
 
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -121,6 +121,7 @@ data Command
 -- | Command builder.
 data CommandDescr = CommandDescr
   { cNames  :: [String]
+  , cArgs   :: [String]
   , cBody   :: CommandBody
   , cHelp   :: String
   }
@@ -168,54 +169,54 @@ nbCommands  = foldl insert emptyTrie nbCommandList
 -- | A subset of commands safe for Notebook execution
 nbCommandList :: [CommandDescr]
 nbCommandList  =
-  [ CommandDescr [ ":t", ":type" ] (ExprArg typeOfCmd)
+  [ CommandDescr [ ":t", ":type" ] ["EXPR"] (ExprArg typeOfCmd)
     "Check the type of an expression."
-  , CommandDescr [ ":b", ":browse" ] (ModNameArg browseCmd)
+  , CommandDescr [ ":b", ":browse" ] ["[ MODULE ]"] (ModNameArg browseCmd)
     "Display environment for all loaded modules, or for a specific module."
-  , CommandDescr [ ":?", ":help" ] (HelpArg helpCmd)
+  , CommandDescr [ ":?", ":help" ] ["[ TOPIC ]"] (HelpArg helpCmd)
     "Display a brief description of a function, type, or command."
-  , CommandDescr [ ":s", ":set" ] (OptionArg setOptionCmd)
+  , CommandDescr [ ":s", ":set" ] ["[ OPTION [ = VALUE ] ]"] (OptionArg setOptionCmd)
     "Set an environmental option (:set on its own displays current values)."
-  , CommandDescr [ ":check" ] (ExprArg (void . qcCmd QCRandom))
+  , CommandDescr [ ":check" ] ["[ EXPR ]"] (ExprArg (void . qcCmd QCRandom))
     "Use random testing to check that the argument always returns true.\n(If no argument, check all properties.)"
-  , CommandDescr [ ":exhaust" ] (ExprArg (void . qcCmd QCExhaust))
+  , CommandDescr [ ":exhaust" ] ["[ EXPR ]"] (ExprArg (void . qcCmd QCExhaust))
     "Use exhaustive testing to prove that the argument always returns\ntrue. (If no argument, check all properties.)"
-  , CommandDescr [ ":prove" ] (ExprArg proveCmd)
+  , CommandDescr [ ":prove" ] ["[ EXPR ]"] (ExprArg proveCmd)
     "Use an external solver to prove that the argument always returns\ntrue. (If no argument, check all properties.)"
-  , CommandDescr [ ":sat" ] (ExprArg satCmd)
+  , CommandDescr [ ":sat" ] ["[ EXPR ]"] (ExprArg satCmd)
     "Use a solver to find a satisfying assignment for which the argument\nreturns true. (If no argument, find an assignment for all properties.)"
-  , CommandDescr [ ":debug_specialize" ] (ExprArg specializeCmd)
+  , CommandDescr [ ":debug_specialize" ] ["EXPR"](ExprArg specializeCmd)
     "Do type specialization on a closed expression."
-  , CommandDescr [ ":eval" ] (ExprArg refEvalCmd)
+  , CommandDescr [ ":eval" ] ["EXPR"] (ExprArg refEvalCmd)
     "Evaluate an expression with the reference evaluator."
-  , CommandDescr [ ":ast" ] (ExprArg astOfCmd)
+  , CommandDescr [ ":ast" ] ["EXPR"] (ExprArg astOfCmd)
     "Print out the pre-typechecked AST of a given term."
-  , CommandDescr [ ":extract-coq" ] (NoArg allTerms)
+  , CommandDescr [ ":extract-coq" ] [] (NoArg allTerms)
     "Print out the post-typechecked AST of all currently defined terms,\nin a Coq-parseable format."
   ]
 
 commandList :: [CommandDescr]
 commandList  =
   nbCommandList ++
-  [ CommandDescr [ ":q", ":quit" ] (NoArg quitCmd)
+  [ CommandDescr [ ":q", ":quit" ] [] (NoArg quitCmd)
     "Exit the REPL."
-  , CommandDescr [ ":l", ":load" ] (FilenameArg loadCmd)
+  , CommandDescr [ ":l", ":load" ] ["FILE"] (FilenameArg loadCmd)
     "Load a module by filename."
-  , CommandDescr [ ":r", ":reload" ] (NoArg reloadCmd)
+  , CommandDescr [ ":r", ":reload" ] [] (NoArg reloadCmd)
     "Reload the currently loaded module."
-  , CommandDescr [ ":e", ":edit" ] (FilenameArg editCmd)
-    "Edit the currently loaded module."
-  , CommandDescr [ ":!" ] (ShellArg runShellCmd)
+  , CommandDescr [ ":e", ":edit" ] ["[ FILE ]"] (FilenameArg editCmd)
+    "Edit FILE or the currently loaded module."
+  , CommandDescr [ ":!" ] ["COMMAND"] (ShellArg runShellCmd)
     "Execute a command in the shell."
-  , CommandDescr [ ":cd" ] (FilenameArg cdCmd)
+  , CommandDescr [ ":cd" ] ["DIR"] (FilenameArg cdCmd)
     "Set the current working directory."
-  , CommandDescr [ ":m", ":module" ] (FilenameArg moduleCmd)
+  , CommandDescr [ ":m", ":module" ] ["[ MODULE ]"] (FilenameArg moduleCmd)
     "Load a module by its name."
-  , CommandDescr [ ":w", ":writeByteArray" ] (FileExprArg writeFileCmd)
+  , CommandDescr [ ":w", ":writeByteArray" ] ["FILE", "EXPR"] (FileExprArg writeFileCmd)
     "Write data of type 'fin n => [n][8]' to a file."
-  , CommandDescr [ ":readByteArray" ] (FilenameArg readFileCmd)
+  , CommandDescr [ ":readByteArray" ] ["FILE"] (FilenameArg readFileCmd)
     "Read data from a file as type 'fin n => [n][8]', binding\nthe value to variable 'it'."
-  , CommandDescr [ ":dumptests" ] (FileExprArg dumpTestsCmd)
+  , CommandDescr [ ":dumptests" ] ["FILE", "EXPR"] (FileExprArg dumpTestsCmd)
     (unlines [ "Dump a tab-separated collection of tests for the given"
              , "expression into a file. The first column in each line is the expected"
              , "output, and the remainder are the inputs. The number of"
@@ -1082,7 +1083,7 @@ helpCmd cmd
 
   showCmdHelp c [arg] | ":set" `elem` cNames c = showOptionHelp arg
   showCmdHelp c _args =
-    do rPutStrLn ("\n    " ++ intercalate ", " (cNames c))
+    do rPutStrLn ("\n    " ++ intercalate ", " (cNames c) ++ " " ++ intercalate " " (cArgs c))
        rPutStrLn ""
        rPutStrLn (cHelp c)
        rPutStrLn ""

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -218,9 +218,9 @@ commandList  =
     "Read data from a file as type 'fin n => [n][8]', binding\nthe value to variable 'it'."
   , CommandDescr [ ":dumptests" ] ["FILE", "EXPR"] (FileExprArg dumpTestsCmd)
     (unlines [ "Dump a tab-separated collection of tests for the given"
-             , "expression into a file. The first column in each line is the expected"
-             , "output, and the remainder are the inputs. The number of"
-             , "tests is determined by the \"tests\" option."
+             , "expression into a file. The first column in each line is"
+             , "the expected output, and the remainder are the inputs. The"
+             , "number of tests is determined by the \"tests\" option."
              ])
   ]
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -315,7 +315,7 @@ dumpTestsCmd outFile str =
             \(args, x) ->
               do argOut <- mapM (rEval . E.ppValue ppopts) args
                  resOut <- rEval (E.ppValue ppopts x)
-                 return (show resOut ++ "\t" ++ intercalate "\t" (map show argOut) ++ "\n")
+                 return (renderOneLine resOut ++ "\t" ++ intercalate "\t" (map renderOneLine argOut) ++ "\n")
      io $ writeFile outFile (concat out)
 
 

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -11,15 +11,17 @@
 {-# LANGUAGE BangPatterns #-}
 module Cryptol.Testing.Random where
 
-import Cryptol.Eval.Monad     (ready,EvalOpts)
+import Cryptol.Eval.Monad     (ready,runEval,EvalOpts)
 import Cryptol.Eval.Value     (BV(..),Value,GenValue(..),SeqMap(..), WordValue(..), BitWord(..))
 import qualified Cryptol.Testing.Concrete as Conc
 import Cryptol.TypeCheck.AST  (Type(..),TCon(..),TC(..),tNoUser)
 import Cryptol.TypeCheck.SimpType(tRebuild')
 
 import Cryptol.Utils.Ident    (Ident)
+import Cryptol.Utils.Panic    (panic)
+import Cryptol.Utils.PP       (pp)
 
-import Control.Monad          (forM)
+import Control.Monad          (forM,join)
 import Data.List              (unfoldr, genericTake, genericIndex)
 import System.Random          (RandomGen, split, random, randomR)
 import qualified Data.Sequence as Seq
@@ -46,6 +48,55 @@ runOneTest evOpts fun argGens sz g0 = do
       mkArg argGen (as, g) = let (a, g') = argGen sz g in (a:as, g')
   result <- Conc.runOneTest evOpts fun args
   return (result, g1)
+
+returnOneTest :: RandomGen g
+           => EvalOpts -- ^ How to evaluate things
+           -> Value    -- ^ Function to be used to calculate tests
+           -> [Gen g Bool BV Integer] -- ^ Argument generators
+           -> Integer -- ^ Size
+           -> g -- ^ Initial random state
+           -> IO ([Value], Value, g) -- ^ Arguments, result, and new random state
+returnOneTest evOpts fun argGens sz g0 =
+  do let (args, g1) = foldr mkArg ([], g0) argGens
+         mkArg argGen (as, g) = let (a, g') = argGen sz g in (a:as, g')
+     result <- runEval evOpts (go fun args)
+     return (args, result, g1)
+   where
+     go (VFun f) (v : vs) = join (go <$> (f (ready v)) <*> pure vs)
+     go (VFun _) [] = panic "Not enough arguments to function while generating tests" []
+     go v@(VBit _) [] = return v
+     go v@(VSeq _ _) [] = return v
+     go v@(VWord _ _) [] = return v
+     go v@(VRecord _) [] = return v
+     go v@(VTuple _) [] = return v
+     go _ _ = panic "Cryptol.Testing.Random" ["Unsupported return value for testing"]
+
+
+-- | Return a collection of random tests.
+returnTests :: RandomGen g
+         => g -- ^ The random generator state
+         -> EvalOpts -- ^ How to evaluate things
+         -> Type -- ^ The type of the function for which tests are to be generated
+         -> Value -- ^ The function itself
+         -> Int -- ^ How many tests?
+         -> IO [([Value], Value)] -- ^ A list of pairs of random arguments and computed outputs
+returnTests g evo ty fun num
+  | num <= 0 = return []
+  | otherwise =
+    case argGens ty of
+      Nothing -> panic "Cryptol.Testing.Random" ["Can't generate test inputs for type", show (pp ty)]
+      Just args ->
+        do let (sz, g') = randomSize 8 100 g
+           (inputs, output, g'') <- returnOneTest evo fun args (toInteger sz) g'
+           more <- returnTests g'' evo ty fun (num - 1)
+           return ((inputs, output) : more)
+  where
+    argGens t =
+      case tNoUser t of
+        TCon (TC TCFun) [t1, t2] ->
+          (:) <$> randomValue t1 <*> argGens t2
+        _ -> pure []
+
 
 {- | Given a (function) type, compute generators for
 the function's arguments. Currently we do not support polymorphic functions.

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -114,6 +114,9 @@ instance IsString Doc where
 render :: Doc -> String
 render d = PJ.render (runDoc mempty d)
 
+renderOneLine :: Doc -> String
+renderOneLine d = PJ.renderStyle (PJ.style { PJ.mode = PJ.OneLineMode }) (runDoc mempty d)
+
 class PP a where
   ppPrec :: Int -> a -> Doc
 


### PR DESCRIPTION
Here's a REPL command to dump generated tests instead of running them, so that they can be consumed by other tools.

I have a couple of questions, pre-merge:

1. The docs for this command are longer than the others due to describing its interaction with options. Should it be shortened, should they be lengthened, or is it OK?

2. Is there a CHANGELOG or NEWS file that I should update?