### PR TITLE
Redefine prelude function `iterate` to preserve sharing.

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -864,4 +864,5 @@ curry f = \a b -> f (a, b)
  * list of successive function applications.
  */
 iterate : {a} (a -> a) -> a -> [inf]a
-iterate f x = [x] # [ f v | v <- iterate f x ]
+iterate f x = xs
+  where xs = [x] # [ f v | v <- xs ]

--- a/tests/issues/T146.icry.stdout
+++ b/tests/issues/T146.icry.stdout
@@ -3,14 +3,14 @@ Loading module Cryptol
 Loading module Main
 
 [error] at T146.cry:1:18--6:10:
-  The type ?fv`929 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`913
+  The type ?fv`927 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`911
   where
-  ?fv`929 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
-  fv`913 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`927 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
+  fv`911 is signature variable 'fv' at T146.cry:11:10--11:12
 [error] at T146.cry:5:19--5:24:
-  The type ?fv`931 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`913
+  The type ?fv`929 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`911
   where
-  ?fv`931 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
-  fv`913 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`929 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
+  fv`911 is signature variable 'fv' at T146.cry:11:10--11:12

--- a/tests/issues/issue290v2.icry.stdout
+++ b/tests/issues/issue290v2.icry.stdout
@@ -4,9 +4,9 @@ Loading module Main
 
 [error] at issue290v2.cry:2:1--2:19:
   Unsolved constraints:
-    • n`910 == 1
+    • n`908 == 1
         arising from
         checking a pattern: type of 1st argument of Main::minMax
         at issue290v2.cry:2:8--2:11
   where
-  n`910 is signature variable 'n' at issue290v2.cry:1:11--1:12
+  n`908 is signature variable 'n' at issue290v2.cry:1:11--1:12


### PR DESCRIPTION
Fixes #707.