### PR TITLE
Issue725

### DIFF
--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -24,6 +24,7 @@ module Cryptol.Eval.SBV
   , forallSInteger_, existsSInteger_
   ) where
 
+import qualified Control.Exception as X
 import           Control.Monad (join, unless)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Data.Bits (bit, complement, shiftL)
@@ -302,7 +303,7 @@ instance Backend SBV where
        do unless (0 <= e) (raiseError sym NegativeExponent)
           pure $! SBV.svExp a b
     | otherwise =
-       raiseError sym (UnsupportedSymbolicOp "integer exponentation")
+       liftIO (X.throw (UnsupportedSymbolicOp "integer exponentation"))
 
   -- NB, we don't do reduction here
   intToZn _ _m a = pure a
@@ -735,7 +736,7 @@ svLg2 :: SInteger SBV -> SEval SBV (SInteger SBV)
 svLg2 x =
   case SBV.svAsInteger x of
     Just n -> pure $ SBV.svInteger SBV.KUnbounded (lg2 n)
-    Nothing -> raiseError SBV (UnsupportedSymbolicOp "integer lg2")
+    Nothing -> liftIO (X.throw (UnsupportedSymbolicOp "integer lg2"))
 
 svDivisible :: Integer -> SInteger SBV -> SEval SBV (SBit SBV)
 svDivisible m x =

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -303,7 +303,7 @@ instance Backend SBV where
        do unless (0 <= e) (raiseError sym NegativeExponent)
           pure $! SBV.svExp a b
     | otherwise =
-       liftIO (X.throw (UnsupportedSymbolicOp "integer exponentation"))
+       liftIO (X.throw (UnsupportedSymbolicOp "integer exponentiation"))
 
   -- NB, we don't do reduction here
   intToZn _ _m a = pure a

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -299,7 +299,7 @@ instance W4.IsExprBuilder sym => Backend (What4 sym) where
 
   intExp (What4 sym) x y
     | Just i <- W4.asInteger y = intExpConcrete sym x i
-    | otherwise = liftIO (X.throw (UnsupportedSymbolicOp "integer exponentation"))
+    | otherwise = liftIO (X.throw (UnsupportedSymbolicOp "integer exponentiation"))
 
   intLg2 (What4 sym) x
     | Just i <- W4.asInteger x = liftIO $ W4.intLit sym (lg2 i)

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -574,6 +574,7 @@ cmdProveSat isSat str = do
             (t, e) <- mkSolverResult cexStr (not isSat) (Left ts)
             bindItVariable t e
           AllSatResult tevss -> do
+            rPutStrLn (if isSat then "Satisfiable" else "Counterexample")
             let tess = map (map $ \(t,e,_) -> (t,e)) tevss
                 vss  = map (map $ \(_,_,v) -> v)     tevss
             resultRecs <- mapM (mkSolverResult cexStr isSat . Right) tess

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -34,6 +34,7 @@ import qualified Control.Exception as X
 import qualified Data.SBV.Dynamic as SBV
 import           Data.SBV (Timing(SaveTiming))
 import           Data.SBV.Internals (showTDiff)
+import           Data.Time (NominalDiffTime)
 
 import qualified Cryptol.ModuleSystem as M hiding (getPrimMap)
 import qualified Cryptol.ModuleSystem.Env as M
@@ -86,6 +87,7 @@ proverConfigs =
   , ("sbv-any"      , SBV.defaultSMTCfg )
   ]
 
+-- | The names of all the solvers supported by SBV
 proverNames :: [String]
 proverNames = map fst proverConfigs
 
@@ -102,6 +104,8 @@ satSMTResults (SBV.SatResult r) = [r]
 allSatSMTResults :: SBV.AllSatResult -> [SBV.SMTResult]
 allSatSMTResults (SBV.AllSatResult (_, _, _, rs)) = rs
 
+-- | Check if the named solver can be found and invoked
+--   in the current solver environment.
 checkProverInstallation :: String -> IO Bool
 checkProverInstallation s =
   do let prover = lookupProver s
