### PR TITLE
Remove signed right-shift primitive, define it in the prelude instead.

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -459,8 +459,8 @@ primitive (>>>) : {n, ix, a} (fin n, fin ix) => [n]a -> [ix] -> [n]a
  * the second argument is the number of positions to shift
  * by (considered as an unsigned value).
  */
-primitive (>>$) : {n, ix} (fin n, n >= 1, fin ix) => [n] -> [ix] -> [n]
-
+(>>$) : {n, ix} (fin n, n >= 1, fin ix) => [n] -> [ix] -> [n]
+x >>$ y = if head x then ~ (~ x >> y) else x >> y
 
 
 /**

--- a/src/Cryptol/Prims/Eval.hs
+++ b/src/Cryptol/Prims/Eval.hs
@@ -98,8 +98,6 @@ primTable = Map.fromList $ map (\(n, v) -> (mkIdent (T.pack n), v))
   , ("%$"         , {-# SCC "Prelude::(%$)" #-}
                     binary (arithBinary (liftSigned bvSrem) (liftDivInteger mod)
                             (const (liftDivInteger mod))))
-  , (">>$"        , {-# SCC "Prelude::(>>$)" #-}
-                    sshrV)
   , ("&&"         , {-# SCC "Prelude::(&&)" #-}
                     binary (logicBinary (.&.) (binBV (.&.))))
   , ("||"         , {-# SCC "Prelude::(||)" #-}
@@ -669,18 +667,6 @@ bvSdiv sz x y = return $! mkBv sz (x `quot` y)
 bvSrem :: Integer -> Integer -> Integer -> Eval BV
 bvSrem  _ _ 0 = divideByZero
 bvSrem sz x y = return $! mkBv sz (x `rem` y)
-
-sshrV :: Value
-sshrV =
-  nlam $ \_n ->
-  nlam $ \_k ->
-  wlam $ \(BV i x) -> return $
-  wlam $ \y ->
-   let signx = testBit x (fromInteger (i-1))
-       amt   = fromInteger (bvVal y)
-       negv  = (((-1) `shiftL` amt) .|. x) `shiftR` amt
-       posv  = x `shiftR` amt
-    in return . VWord i . ready . WordVal . mkBv i $! if signx then negv else posv
 
 -- | Signed carry bit.
 scarryV :: Value

--- a/src/Cryptol/Symbolic/Prims.hs
+++ b/src/Cryptol/Symbolic/Prims.hs
@@ -108,7 +108,6 @@ primTable  = Map.fromList $ map (\(n, v) -> (mkIdent (T.pack n), v))
                              (liftModBin SBV.svQuot))) -- {a} (Arith a) => a -> a -> a
   , ("%$"          , binary (arithBinary (liftBinArith signedRem) (liftBin SBV.svRem)
                              (liftModBin SBV.svRem)))
-  , (">>$"         , sshrV)
   , ("&&"          , binary (logicBinary SBV.svAnd SBV.svAnd))
   , ("||"          , binary (logicBinary SBV.svOr SBV.svOr))
   , ("^"           , binary (logicBinary SBV.svXOr SBV.svXOr))
@@ -591,21 +590,6 @@ signedQuot x y = SBV.svUnsign (SBV.svQuot (SBV.svSign x) (SBV.svSign y))
 
 signedRem :: SWord -> SWord -> SWord
 signedRem x y = SBV.svUnsign (SBV.svRem (SBV.svSign x) (SBV.svSign y))
-
-
-sshrV :: Value
-sshrV =
-  nlam $ \_n ->
-  nlam $ \_k ->
-  wlam $ \x -> return $
-  wlam $ \y ->
-   case SBV.svAsInteger y of
-     Just i ->
-       let z = SBV.svUnsign (SBV.svShr (SBV.svSign x) (fromInteger i))
-        in return . VWord (toInteger (SBV.intSizeOf x)) . ready . WordVal $ z
-     Nothing ->
-       let z = SBV.svUnsign (SBV.svShiftRight (SBV.svSign x) y)
-        in return . VWord (toInteger (SBV.intSizeOf x)) . ready . WordVal $ z
 
 carry :: SWord -> SWord -> Eval Value
 carry x y = return $ VBit c


### PR DESCRIPTION
Fixes #664.