### PR TITLE
Feature/688

### DIFF
--- a/src/Cryptol/ModuleSystem/Monad.hs
+++ b/src/Cryptol/ModuleSystem/Monad.hs
@@ -19,8 +19,7 @@ import           Cryptol.ModuleSystem.Env
 import           Cryptol.ModuleSystem.Fingerprint
 import           Cryptol.ModuleSystem.Interface
 import           Cryptol.ModuleSystem.Name (FreshM(..),Supply)
-import           Cryptol.ModuleSystem.Renamer
-                     (RenamerError(),RenamerWarning(),NamingEnv)
+import           Cryptol.ModuleSystem.Renamer (RenamerError(),RenamerWarning())
 import qualified Cryptol.Parser     as Parser
 import qualified Cryptol.Parser.AST as P
 import           Cryptol.Parser.Position (Located)
@@ -508,8 +507,7 @@ withPrependedSearchPath fps m = ModuleT $ do
   set $! env { meSearchPath = fps0 }
   return x
 
--- XXX improve error handling here
-getFocusedEnv :: ModuleM (IfaceParams,IfaceDecls,NamingEnv,NameDisp)
+getFocusedEnv :: ModuleM ModContext
 getFocusedEnv  = ModuleT (focusedEnv `fmap` get)
 
 getDynEnv :: ModuleM DynamicEnv

--- a/tests/issues/issue226.icry.stdout
+++ b/tests/issues/issue226.icry.stdout
@@ -4,6 +4,10 @@ Loading module issue226r2
 Loading module issue226
 Type Synonyms
 =============
+
+  From Cryptol
+  ------------
+
     type Bool = Bit
     type Char = [8]
     type lg2 n = width (max 1 n - 1)
@@ -12,12 +16,20 @@ Type Synonyms
 
 Constraint Synonyms
 ===================
+
+  From Cryptol
+  ------------
+
     type constraint i < j = j >= 1 + i
     type constraint i <= j = j >= i
     type constraint i > j = i >= 1 + j
 
 Primitive Types
 ===============
+
+  From Cryptol
+  ------------
+
     (!=) : # -> # -> Prop
     (==) : # -> # -> Prop
     (>=) : # -> # -> Prop
@@ -47,6 +59,15 @@ Primitive Types
 
 Symbols
 =======
+
+  Public
+  ------
+
+    foo : {a} a -> a
+
+  From Cryptol
+  ------------
+
     (==>) : Bit -> Bit -> Bit
     (\/) : Bit -> Bit -> Bit
     (/\) : Bit -> Bit -> Bit
@@ -98,7 +119,6 @@ Symbols
     False : Bit
     foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
     foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
-    foo : {a} a -> a
     fromInteger : {a} (Arith a) => Integer -> a
     fromThenTo :
       {first, next, last, a, len} (fin first, fin next, fin last,

--- a/tests/modsys/T10.icry.stdout
+++ b/tests/modsys/T10.icry.stdout
@@ -2,5 +2,9 @@ Loading module Cryptol
 Loading module T10::Main
 Symbols
 =======
+
+  Public
+  ------
+
     f : {T} {x : T} -> T
 


### PR DESCRIPTION
This implements the feature request in #688 improving the output of `:browse` to include more information about the names in scope.   In particular, we keep track of what names are defined in the "focused" module (and if they are public or private) and also what names are defined in imported modules, or on the REPL.