@@ -114,134 +118,216 @@ proverError :: String -> M.ModuleCmd (Maybe String, ProverResult)
 proverError msg (_,modEnv) =
   return (Right ((Nothing, ProverError msg), modEnv), [])
 
+
+runSingleProver ::
+  ProverCommand ->
+  [SBV.SMTConfig] ->
+  (SBV.SMTConfig -> SBV.Symbolic SBV.SVal -> IO res) ->
+  (res -> [SBV.SMTResult]) ->
+  SBV.Symbolic SBV.SVal ->
+  M.ModuleT IO (Maybe String, [SBV.SMTResult])
+runSingleProver ProverCommand{..} provers callSolver processResult e = do
+  let lPutStrLn = M.withLogger logPutStrLn
+
+  case provers of
+    [prover] -> do
+      when pcVerbose $
+        lPutStrLn $ "Trying proof with " ++
+                                  show (SBV.name (SBV.solver prover))
+      res <- M.io (callSolver prover e)
+      when pcVerbose $
+        lPutStrLn $ "Got result from " ++
+                                  show (SBV.name (SBV.solver prover))
+      return (Just (show (SBV.name (SBV.solver prover))), processResult res)
+    _ ->
+      return ( Nothing
+             , [ SBV.ProofError
+                   prover
+                   [":sat with option prover=any requires option satNum=1"]
+                   Nothing
+               | prover <- provers ]
+             )
+
+runMultiProvers ::
+  ProverCommand ->
+  [SBV.SMTConfig] ->
+  ([SBV.SMTConfig] -> SBV.Symbolic SBV.SVal -> IO (SBV.Solver, NominalDiffTime, res)) ->
+  (res -> [SBV.SMTResult]) ->
+  SBV.Symbolic SBV.SVal ->
+  M.ModuleT IO (Maybe String, [SBV.SMTResult])
+runMultiProvers ProverCommand{..} provers callSolvers processResult e = do
+  let lPutStrLn = M.withLogger logPutStrLn
+
+  when pcVerbose $
+    lPutStrLn $ "Trying proof with " ++
+            intercalate ", " (map (show . SBV.name . SBV.solver) provers)
+  (firstProver, timeElapsed, res) <- M.io (callSolvers provers e)
+  when pcVerbose $
+    lPutStrLn $ "Got result from " ++ show firstProver ++
+                                      ", time: " ++ showTDiff timeElapsed
+  return (Just (show firstProver), processResult res)
+
+-- | Select the appropriate solver or solvers from the given prover command,
+--   and invoke those solvers on the given symbolic value.
+runProver :: ProverCommand -> SBV.Symbolic SBV.SVal -> M.ModuleT IO (Maybe String, [SBV.SMTResult])
+runProver pc@ProverCommand{..} x =
+  do let mSatNum = case pcQueryType of
+                     SatQuery (SomeSat n) -> Just n
+                     SatQuery AllSat -> Nothing
+                     ProveQuery -> Nothing
+
+     provers <-
+       case pcProverName of
+         "any" -> M.io SBV.sbvAvailableSolvers
+         "sbv-any" -> M.io SBV.sbvAvailableSolvers
+         _ -> return [(lookupProver pcProverName)
+                        { SBV.transcript = pcSmtFile
+                        , SBV.allSatMaxModelCount = mSatNum
+                        }]
+
+     let provers' = [ p { SBV.timing = SaveTiming pcProverStats
+                        , SBV.verbose = pcVerbose
+                        , SBV.validateModel = pcValidate
+                        }
+                    | p <- provers
+                    ]
+
+     case pcQueryType of
+        ProveQuery -> runMultiProvers pc provers' SBV.proveWithAny thmSMTResults x
+        SatQuery sn -> case sn of
+          SomeSat 1 -> runMultiProvers pc provers' SBV.satWithAny satSMTResults x
+          _         -> runSingleProver pc provers' SBV.allSatWith allSatSMTResults x
+
+
+-- | Prepare a symbolic query by symbolically simulating the expression found in
+--   the @ProverQuery@.  The result will either be an error or a list of the types
+--   of the symbolic inputs and the symbolic value to supply to the solver.
+--
+--   Note that the difference between sat and prove queries is reflected later
+--   in `runProver` where we call different SBV methods depending on the mode,
+--   so we do _not_ negate the goal here.  Moreover, assumptions are added
+--   using conjunction for sat queries and implication for prove queries.
+--
+--   For safety properties, we want to add them as an additional goal
+--   when we do prove queries, and an additional assumption when we do
+--   sat queries.  In both cases, the safety property is combined with
+--   the main goal via a conjunction.
+prepareQuery ::
+  Eval.EvalOpts ->
+  M.ModuleEnv ->
+  ProverCommand ->
+  IO (Either String ([FinType], SBV.Symbolic SBV.SVal))
+prepareQuery evo modEnv ProverCommand{..} =
+  do let extDgs = M.allDeclGroups modEnv ++ pcExtraDecls
+     let tyFn = case pcQueryType of
+           SatQuery _ -> existsFinType
+           ProveQuery -> forallFinType
+     let addAsm = case pcQueryType of
+           ProveQuery -> \x y -> SBV.svOr (SBV.svNot x) y
+           SatQuery _ -> \x y -> SBV.svAnd x y
+     let ?evalPrim = evalPrim
+     case predArgTypes pcSchema of
+       Left msg -> return (Left msg)
+       Right ts ->
+         do when pcVerbose $ logPutStrLn (Eval.evalLogger evo) "Simulating..."
+            pure $ Right $ (ts,
+              do -- Compute the symbolic inputs, and any domain constraints needed
+                 -- according to their types.
+                 (args, asms) <- runWriterT (mapM tyFn ts)
+                 -- Run the main symbolic computation.  First we populate the
+                 -- evaluation environment, then we compute the value, finally
+                 -- we apply it to the symbolic inputs.
+                 (safety,b) <- doSBVEval evo $
+                     do env <- Eval.evalDecls SBV extDgs mempty
+                        v <- Eval.evalExpr SBV env pcExpr
+                        Eval.fromVBit <$> foldM Eval.fromVFun v (map pure args)
+                 return (foldr addAsm (SBV.svAnd safety b) asms))
+
+
+-- | Turn the SMT results from SBV into a @ProverResult@ that is ready for the Cryptol REPL.
+--   There may be more than one result if we made a multi-sat query.
+processResults ::
+  Eval.EvalOpts ->
+  ProverCommand ->
+  [FinType] {- ^ Types of the symbolic inputs -} ->
+  [SBV.SMTResult] {- ^ Results from the solver -} ->
+  M.ModuleT IO ProverResult
+processResults evo ProverCommand{..} ts results =
+ do let isSat = case pcQueryType of
+          ProveQuery -> False
+          SatQuery _ -> True
+
+    prims <- M.getPrimMap
+
+    case results of
+       -- allSat can return more than one as long as
+       -- they're satisfiable
+       (SBV.Satisfiable {} : _) -> do
+         tevss <- mapM mkTevs results
+         return $ AllSatResult tevss
+         where
+           mkTevs result = do
+             let Right (_, cvs) = SBV.getModelAssignment result
+                 (vs, _) = parseValues ts cvs
+                 sattys = unFinType <$> ts
+             satexprs <-
+               doEval evo (zipWithM (Concrete.toExpr prims) sattys vs)
+             case zip3 sattys <$> (sequence satexprs) <*> pure vs of
+               Nothing ->
+                 panic "Cryptol.Symbolic.sat"
+                   [ "unable to make assignment into expression" ]
+               Just tevs -> return $ tevs
+
+       -- prove returns only one
+       [SBV.Unsatisfiable {}] ->
+         return $ ThmResult (unFinType <$> ts)
+
+       -- unsat returns empty
+       [] -> return $ ThmResult (unFinType <$> ts)
+
+       -- otherwise something is wrong
+       _ -> return $ ProverError (rshow results)
+              where rshow | isSat = show .  SBV.AllSatResult . (False,False,False,)
+                          | otherwise = show . SBV.ThmResult . head
+
+-- | Execute a symbolic ':prove' or ':sat' command.
+--
+--   This command returns a pair: the first element is the name of the
+--   solver that completes the given query (if any) along with the result
+--   of executing the query.
 satProve :: ProverCommand -> M.ModuleCmd (Maybe String, ProverResult)
