### PR TITLE
Fix for freevars and adding some exports.

### DIFF
--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -12,6 +12,8 @@
 > module Cryptol.Eval.Reference
 >   ( Value(..)
 >   , evaluate
+>   , evalExpr
+>   , evalDeclGroup
 >   , ppValue
 >   ) where
 >

--- a/src/Cryptol/IR/FreeVars.hs
+++ b/src/Cryptol/IR/FreeVars.hs
@@ -118,7 +118,7 @@ instance FreeVars Expr where
       EAbs x t e        -> freeVars t <> rmVal x (freeVars e)
       EProofAbs p e     -> freeVars p <> freeVars e
       EProofApp e       -> freeVars e
-      EWhere e ds       -> freeVars ds <> rmVals (defs ds) (freeVars e)
+      EWhere e ds       -> rmVals (defs ds) (freeVars ds) <> rmVals (defs ds) (freeVars e)
 
 
 instance FreeVars Match where
@@ -178,6 +178,3 @@ instance Defs Match where
   defs m = case m of
              From x _ _ _ -> Set.singleton x
              Let d -> defs d
-
-
-


### PR DESCRIPTION
1. Cryptol can reference declarations in where clause sequentially so we need to remove the declarations from their body as well. 

2. Exporting evalExpr and evalDeclGroup so I can use them in code generation.