### PR TITLE
Updates for haskeline 0.8 and use of exceptions package.

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -50,6 +50,7 @@ library
                        cryptohash-sha1   >= 0.11 && < 0.12,
                        deepseq           >= 1.3,
                        directory         >= 1.2.2.0,
+                       exceptions,
                        filepath          >= 1.3,
                        gitrev            >= 1.0,
                        GraphSCC          >= 1.0.4,
@@ -206,7 +207,7 @@ executable cryptol
                      , cryptol
                      , directory
                      , filepath
-                     , haskeline >= 0.7 && < 0.8
+                     , haskeline >= 0.7 && < 0.9
                      , monad-control
                      , text
                      , transformers

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -23,7 +23,7 @@ import           Cryptol.Utils.Ident(modNameToText, interactiveName)
 import qualified Control.Exception as X
 import           Control.Monad (guard, join)
 import qualified Control.Monad.Trans.Class as MTL
-#if !MIN_VERSION_base(4,14,0)
+#if !MIN_VERSION_haskeline(0,8,0)
 import           Control.Monad.Trans.Control
 #endif
 import           Data.Char (isAlphaNum, isSpace)
@@ -162,7 +162,7 @@ data Cryptolrc =
 
 -- Utilities -------------------------------------------------------------------
 
-#if !MIN_VERSION_base(4,14,0)
+#if !MIN_VERSION_haskeline(0,8,0)
 instance MonadException REPL where
   controlIO f = join $ liftBaseWith $ \f' ->
     f $ RunIO $ \m -> restoreM <$> (f' m)

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -22,20 +22,19 @@ import           Cryptol.Utils.Ident(modNameToText, interactiveName)
 import qualified Control.Exception as X
 import           Control.Monad (guard, join)
 import qualified Control.Monad.Trans.Class as MTL
-import           Control.Monad.Trans.Control
 import           Data.Char (isAlphaNum, isSpace)
-import           Data.Maybe(isJust)
 import           Data.Function (on)
 import           Data.List (isPrefixOf,nub,sortBy,sort)
+import           Data.Maybe(isJust)
 import qualified Data.Set as Set
 import qualified Data.Text as T (unpack)
-import           System.IO (stdout)
 import           System.Console.ANSI (setTitle, hSupportsANSI)
 import           System.Console.Haskeline
 import           System.Directory ( doesFileExist
                                   , getHomeDirectory
                                   , getCurrentDirectory)
 import           System.FilePath ((</>))
+import           System.IO (stdout)
 
 import           Prelude ()
 import           Prelude.Compat
@@ -128,7 +127,7 @@ setHistoryFile :: Settings REPL -> IO (Settings REPL)
 setHistoryFile ss =
   do dir <- getHomeDirectory
      return ss { historyFile = Just (dir </> ".cryptol_history") }
-   `X.catch` \(SomeException {}) -> return ss
+   `X.catch` \(X.SomeException {}) -> return ss
 
 -- | Haskeline settings for the REPL.
 replSettings :: Bool -> Settings REPL
@@ -156,12 +155,6 @@ data Cryptolrc =
   | CryrcDisabled
   | CryrcFiles [FilePath]
   deriving (Show)
-
--- Utilities -------------------------------------------------------------------
-
-instance MonadException REPL where
-  controlIO f = join $ liftBaseWith $ \f' ->
-    f $ RunIO $ \m -> restoreM <$> (f' m)
 
 -- Titles ----------------------------------------------------------------------
 

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -6,6 +6,7 @@
 -- Stability   :  provisional
 -- Portability :  portable
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE PatternGuards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -22,6 +23,9 @@ import           Cryptol.Utils.Ident(modNameToText, interactiveName)
 import qualified Control.Exception as X
 import           Control.Monad (guard, join)
 import qualified Control.Monad.Trans.Class as MTL
+#if !MIN_VERSION_base(4,13,0)
+import           Control.Monad.Trans.Control
+#endif
 import           Data.Char (isAlphaNum, isSpace)
 import           Data.Function (on)
 import           Data.List (isPrefixOf,nub,sortBy,sort)
@@ -155,6 +159,14 @@ data Cryptolrc =
   | CryrcDisabled
   | CryrcFiles [FilePath]
   deriving (Show)
+
+-- Utilities -------------------------------------------------------------------
+
+#if !MIN_VERSION_base(4,13,0)
+instance MonadException REPL where
+  controlIO f = join $ liftBaseWith $ \f' ->
+    f $ RunIO $ \m -> restoreM <$> (f' m)
+#endif
 
 -- Titles ----------------------------------------------------------------------
 

--- a/cryptol/REPL/Haskeline.hs
+++ b/cryptol/REPL/Haskeline.hs
@@ -23,7 +23,7 @@ import           Cryptol.Utils.Ident(modNameToText, interactiveName)
 import qualified Control.Exception as X
 import           Control.Monad (guard, join)
 import qualified Control.Monad.Trans.Class as MTL
-#if !MIN_VERSION_base(4,13,0)
+#if !MIN_VERSION_base(4,14,0)
 import           Control.Monad.Trans.Control
 #endif
 import           Data.Char (isAlphaNum, isSpace)
@@ -162,7 +162,7 @@ data Cryptolrc =
 
 -- Utilities -------------------------------------------------------------------
 
-#if !MIN_VERSION_base(4,13,0)
+#if !MIN_VERSION_base(4,14,0)
 instance MonadException REPL where
   controlIO f = join $ liftBaseWith $ \f' ->
     f $ RunIO $ \m -> restoreM <$> (f' m)


### PR DESCRIPTION
The version of haskeline was updated for GHC 8.10 (haskeline is one of the bundled libraries in the GHC distribution), and the newer version of haskeline contains some non-backwards-compatible changes that are addressed by this pull request.

More specifically, haskeline dropped its internal MonadExceptions module in favor of using the standard `exceptions` package (pull request 97 in haskeline) which necessitates the addition of some new class instances (and the removal of the MonadException instance) for GHC 8.10.