-satProve ProverCommand {..} =
+satProve pc@ProverCommand {..} =
   protectStack proverError $ \(evo,modEnv) ->
 
   M.runModuleM (evo,modEnv) $ do
-  let (isSat, mSatNum) = case pcQueryType of
-        ProveQuery -> (False, Nothing)
-        SatQuery sn -> case sn of
-          SomeSat n -> (True, Just n)
-          AllSat    -> (True, Nothing)
-  let extDgs = M.allDeclGroups modEnv ++ pcExtraDecls
-  provers <-
-    case pcProverName of
-      "any" -> M.io SBV.sbvAvailableSolvers
-      "sbv-any" -> M.io SBV.sbvAvailableSolvers
-      _ -> return [(lookupProver pcProverName) { SBV.transcript = pcSmtFile
-                                               , SBV.allSatMaxModelCount = mSatNum
-                                               }]
 
-
-  let provers' = [ p { SBV.timing = SaveTiming pcProverStats
-                     , SBV.verbose = pcVerbose
-                     , SBV.validateModel = pcValidate
-                     } | p <- provers ]
-  let tyFn = if isSat then existsFinType else forallFinType
-  let lPutStrLn = M.withLogger logPutStrLn
-  let runProver fn tag e = do
-        case provers of
-          [prover] -> do
-            when pcVerbose $
-              lPutStrLn $ "Trying proof with " ++
-                                        show (SBV.name (SBV.solver prover))
-            res <- M.io (fn prover e)
-            when pcVerbose $
-              lPutStrLn $ "Got result from " ++
-                                        show (SBV.name (SBV.solver prover))
-            return (Just (show (SBV.name (SBV.solver prover))), tag res)
-          _ ->
-            return ( Nothing
-                   , [ SBV.ProofError
-                         prover
-                         [":sat with option prover=any requires option satNum=1"]
-                         Nothing
-                     | prover <- provers ]
-                   )
-      runProvers fn tag e = do
-        when pcVerbose $
-          lPutStrLn $ "Trying proof with " ++
-                  intercalate ", " (map (show . SBV.name . SBV.solver) provers)
-        (firstProver, timeElapsed, res) <- M.io (fn provers' e)
-        when pcVerbose $
-          lPutStrLn $ "Got result from " ++ show firstProver ++
-                                            ", time: " ++ showTDiff timeElapsed
-        return (Just (show firstProver), tag res)
-  let runFn = case pcQueryType of
-        ProveQuery -> runProvers SBV.proveWithAny thmSMTResults
-        SatQuery sn -> case sn of
-          SomeSat 1 -> runProvers SBV.satWithAny satSMTResults
-          _         -> runProver SBV.allSatWith allSatSMTResults
-  let addAsm = case pcQueryType of
-        ProveQuery -> \x y -> SBV.svOr (SBV.svNot x) y
-        SatQuery _ -> \x y -> SBV.svAnd x y
-
-  let ?evalPrim = evalPrim
-  case predArgTypes pcSchema of
+  M.io (prepareQuery evo modEnv pc) >>= \case
     Left msg -> return (Nothing, ProverError msg)
-    Right ts -> do when pcVerbose $ lPutStrLn "Simulating..."
-                   prims <- M.getPrimMap
-                   runRes <- runFn $ do
-                               (args, asms) <- runWriterT (mapM tyFn ts)
-                               (safety,b) <- doSBVEval evo $
-                                   do env <- Eval.evalDecls SBV extDgs mempty
-                                      v <- Eval.evalExpr SBV env pcExpr
-                                      Eval.fromVBit <$> foldM Eval.fromVFun v (map pure args)
-                               return (foldr addAsm (SBV.svAnd safety b) asms)
-                   let (firstProver, results) = runRes
-                   esatexprs <- case results of
-                     -- allSat can return more than one as long as
-                     -- they're satisfiable
-                     (SBV.Satisfiable {} : _) -> do
-                       tevss <- mapM mkTevs results
-                       return $ AllSatResult tevss
-                       where
-                         mkTevs result = do
-                           let Right (_, cvs) = SBV.getModelAssignment result
-                               (vs, _) = parseValues ts cvs
-                               sattys = unFinType <$> ts
-                           satexprs <-
-                             doEval evo (zipWithM (Concrete.toExpr prims) sattys vs)
-                           case zip3 sattys <$> (sequence satexprs) <*> pure vs of
-                             Nothing ->
-                               panic "Cryptol.Symbolic.sat"
-                                 [ "unable to make assignment into expression" ]
-                             Just tevs -> return $ tevs
-                     -- prove returns only one
-                     [SBV.Unsatisfiable {}] ->
-                       return $ ThmResult (unFinType <$> ts)
-                     -- unsat returns empty
-                     [] -> return $ ThmResult (unFinType <$> ts)
-                     -- otherwise something is wrong
-                     _ -> return $ ProverError (rshow results)
-                            where rshow | isSat = show .  SBV.AllSatResult . (False,False,False,)
-                                        | otherwise = show . SBV.ThmResult . head
-                   return (firstProver, esatexprs)
+    Right (ts, q) ->
+      do (firstProver, results) <- runProver pc q
+         esatexprs <- processResults evo pc ts results
+         return (firstProver, esatexprs)
 
+-- | Execute a symbolic ':prove' or ':sat' command when the prover is
+--   set to offline.  This only prepares the SMT input file for the
+--   solver and does not actually invoke the solver.
+--
+--   This method returns either an error message or the text of
+--   the SMT input file corresponding to the given prover command.
 satProveOffline :: ProverCommand -> M.ModuleCmd (Either String String)
-satProveOffline ProverCommand {..} =
+satProveOffline pc@ProverCommand {..} =
   protectStack (\msg (_,modEnv) -> return (Right (Left msg, modEnv), [])) $
   \(evOpts,modEnv) -> do
     let isSat = case pcQueryType of
           ProveQuery -> False
           SatQuery _ -> True
-    let extDgs = M.allDeclGroups modEnv ++ pcExtraDecls
-    let tyFn = if isSat then existsFinType else forallFinType
-    let addAsm = if isSat then SBV.svAnd else \x y -> SBV.svOr (SBV.svNot x) y
-    let ?evalPrim = evalPrim
-    case predArgTypes pcSchema of
+
+    prepareQuery evOpts modEnv pc >>= \case
       Left msg -> return (Right (Left msg, modEnv), [])
-      Right ts ->
-        do when pcVerbose $ logPutStrLn (Eval.evalLogger evOpts) "Simulating..."
-           smtlib <- SBV.generateSMTBenchmark isSat $ do
-             (args, asms) <- runWriterT (mapM tyFn ts)
-             (safety,b) <- doSBVEval evOpts $
-                             do env <- Eval.evalDecls SBV extDgs mempty
-                                v <- Eval.evalExpr SBV env pcExpr
-                                (Eval.fromVBit <$> foldM Eval.fromVFun v (map pure args))
-             return (foldr addAsm (SBV.svAnd safety b) asms)
+      Right (_ts, q) ->
+        do smtlib <- SBV.generateSMTBenchmark isSat q
            return (Right (Right smtlib, modEnv), [])
+
 
 protectStack :: (String -> M.ModuleCmd a)
              -> M.ModuleCmd a
@@ -253,12 +339,18 @@ protectStack mkErr cmd modEnv =
         msg = "Symbolic evaluation failed to terminate."
         handler () = mkErr msg modEnv
 
+-- | Given concrete values from the solver and a collection of finite types,
+--   reconstruct Cryptol concrete values, and return any unused solver
+--   values.
 parseValues :: [FinType] -> [SBV.CV] -> ([Concrete.Value], [SBV.CV])
 parseValues [] cvs = ([], cvs)
 parseValues (t : ts) cvs = (v : vs, cvs'')
   where (v, cvs') = parseValue t cvs
         (vs, cvs'') = parseValues ts cvs'
 
+-- | Parse a single value of a finite type by consuming some number of
+--   solver values.  The parsed Cryptol values is returned along with
+--   any solver values not consumed.
 parseValue :: FinType -> [SBV.CV] -> (Concrete.Value, [SBV.CV])
 parseValue FTBit [] = panic "Cryptol.Symbolic.parseValue" [ "empty FTBit" ]
 parseValue FTBit (cv : cvs) = (Eval.VBit (SBV.cvToBool cv), cvs)

--- a/tests/issues/issue066.icry.stdout
+++ b/tests/issues/issue066.icry.stdout
@@ -4,10 +4,12 @@ it : {result : Bit, arg1 : [4]}
 
 Run-time error: no counterexample available
 True
+Counterexample
 f 0xc = False
 it : {result : Bit, arg1 : [4]}
 {arg1 = 0xc, result = False}
 False
+Satisfiable
 f 0x3 = True
 it : {result : Bit, arg1 : [4]}
 {arg1 = 0x3, result = True}
@@ -16,17 +18,21 @@ Unsatisfiable
 it : {result : Bit, arg1 : [4]}
 
 Run-time error: no satisfying assignment available
+Counterexample
 g {x = 0xffffffff, y = 0x00000000} = False
 it : {result : Bit, arg1 : {x : [32], y : [32]}}
 {arg1 = {x = 0xffffffff, y = 0x00000000}, result = False}
+Satisfiable
 g {x = 0x00000000, y = 0x00000000} = True
 it : {result : Bit, arg1 : {x : [32], y : [32]}}
 {arg1 = {x = 0x00000000, y = 0x00000000}, result = True}
+Counterexample
 h 0x00 0x00 = False
 it : {result : Bit, arg1 : [8], arg2 : [8]}
 {arg1 = 0x00, arg2 = 0x00, result = False}
 0x00
 0x00
+Satisfiable
 h 0x00 0x01 = True
 it : {result : Bit, arg1 : [8], arg2 : [8]}
 {arg1 = 0x00, arg2 = 0x01, result = True}

--- a/tests/issues/issue072.icry.stdout
+++ b/tests/issues/issue072.icry.stdout
@@ -1,6 +1,9 @@
 Loading module Cryptol
+Satisfiable
 it : {result : Bit, arg1 : [4]}
+Satisfiable
 it : [11]{result : Bit, arg1 : [4]}
 must be an integer > 0 or "all"
 must be an integer > 0 or "all"
+Satisfiable
 it : [3]{result : Bit, arg1 : [4]}

--- a/tests/issues/issue093.icry.stdout
+++ b/tests/issues/issue093.icry.stdout
@@ -19,12 +19,16 @@ Testing... f0 = False
 :prove t2
 	Q.E.D.
 :prove f0
-	f0 = False
+	Counterexample
+f0 = False
 :sat t0
-	t0 = True
+	Satisfiable
+t0 = True
 :sat t1
-	t1 0x00000000 = True
+	Satisfiable
+t1 0x00000000 = True
 :sat t2
-	t2 0xfffffffe 0xffffffff = True
+	Satisfiable
+t2 0xfffffffe 0xffffffff = True
 :sat f0
 	Unsatisfiable

--- a/tests/issues/issue135.icry.stdout
+++ b/tests/issues/issue135.icry.stdout
@@ -1,3 +1,4 @@
 Loading module Cryptol
+Satisfiable
 (\(x : Bit) (y : Bit) -> x < y) False True = True
 Q.E.D.

--- a/tests/issues/issue148.icry.stdout
+++ b/tests/issues/issue148.icry.stdout
@@ -1,4 +1,5 @@
 Loading module Cryptol
 Loading module Cryptol
 Loading module Main
+Satisfiable
 (\(e : [64]) -> (e @@ [8 .. 24]) != zero) 0x00feff8000000000 = True

--- a/tests/issues/issue407.icry.stdout
+++ b/tests/issues/issue407.icry.stdout
@@ -3,6 +3,7 @@ Loading module Cryptol
  [False, False, False, False, True, ...],
  [False, False, True, True, False, ...],
  [False, True, False, True, False, ...]]
+Counterexample
 (\(x : [4]) -> (transpose [x ...]) @ 0 @ 0 == False) 0x8 = False
 Q.E.D.
 Q.E.D.

--- a/tests/issues/issue474.icry.stdout
+++ b/tests/issues/issue474.icry.stdout
@@ -1,2 +1,3 @@
 Loading module Cryptol
+Satisfiable
 (\x -> mapped x == 'N') 0x41 = True

--- a/tests/issues/issue702.icry.stdout
+++ b/tests/issues/issue702.icry.stdout
@@ -1,5 +1,7 @@
 Loading module Cryptol
+Satisfiable
 (\(x : {b : Bit, a : Bit}) -> x.a && x.b)
   {a = True, b = True} = True
+Satisfiable
 (\(x : {b : [8], a : Bit}) -> x.b == 0 /\ x.a)
   {a = True, b = 0x00} = True

--- a/tests/issues/issue725.icry
+++ b/tests/issues/issue725.icry
@@ -1,0 +1,14 @@
+:set show-examples = no
+:set prover-stats=no
+
+:set prover=z3
+
+:prove \(n:Integer, p : Bit) -> p ==> (x != x where x = 2 ^^ n)
+:sat \(a:[8], b:[8]) -> a == ~zero /\ a@b == False
+:prove \(a:[8], b:[8]) -> a == zero ==> a@b == False
+
+:set prover=w4-z3
+
+:prove \(n:Integer, p : Bit) -> p ==> (x != x where x = 2 ^^ n)
+:sat \(a:[8], b:[8]) -> a == ~zero /\ a@b == False
+:prove \(a:[8], b:[8]) -> a == zero ==> a@b == False

--- a/tests/issues/issue725.icry.stdout
+++ b/tests/issues/issue725.icry.stdout
@@ -1,0 +1,9 @@
+Loading module Cryptol
+
+operation can not be supported on symbolic values: integer exponentiation
+Unsatisfiable
+Counterexample
+
+operation can not be supported on symbolic values: integer exponentiation
+Unsatisfiable
+Counterexample

--- a/tests/issues/trac289.icry.stdout
+++ b/tests/issues/trac289.icry.stdout
@@ -2,5 +2,6 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module Main
 Q.E.D.
+Counterexample
 av1 0xfdffffe0 0x7fffffe0 = False
 Q.E.D.

--- a/tests/regression/r03.icry.stdout
+++ b/tests/regression/r03.icry.stdout
@@ -1,4 +1,6 @@
 Loading module Cryptol
 Loading module r03
+Satisfiable
 True
+Counterexample
 False


### PR DESCRIPTION
Makes the SBV symbolic backends more strict about error checking.  This behavior now matches the current what4 backend behaviors.

First: untranslatable symbolic expressions cause a more severe class of error which refuses to translate the expression altogether.

Second: safety predicates are automatically included in both `:prove` and `:sat` queries.  So, a proof will only succeed if the safety condition is proved, and a `:sat` will only hold for inputs which validate the safety condition.

Soon, we will be making the second type of behavior configurable.  Moreover, our goal is to eliminate the potential for behavior of the first sort.