### PR TITLE
Enforce datatype invariants when creating `Subst` values

### DIFF
--- a/src/Cryptol/Transform/Specialize.hs
+++ b/src/Cryptol/Transform/Specialize.hs
@@ -324,7 +324,7 @@ instantiateExpr :: [Type] -> Int -> Expr -> SpecM Expr
 instantiateExpr [] 0 e = return e
 instantiateExpr [] n (EProofAbs _ e) = instantiateExpr [] (n - 1) e
 instantiateExpr (t : ts) n (ETAbs param e) =
-  instantiateExpr ts n (apSubst (singleSubst (tpVar param) t) e)
+  instantiateExpr ts n (apSubst (singleTParamSubst param t) e)
 instantiateExpr _ _ _ = fail "instantiateExpr: wrong number of type/proof arguments"
 
 

--- a/src/Cryptol/TypeCheck/Default.hs
+++ b/src/Cryptol/TypeCheck/Default.hs
@@ -9,7 +9,7 @@ import Control.Monad(guard)
 import Cryptol.TypeCheck.Type
 import Cryptol.TypeCheck.SimpType(tMax,tWidth)
 import Cryptol.TypeCheck.Error(Warning(..))
-import Cryptol.TypeCheck.Subst(Subst,apSubst,listSubst,substBinds,singleSubst)
+import Cryptol.TypeCheck.Subst(Subst,apSubst,listSubst,substBinds,uncheckedSingleSubst)
 import Cryptol.TypeCheck.InferTypes(Goal,goal,Goals(..),goalsFromList)
 import Cryptol.TypeCheck.Solver.SMT(Solver,tryGetModel,shrinkModel)
 import Cryptol.Utils.Panic(panic)
@@ -152,7 +152,7 @@ improveByDefaultingWithPure as ps =
           let ty  = case ts of
                       [] -> tNum (0::Int)
                       _  -> foldr1 tMax ts
-              su1 = singleSubst x ty
+              su1 = uncheckedSingleSubst x ty
           in ( (x,ty) : [ (y,apSubst su1 t) | (y,t) <- yes ]
              , no         -- We know that `x` does not appear here
              , otherFree  -- We know that `x` did not appear here either

--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -550,13 +550,7 @@ extendSubst su =
             , "Type:     " ++ show (pp ty)
             ]
         TVFree _ _ tvs _ ->
