### PR TITLE
Add help hint to Cryptol REPL

### DIFF
--- a/cryptol/REPL/Logo.hs
+++ b/cryptol/REPL/Logo.hs
@@ -35,7 +35,8 @@ logo useColor mk =
   versionText = "version " ++ showVersion version ++ hashText
   ver = sgr [SetColor Foreground Dull White]
         ++ replicate (lineLen - 20 - length versionText) ' '
-        ++ versionText
+        ++ versionText ++ "\n"
+        ++ "https://cryptol.net  :? for help"
   ls        = mk ver
   slen      = length ls `div` 3
   (ws,rest) = splitAt slen ls


### PR DESCRIPTION
Added a helpful line to the startup message, specified by #617. Looks like:
```
┏━╸┏━┓╻ ╻┏━┓╺┳╸┏━┓╻
┃  ┣┳┛┗┳┛┣━┛ ┃ ┃ ┃┃
┗━╸╹┗╸ ╹ ╹   ╹ ┗━┛┗━╸
version 2.7.1 (ede8c3f)
https://cryptol.net  :? for help

Loading module Cryptol
Cryptol>
```