### PR TITLE
Serialize nightly windows builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
           ghc-version: "8.8"
 
       - shell: bash
-        run: cabal v2-build exe:cryptol exe:cryptol-html
+        run: cabal -j1 v2-build exe:cryptol exe:cryptol-html
 
       - shell: bash
         run: .github/ci.sh setup_dist_bins


### PR DESCRIPTION
In the latest nightly build, [here](https://github.com/GaloisInc/cryptol/actions/runs/116299915), windows failed. I had originally traced this back down to a problem with ghc 8.8 and windows not getting along super well but missed fixing this in the `nightly.yml` file. This corrects that omission.