### PR TITLE
Do renaming on types the same way we do renaming on expressions.

### DIFF
--- a/tests/issues/issue614.cry
+++ b/tests/issues/issue614.cry
@@ -1,0 +1,6 @@
+f : {m, n, k} (n == max 2 m k == m + 1) => [m] -> [k][n]
+f x = zero
+
+
+g : {n, k} (fin n, fin k, 0 < n <= k) => [n] -> [k]
+g x = sext x

--- a/tests/issues/issue614.icry
+++ b/tests/issues/issue614.icry
@@ -1,0 +1,1 @@
+:l issue614.cry

--- a/tests/issues/issue614.icry.stdout
+++ b/tests/issues/issue614.icry.stdout
@@ -1,0 +1,16 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+
+[error] at issue614.cry:1:18--1:20 and issue614.cry:1:31--1:33
+    The fixities of
+      • (==) (precedence 20, non-associative)
+      • (==) (precedence 20, non-associative)
+    are not compatible.
+    You may use explicit parentheses to disambiguate.
+[error] at issue614.cry:5:29--5:30 and issue614.cry:5:33--5:35
+    The fixities of
+      • (<) (precedence 30, non-associative)
+      • (<=) (precedence 30, non-associative)
+    are not compatible.
+    You may use explicit parentheses to disambiguate.


### PR DESCRIPTION
This does fixity resolution for types during renaming, with proper error reporting when conflicting fixities are encountered.

Fixes issue #614.