### PR TITLE
Fix Array.cry comment.

### DIFF
--- a/lib/Array.cry
+++ b/lib/Array.cry
@@ -3,8 +3,6 @@
  * Distributed under the terms of the BSD3 license (see LICENSE file)
  */
 
-/** The type and operations of the theory of arrays. */
-
 module Array where
 
 primitive type Array : * -> * -> *

--- a/tests/regression/array.icry
+++ b/tests/regression/array.icry
@@ -1,0 +1,3 @@
+:module Array
+:browse Array
+

--- a/tests/regression/array.icry.stdout
+++ b/tests/regression/array.icry.stdout
@@ -1,0 +1,20 @@
+Loading module Cryptol
+Loading module Array
+Primitive Types
+===============
+
+  Public
+  ------
+
+    Array : * -> * -> *
+
+Symbols
+=======
+
+  Public
+  ------
+
+    arrayConstant : {a, b} b -> Array a b
+    arrayLookup : {a, b} Array a b -> a -> b
+    arrayUpdate : {a, b} Array a b -> a -> b -> Array a b
+


### PR DESCRIPTION
Fixes this error:
```
Cryptol> :module Array

Parse error at Array:8:1,
  unexpected: module
  expected: a declaration
```