### PR TITLE
Add cabal bounds to the `haskeline` package.

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -200,7 +200,7 @@ executable cryptol
                      , cryptol
                      , directory
                      , filepath
-                     , haskeline
+                     , haskeline >= 0.7 && <= 0.8
                      , monad-control
                      , text
                      , transformers


### PR DESCRIPTION
Apparently version 0.8 contains some breaking changes.