-          do let bounds tv =
-                   case tv of
-                     TVBound tp -> Set.singleton tp
-                     TVFree _ _ tps _ -> tps
-             let vars = Set.unions (map bounds (Set.elems (fvs ty)))
-                 -- (Set.filter isBoundTV (fvs ty))
-             let escaped = Set.difference vars tvs
+          do let escaped = Set.difference (freeParams ty) tvs
              if Set.null escaped then return () else
                panic "Cryptol.TypeCheck.Monad.extendSubst"
                  [ "Escaped quantified variables:"

--- a/src/Cryptol/TypeCheck/Sanity.hs
+++ b/src/Cryptol/TypeCheck/Sanity.hs
@@ -17,7 +17,7 @@ module Cryptol.TypeCheck.Sanity
 
 import Cryptol.Parser.Position(thing)
 import Cryptol.TypeCheck.AST
-import Cryptol.TypeCheck.Subst (apSubst, singleSubst)
+import Cryptol.TypeCheck.Subst (apSubst, singleTParamSubst)
 import Cryptol.TypeCheck.Monad(InferInput(..))
 import Cryptol.Utils.Ident
 
@@ -221,7 +221,7 @@ exprSchema expr =
                 let k' = kindOf a
                 unless (k == k') $ reportError $ KindMismatch k' k
 
-                let su = singleSubst (tpVar a) t
+                let su = singleTParamSubst a t
                 return $ Forall as (apSubst su ps) (apSubst su t1)
 
            Forall [] _ _ -> reportError BadInstantiation

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -15,6 +15,7 @@ module Cryptol.TypeCheck.Subst
   ( Subst
   , emptySubst
   , singleSubst
+  , singleTParamSubst
   , (@@)
   , defaultingSubst
   , listSubst
@@ -85,6 +86,9 @@ singleSubst v@(TVBound tp) t =
     , suBoundMap = IntMap.singleton (tpUnique tp) (v, t)
     , suDefaulting = False
     }
+
+singleTParamSubst :: TParam -> Type -> Subst
+singleTParamSubst tp t = singleSubst (TVBound tp) t
 
 (@@) :: Subst -> Subst -> Subst
 s2 @@ s1

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -50,19 +50,22 @@ import Cryptol.Utils.Misc(anyJust)
 -- | A 'Subst' value represents a substitution that maps each 'TVar'
 -- to a 'Type'.
 --
--- Invariant: If there is a mapping from @TVFree _ _ tps _@ to a type
--- @t@, then @t@ must not mention (directly or indirectly) any type
--- parameter that is not in @tps@. In particular, if @t@ contains a
--- variable @TVFree _ _ tps2 _@, then @tps2@ must be a subset of
+-- Invariant 1: If there is a mapping from @TVFree _ _ tps _@ to a
+-- type @t@, then @t@ must not mention (directly or indirectly) any
+-- type parameter that is not in @tps@. In particular, if @t@ contains
+-- a variable @TVFree _ _ tps2 _@, then @tps2@ must be a subset of
 -- @tps@. This ensures that applying the substitution will not permit
 -- any type parameter to escape from its scope.
 --
--- Invariant: The substitution must be idempotent, in that applying a
--- substitution to any 'Type' in the map should leave that 'Type'
+-- Invariant 2: The substitution must be idempotent, in that applying
+-- a substitution to any 'Type' in the map should leave that 'Type'
 -- unchanged. In other words, 'Type' values in the range of a 'Subst'
 -- should not mention any 'TVar' in the domain of the 'Subst'. In
 -- particular, this implies that a substitution must not contain any
 -- recursive variable mappings.
+--
+-- Invariant 3: The substitution must be kind correct: Each 'TVar' in
+-- the substitution must map to a 'Type' of the same kind.
 
 data Subst = S { suFreeMap :: !(IntMap.IntMap (TVar, Type))
                , suBoundMap :: !(IntMap.IntMap (TVar, Type))

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -53,6 +53,13 @@ import Cryptol.Utils.Misc(anyJust)
 -- variable @TVFree _ _ tps2 _@, then @tps2@ must be a subset of
 -- @tps@. This ensures that applying the substitution will not permit
 -- any type parameter to escape from its scope.
+--
+-- Invariant: The substitution must be idempotent, in that applying a
+-- substitution to any 'Type' in the map should leave that 'Type'
+-- unchanged. In other words, 'Type' values in the range of a 'Subst'
+-- should not mention any 'TVar' in the domain of the 'Subst'. In
+-- particular, this implies that a substitution must not contain any
+-- recursive variable mappings.
 
 data Subst = S { suFreeMap :: !(IntMap.IntMap (TVar, Type))
                , suBoundMap :: !(IntMap.IntMap (TVar, Type))

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -86,9 +86,12 @@ data SubstError
   -- ^ 'TVar' maps to a type containing the same variable.
   | SubstEscaped [TParam]
   -- ^ 'TVar' maps to a type containing one or more out-of-scope bound variables.
+  | SubstKindMismatch Kind Kind
+  -- ^ 'TVar' maps to a type with a different kind.
 
 singleSubst :: TVar -> Type -> Either SubstError Subst
 singleSubst x t
+  | kindOf x /= kindOf t   = Left (SubstKindMismatch (kindOf x) (kindOf t))
   | x `Set.member` fvs t   = Left SubstRecursive
   | not (Set.null escaped) = Left (SubstEscaped (Set.toList escaped))
   | otherwise              = Right (uncheckedSingleSubst x t)

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -650,6 +650,12 @@ pError msg = TCon (TError KProp msg) []
 noFreeVariables :: FVS t => t -> Bool
 noFreeVariables = all (not . isFreeTV) . Set.toList . fvs
 
+freeParams :: FVS t => t -> Set TParam
+freeParams x = Set.unions (map params (Set.toList (fvs x)))
+  where
+    params (TVFree _ _ tps _) = tps
+    params (TVBound tp) = Set.singleton tp
+
 class FVS t where
   fvs :: t -> Set TVar
 

--- a/src/Cryptol/TypeCheck/TypeOf.hs
+++ b/src/Cryptol/TypeCheck/TypeOf.hs
@@ -68,7 +68,7 @@ fastSchemaOf tyenv expr =
     ETApp e t      -> case fastSchemaOf tyenv e of
                         Forall (tparam : tparams) props ty
                           -> Forall tparams (map (plainSubst s) props) (plainSubst s ty)
-                          where s = singleSubst (tpVar tparam) t
+                          where s = singleTParamSubst tparam t
                         _ -> panic "Cryptol.TypeCheck.TypeOf.fastSchemaOf"
                                [ "ETApp body with no type parameters" ]
                         -- When calling 'fastSchemaOf' on a

--- a/src/Cryptol/TypeCheck/Unify.hs
+++ b/src/Cryptol/TypeCheck/Unify.hs
@@ -122,10 +122,3 @@ bindVar x@(TVFree _ k inScope _d) t
     where
     escaped = freeParams t `Set.difference` inScope
     recTy   = x `Set.member` fvs t
-
-
-freeParams :: FVS t => t -> Set.Set TParam
-freeParams x = Set.unions (map params (Set.toList (fvs x)))
-  where
-    params (TVFree _ _ tps _) = tps
-    params (TVBound tp) = Set.singleton tp

--- a/tests/issues/issue723.cry
+++ b/tests/issues/issue723.cry
@@ -1,0 +1,7 @@
+f : {n} (fin n) => [n] -> [n]
+f x = g x
+  where
+    m1 = zero # x
+
+    g : {k} (fin k) => [k] -> [k]
+    g m0 = m0 ^ m1

--- a/tests/issues/issue723.icry
+++ b/tests/issues/issue723.icry
@@ -1,0 +1,1 @@
+:l issue723.cry

--- a/tests/issues/issue723.icry.stdout
+++ b/tests/issues/issue723.icry.stdout
@@ -1,0 +1,20 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+[warning] at issue723.cry:4:10--4:18:
+  Defaulting type argument 'front' of '(#)' to 0
+
+[error] at issue723.cry:7:5--7:19:
+  Failed to validate user-specified signature.
+    in the definition of 'Main::g', at issue723.cry:7:5--7:6,
+    we need to show that
+      for any type k
+      assuming
+        • fin k
+      the following constraints hold:
+        • k >= n`908
+            arising from
+            matching types
+            at issue723.cry:7:17--7:19
+  where
+  n`908 is signature variable 'n' at issue723.cry:1:6--1:7


### PR DESCRIPTION
This patch adds/changes some functions in the `Cryptol.TypeCheck.Subst` module to make it harder to accidentally make `Subst` values that violate the datatype invariant (a situation that can lead to a `panic`).

Fixes #723.