### PR TITLE
issue702

### DIFF
--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -24,7 +24,13 @@ module Cryptol.Eval.Concrete
   ) where
 
 import Control.Monad (join,guard,zipWithM)
+import Data.List(sortBy)
+import Data.Ord(comparing)
+import Data.Bits (Bits(..))
 import MonadLib( ChoiceT, findOne, lift )
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 
 import Cryptol.TypeCheck.Solver.InfNat (Nat'(..))
 import Cryptol.Eval.Backend
@@ -41,10 +47,6 @@ import Cryptol.Utils.Ident (Ident,mkIdent)
 import Cryptol.Utils.PP
 import Cryptol.Utils.Logger(logPrint)
 
-import Data.Bits (Bits(..))
-
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
 
 
 -- Value to Expression conversion ----------------------------------------------
@@ -61,7 +63,7 @@ toExpr prims t0 v0 = findOne (go t0 v0)
 
   go :: AST.Type -> Value -> ChoiceT Eval Expr
   go ty val = case (tNoUser ty, val) of
-    (TRec tfs, VRecord vfs) -> do
+    (TRec (sortBy (comparing fst) -> tfs), VRecord vfs) -> do
       let fns = Map.keys vfs
       guard (map fst tfs == fns)
       fes <- zipWithM go (map snd tfs) =<< lift (sequence (Map.elems vfs))

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -274,7 +274,7 @@ parseValue (FTSeq n t) cvs =
 parseValue (FTTuple ts) cvs = (Eval.VTuple (map Eval.ready vs), cvs')
   where (vs, cvs') = parseValues ts cvs
 parseValue (FTRecord fs) cvs = (Eval.VRecord (Map.fromList (zip ns (map Eval.ready vs))), cvs')
-  where (ns, ts) = unzip fs
+  where (ns, ts)   = unzip (Map.toList fs)
         (vs, cvs') = parseValues ts cvs
 
 inBoundsIntMod :: Integer -> Eval.SInteger SBV -> Eval.SBit SBV
@@ -296,7 +296,7 @@ forallFinType ty =
     FTSeq n t     -> do vs <- replicateM n (forallFinType t)
                         return $ Eval.VSeq (toInteger n) $ Eval.finiteSeqMap SBV (map pure vs)
     FTTuple ts    -> Eval.VTuple <$> mapM (fmap pure . forallFinType) ts
-    FTRecord fs   -> Eval.VRecord <$> mapM (fmap pure . forallFinType) (Map.fromList fs)
+    FTRecord fs   -> Eval.VRecord <$> mapM (fmap pure . forallFinType) fs
 
 existsFinType :: FinType -> WriterT [Eval.SBit SBV] SBV.Symbolic Value
 existsFinType ty =
@@ -311,4 +311,4 @@ existsFinType ty =
     FTSeq n t     -> do vs <- replicateM n (existsFinType t)
                         return $ Eval.VSeq (toInteger n) $ Eval.finiteSeqMap SBV (map pure vs)
     FTTuple ts    -> Eval.VTuple <$> mapM (fmap pure . existsFinType) ts
-    FTRecord fs   -> Eval.VRecord <$> mapM (fmap pure . existsFinType) (Map.fromList fs)
+    FTRecord fs   -> Eval.VRecord <$> mapM (fmap pure . existsFinType) fs

--- a/tests/issues/issue702.icry
+++ b/tests/issues/issue702.icry
@@ -1,0 +1,2 @@
+:sat \(x : {b:Bit, a:Bit}) -> x.a && x.b
+:sat \(x : {b:[8], a:Bit}) -> x.b == 0 /\ x.a

--- a/tests/issues/issue702.icry.stdout
+++ b/tests/issues/issue702.icry.stdout
@@ -1,0 +1,5 @@
+Loading module Cryptol
+(\(x : {b : Bit, a : Bit}) -> x.a && x.b)
+  {a = True, b = True} = True
+(\(x : {b : [8], a : Bit}) -> x.b == 0 /\ x.a)
+  {a = True, b = 0x00} = True


### PR DESCRIPTION
Sort the fields of a record type before comparing with the fields in a concrete value in `toExpr`.

Fixes #702