### PR TITLE
Update cryptol-test-runner maintainer and license

### DIFF
--- a/tests/cryptol-test-runner.cabal
+++ b/tests/cryptol-test-runner.cabal
@@ -1,9 +1,9 @@
 Name:                cryptol-test-runner
 Version:             2.0
 Synopsis:            Testing framework for cryptol-2
-License:             AllRightsReserved
+License:             BSD3
 Author:              Galois, Inc.
-Maintainer:          trevor@galois.com
+Maintainer:          cryptol@galois.com
 Copyright:           Galois Inc.
 Category:            Language
 Build-type:          Simple


### PR DESCRIPTION
Assigns a valid license to the cryptol-test-runner (to match cryptol itself) and updates the maintainer.