### PR TITLE
Rational type

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -45,7 +45,8 @@ primitive type Integer : *
 /** 'Z n' is the type of integers, modulo 'n'. */
 primitive type {n : #} (fin n, n >= 1) => Z n : *
 
-
+/** `Rational` is the type of rational numbers. */
+primitive type Rational : *
 
 /** Assert that two numeric types are equal. */
 primitive type (==) : # -> # -> Prop
@@ -77,7 +78,8 @@ primitive type SignedCmp : * -> Prop
 /** 'Literal n a' asserts that type 'a' contains the number 'n'. */
 primitive type Literal : # -> * -> Prop
 
-
+/** 'Field a' asserts that type 'a' is a field (or approximately a field). */
+primitive type Field : * -> Prop
 
 /** Add numeric types. */
 primitive type (+) : # -> # -> #
@@ -210,6 +212,40 @@ primitive (^^) : {a} (Arith a) => a -> a -> a
  */
 primitive lg2 : {a} (Arith a) => a -> a
 
+/**
+ * Reciprocal
+ *
+ * Compute the multiplicative inverse of an element of a field.
+ * The reciprocal of zero is undefined
+ */
+primitive recip : {a} (Field a) => a -> a
+
+/**
+ * Field division
+ *
+ * The division operation in a field.
+ * x /. y == x * (recip y)
+ */
+primitive (/.) : {a} (Field a) => a -> a -> a
+
+/**
+ * Compute the ratio of two integers as a rational.
+ * ratio x y = (fromInteger x /. fromInteger y) : Rational
+ */
+primitive ratio : Integer -> Integer -> Rational
+
+/**
+ * Compute the largest integer less than or equal
+ * to the given rational.
+ */
+primitive floor : Rational -> Integer
+
+/**
+ * Compute the smallest integer greater than or
+ * equal to the given rational.
+ */
+ceiling : Rational -> Integer
+ceiling x = negate (floor (negate x))
 
 type Bool = Bit
 
@@ -228,7 +264,7 @@ primitive False : Bit
  * Over structured values, operates element-wise.
  * The prefix notation '- x' is syntactic sugar
  * for 'negate x'.
- * Satisfies 'negate a = ~a + 1'.
+ * Satisfies 'negate a = ~a + 1' for bitvectors.
  */
 primitive negate : {a} (Arith a) => a -> a
 

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -426,6 +426,7 @@ etaDelay sym msg env0 Forall{ sVars = vs0, sType = tp0 } = goTpVars env0 vs0
       TVBit -> v
       TVInteger -> v
       TVIntMod _ -> v
+      TVRational -> v
 
       TVSeq n TVBit ->
           do w <- sDelayFill sym (fromWordVal "during eta-expansion" =<< v) (etaWord sym n v)

--- a/src/Cryptol/Eval/Backend.hs
+++ b/src/Cryptol/Eval/Backend.hs
@@ -27,6 +27,7 @@ module Cryptol.Eval.Backend
 
 import Control.Monad.IO.Class
 import Data.Kind (Type)
+import Data.Ratio ( (%), numerator, denominator )
 
 import Cryptol.Eval.Monad
 import Cryptol.TypeCheck.AST(Name)
@@ -146,7 +147,14 @@ iteRational sym p (SRational a b) (SRational c d) =
   SRational <$> iteInteger sym p a c <*> iteInteger sym p b d
 
 ppRational :: Backend sym => sym -> PPOpts -> SRational sym -> Doc
-ppRational sym opts (SRational n d) = text "(ratio" <+> ppInteger sym opts n <+> (ppInteger sym opts d <> text ")")
+ppRational sym opts (SRational n d)
+  | Just ni <- integerAsLit sym n
+  , Just di <- integerAsLit sym d
+  = let q = ni % di in
+      text "(ratio" <+> integer (numerator q) <+> (integer (denominator q) <> text ")")
+
+  | otherwise
+  = text "(ratio" <+> ppInteger sym opts n <+> (ppInteger sym opts d <> text ")")
 
 -- | This type class defines a collection of operations on bits, words and integers that
 --   are necessary to define generic evaluator primitives that operate on both concrete

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -50,6 +50,7 @@ mkLit sym ty i =
       | m == 0                   -> evalPanic "mkLit" ["0 modulus not allowed"]
       | otherwise                -> VInteger <$> integerLit sym (i `mod` m)
     TVSeq w TVBit                -> pure $ word sym w i
+    TVRational                   -> VRational <$> (intToRational sym =<< integerLit sym i)
     _                            -> evalPanic "Cryptol.Eval.Prim.evalConst"
                                     [ "Invalid type for number" ]
 
@@ -83,7 +84,7 @@ ecFromIntegerV sym =
 {-# SPECIALIZE intV :: Concrete -> Integer -> TValue -> Eval (GenValue Concrete)
   #-}
 intV :: Backend sym => sym -> SInteger sym -> TValue -> SEval sym (GenValue sym)
-intV sym i = arithNullary sym (\w -> wordFromInt sym w i) (pure i) (\m -> intToZn sym m i)
+intV sym i = arithNullary sym (\w -> wordFromInt sym w i) (pure i) (\m -> intToZn sym m i) (intToRational sym i)
 
 {-# SPECIALIZE ecToIntegerV :: Concrete -> GenValue Concrete
   #-}
@@ -132,6 +133,7 @@ type BinArith sym = Integer -> SWord sym -> SWord sym -> SEval sym (SWord sym)
 {-# SPECIALIZE arithBinary :: Concrete -> BinArith Concrete ->
       (SInteger Concrete -> SInteger Concrete -> SEval Concrete (SInteger Concrete)) ->
       (Integer -> SInteger Concrete -> SInteger Concrete -> SEval Concrete (SInteger Concrete)) ->
+      (SRational Concrete -> SRational Concrete -> SEval Concrete (SRational Concrete)) ->
       Binary Concrete
   #-}
 
@@ -141,8 +143,9 @@ arithBinary :: forall sym.
   BinArith sym ->
   (SInteger sym -> SInteger sym -> SEval sym (SInteger sym)) ->
   (Integer -> SInteger sym -> SInteger sym -> SEval sym (SInteger sym)) ->
+  (SRational sym -> SRational sym -> SEval sym (SRational sym)) ->
   Binary sym
-arithBinary sym opw opi opz = loop
+arithBinary sym opw opi opz opq = loop
   where
   loop' :: TValue
         -> SEval sym (GenValue sym)
@@ -163,6 +166,9 @@ arithBinary sym opw opi opz = loop
 
     TVIntMod n ->
       VInteger <$> opz n (fromVInteger l) (fromVInteger r)
+
+    TVRational ->
+      VRational <$> opq (fromVRational l) (fromVRational r)
 
     TVSeq w a
       -- words and finite sequences
@@ -209,6 +215,7 @@ type UnaryArith sym = Integer -> SWord sym -> SEval sym (SWord sym)
   UnaryArith Concrete ->
   (SInteger Concrete -> SEval Concrete (SInteger Concrete)) ->
   (Integer -> SInteger Concrete -> SEval Concrete (SInteger Concrete)) ->
+  (SRational Concrete -> SEval Concrete (SRational Concrete)) ->
   Unary Concrete
   #-}
 arithUnary :: forall sym.
@@ -217,8 +224,9 @@ arithUnary :: forall sym.
   UnaryArith sym ->
   (SInteger sym -> SEval sym (SInteger sym)) ->
   (Integer -> SInteger sym -> SEval sym (SInteger sym)) ->
+  (SRational sym -> SEval sym (SRational sym)) ->
   Unary sym
-arithUnary sym opw opi opz = loop
+arithUnary sym opw opi opz opq = loop
   where
   loop' :: TValue -> SEval sym (GenValue sym) -> SEval sym (GenValue sym)
   loop' ty v = loop ty =<< v
@@ -234,6 +242,9 @@ arithUnary sym opw opi opz = loop
 
     TVIntMod n ->
       VInteger <$> opz n (fromVInteger v)
+
+    TVRational ->
+      VRational <$> opq (fromVRational v)
 
     TVSeq w a
       -- words and finite sequences
@@ -269,6 +280,7 @@ arithUnary sym opw opi opz = loop
   (Integer -> SEval Concrete (SWord Concrete)) ->
   SEval Concrete (SInteger Concrete) ->
   (Integer -> SEval Concrete (SInteger Concrete)) ->
+  SEval Concrete (SRational Concrete) ->
   TValue ->
   SEval Concrete (GenValue Concrete)
   #-}
@@ -279,9 +291,10 @@ arithNullary :: forall sym.
   (Integer -> SEval sym (SWord sym)) ->
   SEval sym (SInteger sym) ->
   (Integer -> SEval sym (SInteger sym)) ->
+  SEval sym (SRational sym) ->
   TValue ->
   SEval sym (GenValue sym)
-arithNullary sym opw opi opz = loop
+arithNullary sym opw opi opz opq = loop
   where
     loop :: TValue -> SEval sym (GenValue sym)
     loop ty =
@@ -291,6 +304,8 @@ arithNullary sym opw opi opz = loop
         TVInteger -> VInteger <$> opi
 
         TVIntMod n -> VInteger <$> opz n
+
+        TVRational -> VRational <$> opq
 
         TVSeq w a
           -- words and finite sequences
@@ -324,84 +339,123 @@ arithNullary sym opw opi opz = loop
 
 {-# INLINE addV #-}
 addV :: Backend sym => sym -> Binary sym
-addV sym = arithBinary sym opw opi opz
+addV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordPlus sym x y
     opi x y = intPlus sym x y
     opz m x y = znPlus sym m x y
+    opq x y = rationalAdd sym x y
 
 {-# INLINE subV #-}
 subV :: Backend sym => sym -> Binary sym
-subV sym = arithBinary sym opw opi opz
+subV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordMinus sym x y
     opi x y = intMinus sym x y
     opz m x y = znMinus sym m x y
+    opq x y = rationalSub sym x y
 
 {-# INLINE mulV #-}
 mulV :: Backend sym => sym -> Binary sym
-mulV sym = arithBinary sym opw opi opz
+mulV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordMult sym x y
     opi x y = intMult sym x y
     opz m x y = znMult sym m x y
+    opq x y = rationalMul sym x y
 
 {-# INLINE divV #-}
 divV :: Backend sym => sym -> Binary sym
-divV sym = arithBinary sym opw opi opz
+divV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordDiv sym x y
     opi x y = intDiv sym x y
     opz m x y = znDiv sym m x y
+    opq x y = rationalDivide sym x y
 
 {-# INLINE modV #-}
 modV :: Backend sym => sym -> Binary sym
-modV sym = arithBinary sym opw opi opz
+modV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordMod sym x y
     opi x y = intMod sym x y
     opz m x y = znMod sym m x y
+    opq _ _ = intToRational sym =<< integerLit sym 0
 
 {-# INLINE sdivV #-}
 sdivV :: Backend sym => sym -> Binary sym
-sdivV sym = arithBinary sym opw opi opz
+sdivV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordSignedDiv sym x y
     opi x y = intDiv sym x y
     opz m x y = znDiv sym m x y
+    opq x y = rationalDivide sym x y
 
 {-# INLINE smodV #-}
 smodV :: Backend sym => sym -> Binary sym
-smodV sym = arithBinary sym opw opi opz
+smodV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordSignedMod sym x y
     opi x y = intMod sym x y
     opz m x y = znMod sym m x y
+    opq _ _ = intToRational sym =<< integerLit sym 0
 
 {-# INLINE expV #-}
 expV :: Backend sym => sym -> Binary sym
-expV sym = arithBinary sym opw opi opz
+expV sym = arithBinary sym opw opi opz opq
   where
     opw _w x y = wordExp sym x y
     opi x y = intExp sym x y
     opz m x y = znExp sym m x y
+    opq _ _ = fail "Rational exponentation"
 
 
 {-# INLINE negateV #-}
 negateV :: Backend sym => sym -> Unary sym
-negateV sym = arithUnary sym opw opi opz
+negateV sym = arithUnary sym opw opi opz opq
   where
     opw _w x = wordNegate sym x
     opi x = intNegate sym x
     opz m x = znNegate sym m x
+    opq x = rationalNegate sym x
 
 {-# INLINE lg2V #-}
 lg2V :: Backend sym => sym -> Unary sym
-lg2V sym = arithUnary sym opw opi opz
+lg2V sym = arithUnary sym opw opi opz opq
   where
     opw _w x = wordLg2 sym x
     opi x = intLg2 sym x
     opz m x = znLg2 sym m x
+    opq _ = fail "Rational lg2"
+
+
+recipV :: Backend sym => sym -> Unary sym
+recipV sym = arithUnary sym opw opi opz opq
+  where
+    opw _w _x = evalPanic "recip" ["[_] is not a Field"]
+    opi _x    = evalPanic "recip" ["Integer is not a Field"]
+    opz _m _x = evalPanic "recip" ["Z is not a Field"]
+    opq x = rationalRecip sym x
+
+
+fieldDivideV :: Backend sym => sym -> Binary sym
+fieldDivideV sym = arithBinary sym opw opi opz opq 
+  where
+    opw _w _x = evalPanic "(/.)" ["[_] is not a Field"]
+    opi _x    = evalPanic "(/.)" ["Integer is not a Field"]
+    opz _m _x = evalPanic "(/.)" ["Z is not a Field" ]
+    opq x y = rationalDivide sym x y
+
+ratioV :: Backend sym => sym -> GenValue sym
+ratioV sym =
+  lam $ \x -> return $
+  lam $ \y ->
+    do x' <- fromVInteger <$> x
+       y' <- fromVInteger <$> y
+       VRational <$> ratio sym x' y'
+
+floorV :: Backend sym => sym -> GenValue sym
+floorV sym = lam $ \x -> VInteger <$> (rationalFloor sym . fromVRational =<< x)
 
 {-# INLINE andV #-}
 andV :: Backend sym => sym -> Binary sym
@@ -427,6 +481,7 @@ complementV sym = logicUnary sym (bitComplement sym) (wordComplement sym)
   (SWord Concrete -> SWord Concrete -> SEval Concrete a -> SEval Concrete a) ->
   (SInteger Concrete -> SInteger Concrete -> SEval Concrete a -> SEval Concrete a) ->
   (Integer -> SInteger Concrete -> SInteger Concrete -> SEval Concrete a -> SEval Concrete a) ->
+  (SRational Concrete -> SRational Concrete -> SEval Concrete a -> SEval Concrete a) ->
   (TValue -> GenValue Concrete -> GenValue Concrete -> SEval Concrete a -> SEval Concrete a)
   #-}
 
@@ -437,14 +492,16 @@ cmpValue ::
   (SWord sym -> SWord sym -> SEval sym a -> SEval sym a) ->
   (SInteger sym -> SInteger sym -> SEval sym a -> SEval sym a) ->
   (Integer -> SInteger sym -> SInteger sym -> SEval sym a -> SEval sym a) ->
+  (SRational sym -> SRational sym -> SEval sym a -> SEval sym a) ->
   (TValue -> GenValue sym -> GenValue sym -> SEval sym a -> SEval sym a)
-cmpValue sym fb fw fi fz = cmp
+cmpValue sym fb fw fi fz fq = cmp
   where
     cmp ty v1 v2 k =
       case ty of
         TVBit         -> fb (fromVBit v1) (fromVBit v2) k
         TVInteger     -> fi (fromVInteger v1) (fromVInteger v2) k
         TVIntMod n    -> fz n (fromVInteger v1) (fromVInteger v2) k
+        TVRational    -> fq (fromVRational v1) (fromVRational v2) k
         TVSeq n t
           | isTBit t  -> do w1 <- fromVWord sym "cmpValue" v1
                             w2 <- fromVWord sym "cmpValue" v2
@@ -485,32 +542,35 @@ bitGreaterThan sym x y = bitLessThan sym y x
 
 {-# INLINE valEq #-}
 valEq :: Backend sym => sym -> TValue -> GenValue sym -> GenValue sym -> SEval sym (SBit sym)
-valEq sym ty v1 v2 = cmpValue sym fb fw fi fz ty v1 v2 (pure $ bitLit sym True)
+valEq sym ty v1 v2 = cmpValue sym fb fw fi fz fq ty v1 v2 (pure $ bitLit sym True)
   where
   fb x y k   = eqCombine sym (bitEq  sym x y) k
   fw x y k   = eqCombine sym (wordEq sym x y) k
   fi x y k   = eqCombine sym (intEq  sym x y) k
   fz m x y k = eqCombine sym (znEq sym m x y) k
+  fq x y k   = eqCombine sym (rationalEq sym x y) k
 
 {-# INLINE valLt #-}
 valLt :: Backend sym =>
   sym -> TValue -> GenValue sym -> GenValue sym -> SBit sym -> SEval sym (SBit sym)
-valLt sym ty v1 v2 final = cmpValue sym fb fw fi fz ty v1 v2 (pure final)
+valLt sym ty v1 v2 final = cmpValue sym fb fw fi fz fq ty v1 v2 (pure final)
   where
   fb x y k   = lexCombine sym (bitLessThan  sym x y) (bitEq  sym x y) k
   fw x y k   = lexCombine sym (wordLessThan sym x y) (wordEq sym x y) k
   fi x y k   = lexCombine sym (intLessThan  sym x y) (intEq  sym x y) k
   fz m x y k = lexCombine sym (znLessThan sym m x y) (znEq sym m x y) k
+  fq x y k   = lexCombine sym (rationalLessThan sym x y) (rationalEq sym x y) k
 
 {-# INLINE valGt #-}
 valGt :: Backend sym =>
   sym -> TValue -> GenValue sym -> GenValue sym -> SBit sym -> SEval sym (SBit sym)
-valGt sym ty v1 v2 final = cmpValue sym fb fw fi fz ty v1 v2 (pure final)
+valGt sym ty v1 v2 final = cmpValue sym fb fw fi fz fq ty v1 v2 (pure final)
   where
   fb x y k   = lexCombine sym (bitGreaterThan  sym x y) (bitEq  sym x y) k
   fw x y k   = lexCombine sym (wordGreaterThan sym x y) (wordEq sym x y) k
   fi x y k   = lexCombine sym (intGreaterThan  sym x y) (intEq  sym x y) k
   fz m x y k = lexCombine sym (znGreaterThan sym m x y) (znEq sym m x y) k
+  fq x y k   = lexCombine sym (rationalGreaterThan sym x y) (rationalEq sym x y) k
 
 {-# INLINE eqCombine #-}
 eqCombine :: Backend sym =>
@@ -558,12 +618,13 @@ greaterThanEqV sym ty v1 v2 = VBit <$> valGt sym ty v1 v2 (bitLit sym True)
 
 {-# INLINE signedLessThanV #-}
 signedLessThanV :: Backend sym => sym -> Binary sym
-signedLessThanV sym ty v1 v2 = VBit <$> cmpValue sym fb fw fi fz ty v1 v2 (pure $ bitLit sym False)
+signedLessThanV sym ty v1 v2 = VBit <$> cmpValue sym fb fw fi fz fq ty v1 v2 (pure $ bitLit sym False)
   where
   fb _ _ _   = panic "signedLessThan" ["Attempted to perform signed comparison on bit type"]
   fw x y k   = lexCombine sym (wordSignedLessThan sym x y) (wordEq sym x y) k
   fi _ _ _   = panic "signedLessThan" ["Attempted to perform signed comparison on Integer type"]
   fz m _ _ _ = panic "signedLessThan" ["Attempted to perform signed comparison on Z_" ++ show m ++ " type"]
+  fq _ _ _   = panic "signedLessThan" ["Attempted to perform signed comparison on Rational type"]
 
 -- Signed arithmetic -----------------------------------------------------------
 
@@ -607,6 +668,9 @@ zeroV sym ty = case ty of
   -- integers mod n
   TVIntMod _ ->
     VInteger <$> integerLit sym 0
+
+  TVRational ->
+    VRational <$> (intToRational sym =<< integerLit sym 0)
 
   -- sequences
   TVSeq w ety
@@ -1010,6 +1074,7 @@ logicBinary sym opb opw = loop
     TVBit -> VBit <$> (opb (fromVBit l) (fromVBit r))
     TVInteger -> evalPanic "logicBinary" ["Integer not in class Logic"]
     TVIntMod _ -> evalPanic "logicBinary" ["Z not in class Logic"]
+    TVRational -> evalPanic "logicBinary" ["Rational not in class Logic"]
     TVSeq w aty
          -- words
          | isTBit aty
@@ -1085,6 +1150,7 @@ logicUnary sym opb opw = loop
 
     TVInteger -> evalPanic "logicUnary" ["Integer not in class Logic"]
     TVIntMod _ -> evalPanic "logicUnary" ["Z not in class Logic"]
+    TVRational -> evalPanic "logicBinary" ["Rational not in class Logic"]
 
     TVSeq w ety
          -- words
@@ -1420,6 +1486,7 @@ errorV sym ty msg = case ty of
   TVBit -> cryUserError sym msg
   TVInteger -> cryUserError sym msg
   TVIntMod _ -> cryUserError sym msg
+  TVRational -> cryUserError sym msg
 
   -- sequences
   TVSeq w ety
@@ -1513,18 +1580,19 @@ mergeValue :: Backend sym =>
   SEval sym (GenValue sym)
 mergeValue sym c v1 v2 =
   case (v1, v2) of
-    (VRecord fs1, VRecord fs2)  | Map.keys fs1 == Map.keys fs2 ->
+    (VRecord fs1 , VRecord fs2 )  | Map.keys fs1 == Map.keys fs2 ->
                                   pure $ VRecord $ Map.intersectionWith (mergeValue' sym c) fs1 fs2
-    (VTuple vs1 , VTuple vs2 ) | length vs1 == length vs2  ->
+    (VTuple vs1  , VTuple vs2  ) | length vs1 == length vs2  ->
                                   pure $ VTuple $ zipWith (mergeValue' sym c) vs1 vs2
-    (VBit b1    , VBit b2    ) -> VBit <$> iteBit sym c b1 b2
-    (VInteger i1, VInteger i2) -> VInteger <$> iteInteger sym c i1 i2
-    (VWord n1 w1, VWord n2 w2 ) | n1 == n2 -> pure $ VWord n1 $ mergeWord' sym c w1 w2
-    (VSeq n1 vs1, VSeq n2 vs2 ) | n1 == n2 -> VSeq n1 <$> memoMap (mergeSeqMap sym c vs1 vs2)
-    (VStream vs1, VStream vs2) -> VStream <$> memoMap (mergeSeqMap sym c vs1 vs2)
-    (VFun f1    , VFun f2    ) -> pure $ VFun $ \x -> mergeValue' sym c (f1 x) (f2 x)
-    (VPoly f1   , VPoly f2   ) -> pure $ VPoly $ \x -> mergeValue' sym c (f1 x) (f2 x)
-    (_          , _          ) -> panic "Cryptol.Eval.Generic"
+    (VBit b1     , VBit b2     ) -> VBit <$> iteBit sym c b1 b2
+    (VInteger i1 , VInteger i2 ) -> VInteger <$> iteInteger sym c i1 i2
+    (VRational q1, VRational q2) -> VRational <$> iteRational sym c q1 q2
+    (VWord n1 w1 , VWord n2 w2 ) | n1 == n2 -> pure $ VWord n1 $ mergeWord' sym c w1 w2
+    (VSeq n1 vs1 , VSeq n2 vs2 ) | n1 == n2 -> VSeq n1 <$> memoMap (mergeSeqMap sym c vs1 vs2)
+    (VStream vs1 , VStream vs2 ) -> VStream <$> memoMap (mergeSeqMap sym c vs1 vs2)
+    (VFun f1     , VFun f2     ) -> pure $ VFun $ \x -> mergeValue' sym c (f1 x) (f2 x)
+    (VPoly f1    , VPoly f2    ) -> pure $ VPoly $ \x -> mergeValue' sym c (f1 x) (f2 x)
+    (_           , _           ) -> panic "Cryptol.Eval.Generic"
                                   [ "mergeValue: incompatible values" ]
 
 {-# INLINE mergeSeqMap #-}

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -355,6 +355,8 @@ primTable  = let sym = SBV in
   , ("False"       , VBit (bitLit sym False))
   , ("number"      , ecNumberV sym) -- Converts a numeric type into its corresponding value.
                                     -- { val, rep } (Literal val rep) => rep
+  , ("ratio"       , ratioV sym)
+  , ("floor"       , floorV sym)
 
     -- Arith
   , ("fromInteger" , ecFromIntegerV sym)
@@ -370,6 +372,10 @@ primTable  = let sym = SBV in
   , ("negate"      , unary (negateV sym))
   , ("infFrom"     , infFromV sym)
   , ("infFromThen" , infFromThenV sym)
+
+    -- Field
+  , ("recip"      , unary (recipV sym))
+  , ("/."         , binary (fieldDivideV sym))
 
     -- Cmp
   , ("<"           , binary (lessThanV sym))

--- a/src/Cryptol/Eval/Type.hs
+++ b/src/Cryptol/Eval/Type.hs
@@ -30,6 +30,7 @@ data TValue
   = TVBit                     -- ^ @ Bit @
   | TVInteger                 -- ^ @ Integer @
   | TVIntMod Integer          -- ^ @ Z n @
+  | TVRational                -- ^ @Rational@
   | TVSeq Integer TValue      -- ^ @ [n]a @
   | TVStream TValue           -- ^ @ [inf]t @
   | TVTuple [TValue]          -- ^ @ (a, b, c )@
@@ -45,6 +46,7 @@ tValTy tv =
     TVBit       -> tBit
     TVInteger   -> tInteger
     TVIntMod n  -> tIntMod (tNum n)
+    TVRational  -> tRational
     TVSeq n t   -> tSeq (tNum n) (tValTy t)
     TVStream t  -> tSeq tInf (tValTy t)
     TVTuple ts  -> tTuple (map tValTy ts)
@@ -102,6 +104,7 @@ evalType env ty =
       case (c, ts) of
         (TCBit, [])     -> Right $ TVBit
         (TCInteger, []) -> Right $ TVInteger
+        (TCRational, []) -> Right $ TVRational
         (TCIntMod, [n]) -> case num n of
                              Inf   -> evalPanic "evalType" ["invalid type Z inf"]
                              Nat m -> Right $ TVIntMod m

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -43,6 +43,7 @@ module Cryptol.Eval.Value
     -- ** Value eliminators
   , fromVBit
   , fromVInteger
+  , fromVRational
   , fromVSeq
   , fromSeq
   , fromWordVal
@@ -295,6 +296,7 @@ data GenValue sym
   | VTuple ![SEval sym (GenValue sym)]              -- ^ @ ( .. ) @
   | VBit !(SBit sym)                           -- ^ @ Bit    @
   | VInteger !(SInteger sym)                   -- ^ @ Integer @ or @ Z n @
+  | VRational !(SRational sym)                 -- ^ @ Rational @
   | VSeq !Integer !(SeqMap sym)                -- ^ @ [n]a   @
                                                --   Invariant: VSeq is never a sequence of bits
   | VWord !Integer !(SEval sym (WordValue sym))  -- ^ @ [n]Bit @
@@ -318,6 +320,7 @@ forceValue v = case v of
   VSeq n xs   -> mapM_ (forceValue =<<) (enumerateSeqMap n xs)
   VBit b      -> seq b (return ())
   VInteger i  -> seq i (return ())
+  VRational q -> seq q (return ())
   VWord _ wv  -> forceWordValue =<< wv
   VStream _   -> return ()
   VFun _      -> return ()
@@ -331,6 +334,7 @@ instance Backend sym => Show (GenValue sym) where
     VTuple xs  -> "tuple:" ++ show (length xs)
     VBit _     -> "bit"
     VInteger _ -> "integer"
+    VRational _ -> "rational"
     VSeq n _   -> "seq:" ++ show n
     VWord n _  -> "word:"  ++ show n
     VStream _  -> "stream"
@@ -359,6 +363,7 @@ ppValue x opts = loop
                              return $ parens (sep (punctuate comma vals'))
     VBit b             -> return $ ppBit x b
     VInteger i         -> return $ ppInteger x opts i
+    VRational q        -> return $ ppRational x opts q
     VSeq sz vals       -> ppWordSeq sz vals
     VWord _ wv         -> ppWordVal =<< wv
     VStream vals       -> do vals' <- traverse (>>=loop) $ enumerateSeqMap (useInfLength opts) vals
@@ -460,6 +465,12 @@ fromVInteger :: GenValue sym -> SInteger sym
 fromVInteger val = case val of
   VInteger i -> i
   _      -> evalPanic "fromVInteger" ["not an Integer"]
+
+-- | Extract a rational value.
+fromVRational :: GenValue sym -> SRational sym
+fromVRational val = case val of
+  VRational q -> q
+  _      -> evalPanic "fromVRational" ["not a Rational"]
 
 -- | Extract a finite sequence value.
 fromVSeq :: GenValue sym -> SeqMap sym

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -103,6 +103,7 @@ data FinType
     = FTBit
     | FTInteger
     | FTIntMod Integer
+    | FTRational
     | FTSeq Int FinType
     | FTTuple [FinType]
     | FTRecord [(Ident, FinType)]
@@ -121,6 +122,7 @@ finType ty =
     TVBit            -> Just FTBit
     TVInteger        -> Just FTInteger
     TVIntMod n       -> Just (FTIntMod n)
+    TVRational       -> Just FTRational
     TVSeq n t        -> FTSeq <$> numType n <*> finType t
     TVTuple ts       -> FTTuple <$> traverse finType ts
     TVRec fields     -> FTRecord <$> traverse (traverseSnd finType) fields
@@ -133,6 +135,7 @@ unFinType fty =
     FTBit        -> tBit
     FTInteger    -> tInteger
     FTIntMod n   -> tIntMod (tNum n)
+    FTRational   -> tRational
     FTSeq l ety  -> tSeq (tNum l) (unFinType ety)
     FTTuple ftys -> tTuple (unFinType <$> ftys)
     FTRecord fs  -> tRec (zip fns tys)

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -26,7 +26,7 @@ import qualified Data.Sequence as Seq
 import System.Random          (RandomGen, split, random, randomR)
 import System.Random.TF.Gen   (seedTFGen)
 
-import Cryptol.Eval.Backend   (Backend(..))
+import Cryptol.Eval.Backend   (Backend(..), SRational(..))
 import Cryptol.Eval.Concrete.Value
 import Cryptol.Eval.Monad     (ready,runEval,EvalOpts,Eval,EvalError(..))
 import Cryptol.Eval.Type      (TValue(..), tValTy)
@@ -144,6 +144,8 @@ randomValue sym ty =
 
         (TC TCInteger, [])                    -> Just (randomInteger sym)
 
+        (TC TCRational, [])                   -> Just (randomRational sym)
+
         (TC TCIntMod, [TCon (TC (TCNum n)) []]) ->
           do return (randomIntMod sym n)
 
@@ -202,6 +204,18 @@ randomIntMod :: (Backend sym, RandomGen g) => sym -> Integer -> Gen g sym
 randomIntMod sym modulus _ g =
   let (i, g') = randomR (0, modulus-1) g
   in (VInteger <$> integerLit sym i, g')
+
+{-# INLINE randomRational #-}
+
+randomRational :: (Backend sym, RandomGen g) => sym -> Gen g sym 
+randomRational sym w g =
+  let (sz, g1) = if w < 100 then (fromInteger w, g) else randomSize 8 100 g
+      (n, g2) = randomR (- 256^sz, 256^sz) g1
+      (d, g3) = randomR ( 1, 256^sz) g2
+   in (do n' <- integerLit sym n
+          d' <- integerLit sym d
+          pure (VRational (SRational n' d'))
+       , g3)
 
 {-# INLINE randomWord #-}
 
@@ -344,6 +358,7 @@ typeSize ty =
         (TCInf, _)       -> Nothing
         (TCBit, _)       -> Just 2
         (TCInteger, _)   -> Nothing
+        (TCRational, _)  -> Nothing
         (TCIntMod, [sz]) -> case tNoUser sz of
                               TCon (TC (TCNum n)) _ -> Just n
                               _                     -> Nothing
@@ -376,6 +391,7 @@ typeValues ty =
         TCInf       -> []
         TCBit       -> [ VBit False, VBit True ]
         TCInteger   -> []
+        TCRational  -> []
         TCIntMod    ->
           case map tNoUser ts of
             [ TCon (TC (TCNum n)) _ ] | 0 < n ->

--- a/src/Cryptol/TypeCheck/SimpleSolver.hs
+++ b/src/Cryptol/TypeCheck/SimpleSolver.hs
@@ -8,7 +8,7 @@ import Cryptol.TypeCheck.Solver.Numeric.Fin(cryIsFinType)
 import Cryptol.TypeCheck.Solver.Numeric(cryIsEqual, cryIsNotEqual, cryIsGeq)
 import Cryptol.TypeCheck.Solver.Class
   ( solveZeroInst, solveLogicInst, solveArithInst, solveCmpInst
-  , solveSignedCmpInst, solveLiteralInst )
+  , solveSignedCmpInst, solveLiteralInst, solveFieldInst )
 
 import Cryptol.Utils.Debug(ppTrace)
 import Cryptol.TypeCheck.PP
@@ -40,6 +40,7 @@ simplifyStep ctxt prop =
     TCon (PC PZero)  [ty]      -> solveZeroInst ty
     TCon (PC PLogic) [ty]      -> solveLogicInst ty
     TCon (PC PArith) [ty]      -> solveArithInst ty
+    TCon (PC PField) [ty]      -> solveFieldInst ty
     TCon (PC PCmp)   [ty]      -> solveCmpInst   ty
     TCon (PC PSignedCmp) [ty]  -> solveSignedCmpInst ty
     TCon (PC PLiteral) [t1,t2] -> solveLiteralInst t1 t2

--- a/src/Cryptol/TypeCheck/TCon.hs
+++ b/src/Cryptol/TypeCheck/TCon.hs
@@ -52,6 +52,7 @@ builtInType nm =
       "inf"               ~> TC TCInf
     , "Bit"               ~> TC TCBit
     , "Integer"           ~> TC TCInteger
+    , "Rational"          ~> TC TCRational
     , "Z"                 ~> TC TCIntMod
 
       -- Predicate contstructors
@@ -62,6 +63,7 @@ builtInType nm =
     , "Zero"              ~> PC PZero
     , "Logic"             ~> PC PLogic
     , "Arith"             ~> PC PArith
+    , "Field"             ~> PC PField
     , "Cmp"               ~> PC PCmp
     , "SignedCmp"         ~> PC PSignedCmp
     , "Literal"           ~> PC PLiteral
@@ -114,6 +116,7 @@ instance HasKind TC where
       TCInf     -> KNum
       TCBit     -> KType
       TCInteger -> KType
+      TCRational -> KType
       TCIntMod  -> KNum :-> KType
       TCSeq     -> KNum :-> KType :-> KType
       TCFun     -> KType :-> KType :-> KType
@@ -132,6 +135,7 @@ instance HasKind PC where
       PZero      -> KType :-> KProp
       PLogic     -> KType :-> KProp
       PArith     -> KType :-> KProp
+      PField     -> KType :-> KProp
       PCmp       -> KType :-> KProp
       PSignedCmp -> KType :-> KProp
       PLiteral   -> KNum :-> KType :-> KProp
@@ -175,6 +179,7 @@ data PC     = PEqual        -- ^ @_ == _@
             | PZero         -- ^ @Zero _@
             | PLogic        -- ^ @Logic _@
             | PArith        -- ^ @Arith _@
+            | PField        -- ^ @Field _@
             | PCmp          -- ^ @Cmp _@
             | PSignedCmp    -- ^ @SignedCmp _@
             | PLiteral      -- ^ @Literal _ _@
@@ -190,6 +195,7 @@ data TC     = TCNum Integer            -- ^ Numbers
             | TCBit                    -- ^ Bit
             | TCInteger                -- ^ Integer
             | TCIntMod                 -- ^ @Z _@
+            | TCRational               -- ^ @Rational@
             | TCSeq                    -- ^ @[_] _@
             | TCFun                    -- ^ @_ -> _@
             | TCTuple Int              -- ^ @(_, _, _)@
@@ -272,6 +278,7 @@ instance PP PC where
       PZero      -> text "Zero"
       PLogic     -> text "Logic"
       PArith     -> text "Arith"
+      PField     -> text "Field"
       PCmp       -> text "Cmp"
       PSignedCmp -> text "SignedCmp"
       PLiteral   -> text "Literal"
@@ -286,6 +293,7 @@ instance PP TC where
       TCBit     -> text "Bit"
       TCInteger -> text "Integer"
       TCIntMod  -> text "Z"
+      TCRational -> text "Rational"
       TCSeq     -> text "[]"
       TCFun     -> text "(->)"
       TCTuple 0 -> text "()"

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -478,6 +478,9 @@ tBit      = TCon (TC TCBit) []
 tInteger :: Type
 tInteger  = TCon (TC TCInteger) []
 
+tRational :: Type
+tRational  = TCon (TC TCRational) []
+
 tIntMod :: Type -> Type
 tIntMod n = TCon (TC TCIntMod) [n]
 
@@ -584,6 +587,9 @@ pLogic t = TCon (PC PLogic) [t]
 
 pArith :: Type -> Prop
 pArith t = TCon (PC PArith) [t]
+
+pField :: Type -> Prop
+pField t = TCon (PC PField) [t]
 
 pCmp :: Type -> Prop
 pCmp t = TCon (PC PCmp) [t]
@@ -772,6 +778,8 @@ instance PP (WithNames Type) where
           (TCInf,   [])       -> text "inf"
           (TCBit,   [])       -> text "Bit"
           (TCInteger, [])     -> text "Integer"
+          (TCRational, [])    -> text "Rational"
+
           (TCIntMod, [n])     -> optParens (prec > 3) $ text "Z" <+> go 4 n
 
           (TCSeq,   [t1,TCon (TC TCBit) []]) -> brackets (go 0 t1)
@@ -795,6 +803,7 @@ instance PP (WithNames Type) where
                                <+> go 0 t1 <+> text "is" <+> go 0 t2
 
           (PArith, [t1])      -> pp pc <+> go 4 t1
+          (PField, [t1])      -> pp pc <+> go 4 t1
           (PCmp, [t1])        -> pp pc <+> go 4 t1
           (PSignedCmp, [t1])  -> pp pc <+> go 4 t1
           (PLiteral, [t1,t2]) -> pp pc <+> go 4 t1 <+> go 4 t2

--- a/tests/issues/T146.icry.stdout
+++ b/tests/issues/T146.icry.stdout
@@ -3,14 +3,14 @@ Loading module Cryptol
 Loading module Main
 
 [error] at T146.cry:1:18--6:10:
-  The type ?fv`929 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`913
+  The type ?fv`937 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`921
   where
-  ?fv`929 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
-  fv`913 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`937 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
+  fv`921 is signature variable 'fv' at T146.cry:11:10--11:12
 [error] at T146.cry:5:19--5:24:
-  The type ?fv`931 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`913
+  The type ?fv`939 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`921
   where
-  ?fv`931 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
-  fv`913 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`939 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
+  fv`921 is signature variable 'fv' at T146.cry:11:10--11:12

--- a/tests/issues/issue226.icry.stdout
+++ b/tests/issues/issue226.icry.stdout
@@ -44,6 +44,7 @@ Primitive Types
     Arith : * -> Prop
     Bit : *
     Cmp : * -> Prop
+    Field : * -> Prop
     fin : * -> Prop
     Integer : *
     inf : #
@@ -52,6 +53,7 @@ Primitive Types
     lengthFromThenTo : # -> # -> # -> #
     max : # -> # -> #
     min : # -> # -> #
+    Rational : *
     SignedCmp : * -> Prop
     width : # -> #
     Z : # -> *
@@ -68,6 +70,7 @@ Symbols
   From Cryptol
   ------------
 
+    (/.) : {a} (Field a) => a -> a -> a
     (==>) : Bit -> Bit -> Bit
     (\/) : Bit -> Bit -> Bit
     (/\) : Bit -> Bit -> Bit
@@ -110,6 +113,7 @@ Symbols
     and : {n} (fin n) => [n] -> Bit
     any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
     carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : Rational -> Integer
     complement : {a} (Logic a) => a -> a
     curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
     demote : {val, rep} (Literal val rep) => rep
@@ -117,6 +121,7 @@ Symbols
     elem : {n, a} (fin n, Cmp a) => a -> [n]a -> Bit
     error : {a, len} (fin len) => [len][8] -> a
     False : Bit
+    floor : Rational -> Integer
     foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
     foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
     fromInteger : {a} (Arith a) => Integer -> a
@@ -154,6 +159,8 @@ Symbols
     pmult :
       {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
     random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
     repeat : {n, a} a -> [n]a
     reverse : {n, a} (fin n) => [n]a -> [n]a
     sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit

--- a/tests/issues/issue290v2.icry.stdout
+++ b/tests/issues/issue290v2.icry.stdout
@@ -4,9 +4,9 @@ Loading module Main
 
 [error] at issue290v2.cry:2:1--2:19:
   Unsolved constraints:
-    • n`910 == 1
+    • n`918 == 1
         arising from
         checking a pattern: type of 1st argument of Main::minMax
         at issue290v2.cry:2:8--2:11
   where
-  n`910 is signature variable 'n' at issue290v2.cry:1:11--1:12
+  n`918 is signature variable 'n' at issue290v2.cry:1:11--1:12

--- a/tests/regression/rational_properties.cry
+++ b/tests/regression/rational_properties.cry
@@ -1,0 +1,92 @@
+// == Q is a commutative ring ==
+
+property QaddUnit (x : Rational) =
+  x + 0 == x
+
+property QaddComm (x:Rational) (y:Rational) =
+  x + y == y + x
+
+property QaddAssoc (x:Rational) (y:Rational) (z:Rational) =
+  x + (y + z) == (x + y) + z
+
+property Qneg (x: Rational) = x + negate x == 0
+
+property QmulUnit (x : Rational) =
+  x * 1 == x
+
+property QmulComm (x:Rational) (y:Rational) =
+  x * y == y * x
+
+property QmulAssoc (x:Rational) (y:Rational) (z:Rational) =
+  x * (y * z) == (x * y) * z
+
+// Distributivity in Q
+property Qdistrib (x:Rational) (y:Rational) (z:Rational) =
+  x * (y + z) == x*y + x*z
+
+// == Q is a field ==
+
+property Qrecip (x: Rational) = x == 0 \/ x * recip x == 1
+
+property QdivisionEquiv (x : Rational) (y : Rational) =
+  y == 0 \/ x /. y == x * (recip y)
+
+// == Q is a total order ==
+
+property QordEquiv1 (x : Rational) (y : Rational) =
+  (x <= y) == ~(y < x)
+
+property QordEquiv2 (x : Rational) (y : Rational) =
+  (x <= y) == (x == y \/ x < y)
+
+property QordTrans (x : Rational) (y : Rational) (z : Rational) =
+  x < y ==> y < z ==> x < z
+
+property QordIrreflexive (x : Rational) =
+  ~(x < x)
+
+property QordExclusive (x : Rational) (y:Rational) =
+  ~(x < y) || ~(y < x) 
+
+property Qtrichotomy (x : Rational) (y : Rational) =
+  x < y \/ x == y \/ x > y
+
+
+//  == Q is an ordered field
+
+property QordCompatible (x : Rational) (y : Rational) (z:Rational) =
+  x < y ==> x+z < y+z
+
+property QordPositive (x : Rational) (y : Rational) =
+  0 < x ==> 0 < y ==> 0 < x*y
+
+// == Q is a dense total order ==
+property Qdense (x : Rational) (y : Rational) = x < y ==> x < mid /\ mid < y
+  where
+  mid = (x + y) /. 2
+
+
+// == Integer division rounds down ==
+property intDivDown (x : Integer) (y:Integer) =
+  y == 0 \/ fromInteger (x / y) <= ratio x y
+
+
+// == correctness of floor and ceiling
+
+// floor(x) is an integer below x
+property floorCorrect1 (x:Rational) =
+  fromInteger (floor x) <= x
+
+// floor(x) is the largest integer below x
+property floorCorrect2 (x:Rational) (y:Integer) =
+  fromInteger y <= x ==>
+  y <= floor x
+  
+// ceiling(x) is an integer above x
+property ceilingCorrect1 (x:Rational) =
+  fromInteger (ceiling x) >= x
+
+// ceiling(x) is the smallest integer above x
+property ceilingCorrect2 (x:Rational) (y:Integer) =
+  fromInteger y >= x ==>
+  y >= ceiling x

--- a/tests/regression/rational_properties.icry
+++ b/tests/regression/rational_properties.icry
@@ -1,0 +1,15 @@
+:l rational_properties.cry
+
+:check
+
+:! echo "CVC4 proves most of these"
+:set prover=cvc4
+:prove
+
+:set prover=z3
+:! echo "prove Qdense"
+:prove Qdense
+:! echo "prove QordTrans"
+:prove QordTrans
+
+:! echo "have not found a prover that can prove QordCompatible :-("

--- a/tests/regression/rational_properties.icry.stdout
+++ b/tests/regression/rational_properties.icry.stdout
@@ -1,0 +1,108 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+property QaddUnit Using random testing.
+Testing... Passed 100 tests.
+property QaddComm Using random testing.
+Testing... Passed 100 tests.
+property QaddAssoc Using random testing.
+Testing... Passed 100 tests.
+property Qneg Using random testing.
+Testing... Passed 100 tests.
+property QmulUnit Using random testing.
+Testing... Passed 100 tests.
+property QmulComm Using random testing.
+Testing... Passed 100 tests.
+property QmulAssoc Using random testing.
+Testing... Passed 100 tests.
+property Qdistrib Using random testing.
+Testing... Passed 100 tests.
+property Qrecip Using random testing.
+Testing... Passed 100 tests.
+property QdivisionEquiv Using random testing.
+Testing... Passed 100 tests.
+property QordEquiv1 Using random testing.
+Testing... Passed 100 tests.
+property QordEquiv2 Using random testing.
+Testing... Passed 100 tests.
+property QordTrans Using random testing.
+Testing... Passed 100 tests.
+property QordIrreflexive Using random testing.
+Testing... Passed 100 tests.
+property QordExclusive Using random testing.
+Testing... Passed 100 tests.
+property Qtrichotomy Using random testing.
+Testing... Passed 100 tests.
+property QordCompatible Using random testing.
+Testing... Passed 100 tests.
+property QordPositive Using random testing.
+Testing... Passed 100 tests.
+property Qdense Using random testing.
+Testing... Passed 100 tests.
+property intDivDown Using random testing.
+Testing... Passed 100 tests.
+property floorCorrect1 Using random testing.
+Testing... Passed 100 tests.
+property floorCorrect2 Using random testing.
+Testing... Passed 100 tests.
+property ceilingCorrect1 Using random testing.
+Testing... Passed 100 tests.
+property ceilingCorrect2 Using random testing.
+Testing... Passed 100 tests.
+CVC4 proves most of these
+:prove QaddUnit
+	Q.E.D.
+:prove QaddComm
+	Q.E.D.
+:prove QaddAssoc
+	Q.E.D.
+:prove Qneg
+	Q.E.D.
+:prove QmulUnit
+	Q.E.D.
+:prove QmulComm
+	Q.E.D.
+:prove QmulAssoc
+	Q.E.D.
+:prove Qdistrib
+	Q.E.D.
+:prove Qrecip
+	Q.E.D.
+:prove QdivisionEquiv
+	Q.E.D.
+:prove QordEquiv1
+	Q.E.D.
+:prove QordEquiv2
+	Q.E.D.
+:prove QordTrans
+	Unknown.
+  Reason: incomplete
+:prove QordIrreflexive
+	Q.E.D.
+:prove QordExclusive
+	Q.E.D.
+:prove Qtrichotomy
+	Q.E.D.
+:prove QordCompatible
+	Unknown.
+  Reason: incomplete
+:prove QordPositive
+	Q.E.D.
+:prove Qdense
+	Unknown.
+  Reason: incomplete
+:prove intDivDown
+	Q.E.D.
+:prove floorCorrect1
+	Q.E.D.
+:prove floorCorrect2
+	Q.E.D.
+:prove ceilingCorrect1
+	Q.E.D.
+:prove ceilingCorrect2
+	Q.E.D.
+prove Qdense
+Q.E.D.
+prove QordTrans
+Q.E.D.
+have not found a prover that can prove QordCompatible :-(


### PR DESCRIPTION
Add a new type of `Rational` values, which are explicitly constructed internally as pairs of integers in the usual way (#694).  Partially, this was a test to see where all the places are that need to be touched to add a new base type. I think I found them all.

As an experiment in language design, along the lines of #686, I added a new typeclass `Field` for field division and reciprocal.

Depends on #684 