### PR TITLE
Specialize types of signed div/mod operators (/$) and (%$) to bitvectors

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -329,12 +329,12 @@ x >=$ y = ~(x <$ y)
 /**
  * 2's complement signed division.  Division rounds toward 0.
  */
-primitive (/$) : {a} (Arith a) => a -> a -> a
+primitive (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
 
 /**
  * 2's complement signed remainder.  Division rounds toward 0.
  */
-primitive (%$) : {a} (Arith a) => a -> a -> a
+primitive (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
 
 /**
  * Unsigned carry.  Returns true if the unsigned addition of the given

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -125,9 +125,9 @@ primTable = let sym = Concrete in
   , ("%"          , {-# SCC "Prelude::(%)" #-}
                     binary (modV sym))
   , ("/$"         , {-# SCC "Prelude::(/$)" #-}
-                    binary (sdivV sym))
+                    sdivV sym)
   , ("%$"         , {-# SCC "Prelude::(%$)" #-}
-                    binary (smodV sym))
+                    smodV sym)
   , ("^^"         , {-# SCC "Prelude::(^^)" #-}
                     binary (expV sym))
   , ("lg2"        , {-# SCC "Prelude::lg2" #-}

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -362,22 +362,6 @@ modV sym = arithBinary sym opw opi opz
     opi x y = intMod sym x y
     opz m x y = znMod sym m x y
 
-{-# INLINE sdivV #-}
-sdivV :: Backend sym => sym -> Binary sym
-sdivV sym = arithBinary sym opw opi opz
-  where
-    opw _w x y = wordSignedDiv sym x y
-    opi x y = intDiv sym x y
-    opz m x y = znDiv sym m x y
-
-{-# INLINE smodV #-}
-smodV :: Backend sym => sym -> Binary sym
-smodV sym = arithBinary sym opw opi opz
-  where
-    opw _w x y = wordSignedMod sym x y
-    opi x y = intMod sym x y
-    opz m x y = znMod sym m x y
-
 {-# INLINE expV #-}
 expV :: Backend sym => sym -> Binary sym
 expV sym = arithBinary sym opw opi opz
@@ -418,6 +402,25 @@ xorV sym = logicBinary sym (bitXor sym) (wordXor sym)
 {-# INLINE complementV #-}
 complementV :: Backend sym => sym -> Unary sym
 complementV sym = logicUnary sym (bitComplement sym) (wordComplement sym)
+
+-- Bitvector signed div and modulus
+
+{-# SPECIALIZE sdivV :: Concrete -> GenValue Concrete #-}
+sdivV :: Backend sym => sym -> GenValue sym
+sdivV sym =
+  nlam $ \(finNat' -> w) ->
+  wlam sym $ \x -> return $
+  wlam sym $ \y -> return $
+  VWord w (WordVal <$> wordSignedDiv sym x y)
+
+{-# SPECIALIZE smodV :: Concrete -> GenValue Concrete #-}
+smodV :: Backend sym => sym -> GenValue sym
+smodV sym  =
+  nlam $ \(finNat' -> w) ->
+  wlam sym $ \x -> return $
+  wlam sym $ \y -> return $
+  VWord w (WordVal <$> wordSignedMod sym x y)
+
 
 -- Cmp -------------------------------------------------------------------------
 

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -363,8 +363,8 @@ primTable  = let sym = SBV in
   , ("*"           , binary (mulV sym)) -- {a} (Arith a) => a -> a -> a
   , ("/"           , binary (divV sym)) -- {a} (Arith a) => a -> a -> a
   , ("%"           , binary (modV sym)) -- {a} (Arith a) => a -> a -> a
-  , ("/$"          , binary (sdivV sym))
-  , ("%$"          , binary (smodV sym))
+  , ("/$"          , sdivV sym)
+  , ("%$"          , smodV sym)
   , ("^^"          , binary (expV sym))
   , ("lg2"         , unary (lg2V sym))
   , ("negate"      , unary (negateV sym))

--- a/tests/issues/issue226.icry.stdout
+++ b/tests/issues/issue226.icry.stdout
@@ -97,10 +97,10 @@ Symbols
     (+) : {a} (Arith a) => a -> a -> a
     (-) : {a} (Arith a) => a -> a -> a
     (%) : {a} (Arith a) => a -> a -> a
-    (%$) : {a} (Arith a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
     (*) : {a} (Arith a) => a -> a -> a
     (/) : {a} (Arith a) => a -> a -> a
-    (/$) : {a} (Arith a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
     (^^) : {a} (Arith a) => a -> a -> a
     (!) : {n, a, ix} (fin n, fin ix) => [n]a -> [ix] -> a
     (!!) : {n, k, ix, a} (fin n, fin ix) => [n]a -> [k][ix] -> [k]a


### PR DESCRIPTION
We discussed this idea in the thread for #686. This change would trivially fix issue #661.

This branch is not ready yet, as there are some other things I'd like to add:
* more tests (apparently neither `/$` nor `%$` is used in the test suite)
* improved doc-strings for `/$` and `%$` (#677)
* documentation in `CHANGELOG.md`

While I'm working on div/mod, I'd also like to add a fix for #662.