### PR TITLE
Split Cmp

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -404,6 +404,34 @@ primitive trunc : {a} (Round a) => a -> Integer
 primitive round : {a} (Round a) => a -> Integer
 
 
+// The Eq class ----------------------------------------------------
+
+/** Value types that support equality comparisons. */
+primitive type Eq : * -> Prop
+
+/**
+ * Compares any two values of the same type for equality.
+ */
+primitive (==) : {a} (Eq a) => a -> a -> Bit
+
+/**
+ * Compares any two values of the same type for inequality.
+ */
+primitive (!=) : {a} (Eq a) => a -> a -> Bit
+
+/**
+ * Compare the outputs of two functions for equality.
+ */
+(===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> (a -> Bit)
+f === g = \ x -> f x == g x
+
+/**
+ * Compare the outputs of two functions for inequality.
+ */
+(!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> (a -> Bit)
+f !== g = \x -> f x != g x
+
+
 // The Cmp class ---------------------------------------------------
 
 /** Value types that support equality and ordering comparisons. */
@@ -436,28 +464,6 @@ primitive (<=) : {a} (Cmp a) => a -> a -> Bit
  * Bitvectors are compared using unsigned arithmetic.
  */
 primitive (>=) : {a} (Cmp a) => a -> a -> Bit
-
-/**
- * Compares any two values of the same type for equality.
- */
-primitive (==) : {a} (Cmp a) => a -> a -> Bit
-
-/**
- * Compares any two values of the same type for inequality.
- */
-primitive (!=) : {a} (Cmp a) => a -> a -> Bit
-
-/**
- * Compare the outputs of two functions for equality.
- */
-(===) : {a, b} (Cmp b) => (a -> b) -> (a -> b) -> (a -> Bit)
-f === g = \ x -> f x == g x
-
-/**
- * Compare the outputs of two functions for inequality.
- */
-(!==) : {a, b} (Cmp b) => (a -> b) -> (a -> b) -> (a -> Bit)
-f !== g = \x -> f x != g x
 
 /**
  * Returns the smaller of two comparable arguments.

--- a/src/Cryptol/Eval/Backend.hs
+++ b/src/Cryptol/Eval/Backend.hs
@@ -621,32 +621,3 @@ class MonadIO (SEval sym) => Backend sym where
     SInteger sym ->
     SInteger sym ->
     SEval sym (SBit sym)
-
-
-  -- ==== Z_n operations defined via projection to the integers ====
-
-  -- | Less-than test of integers modulo n.  Note this test
-  --   first computes the reduced integers and compares.
-  znLessThan ::
-    sym ->
-    Integer {- ^ modulus -} ->
-    SInteger sym ->
-    SInteger sym ->
-    SEval sym (SBit sym)
-  znLessThan sym m x y =
-    do x' <- znToInt sym m x
-       y' <- znToInt sym m y
-       intLessThan sym x' y'
-
-  -- | Greater-than test of integers modulo n.  Note this test
-  --   first computes the reduced integers and compares.
-  znGreaterThan ::
-    sym ->
-    Integer {- ^ modulus -} ->
-    SInteger sym ->
-    SInteger sym ->
-    SEval sym (SBit sym)
-  znGreaterThan sym m x y =
-    do x' <- znToInt sym m x
-       y' <- znToInt sym m y
-       intGreaterThan sym x' y'

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -689,7 +689,7 @@ valLt sym ty v1 v2 final = cmpValue sym fb fw fi fz fq ty v1 v2 (pure final)
   fb x y k   = lexCombine sym (bitLessThan  sym x y) (bitEq  sym x y) k
   fw x y k   = lexCombine sym (wordLessThan sym x y) (wordEq sym x y) k
   fi x y k   = lexCombine sym (intLessThan  sym x y) (intEq  sym x y) k
-  fz m x y k = lexCombine sym (znLessThan sym m x y) (znEq sym m x y) k
+  fz _ _ _ _ = panic "valLt" ["Z_n is not in `Cmp`"]
   fq x y k   = lexCombine sym (rationalLessThan sym x y) (rationalEq sym x y) k
 
 {-# INLINE valGt #-}
@@ -700,7 +700,7 @@ valGt sym ty v1 v2 final = cmpValue sym fb fw fi fz fq ty v1 v2 (pure final)
   fb x y k   = lexCombine sym (bitGreaterThan  sym x y) (bitEq  sym x y) k
   fw x y k   = lexCombine sym (wordGreaterThan sym x y) (wordEq sym x y) k
   fi x y k   = lexCombine sym (intGreaterThan  sym x y) (intEq  sym x y) k
-  fz m x y k = lexCombine sym (znGreaterThan sym m x y) (znEq sym m x y) k
+  fz _ _ _ _ = panic "valGt" ["Z_n is not in `Cmp`"]
   fq x y k   = lexCombine sym (rationalGreaterThan sym x y) (rationalEq sym x y) k
 
 {-# INLINE eqCombine #-}

--- a/src/Cryptol/TypeCheck/SimpleSolver.hs
+++ b/src/Cryptol/TypeCheck/SimpleSolver.hs
@@ -9,7 +9,8 @@ import Cryptol.TypeCheck.Solver.Numeric(cryIsEqual, cryIsNotEqual, cryIsGeq)
 import Cryptol.TypeCheck.Solver.Class
   ( solveZeroInst, solveLogicInst, solveRingInst
   , solveIntegralInst, solveFieldInst, solveRoundInst
-  , solveCmpInst, solveSignedCmpInst, solveLiteralInst )
+  , solveEqInst, solveCmpInst, solveSignedCmpInst
+  , solveLiteralInst )
 
 import Cryptol.Utils.Debug(ppTrace)
 import Cryptol.TypeCheck.PP
@@ -46,7 +47,8 @@ simplifyStep ctxt prop =
     TCon (PC PIntegral) [ty]   -> solveIntegralInst ty
     TCon (PC PRound) [ty]      -> solveRoundInst ty
 
-    TCon (PC PCmp)   [ty]      -> solveCmpInst   ty
+    TCon (PC PEq)    [ty]      -> solveEqInst ty
+    TCon (PC PCmp)   [ty]      -> solveCmpInst ty
     TCon (PC PSignedCmp) [ty]  -> solveSignedCmpInst ty
     TCon (PC PLiteral) [t1,t2] -> solveLiteralInst t1 t2
 

--- a/src/Cryptol/TypeCheck/Solver/Class.hs
+++ b/src/Cryptol/TypeCheck/Solver/Class.hs
@@ -257,8 +257,9 @@ solveCmpInst ty = case tNoUser ty of
   -- Cmp Rational
   TCon (TC TCRational) [] -> SolvedIf []
 
-  -- Cmp (Z n)
-  TCon (TC TCIntMod) [n] -> SolvedIf [ pFin n, n >== tOne ]
+  -- Cmp (Z n) fails
+  TCon (TC TCIntMod) [_] ->
+    Unsolvable $ TCErrorMessage "Values of Z_n type cannot be compared for order"
 
   -- (fin n, Cmp a) => Cmp [n]a
   TCon (TC TCSeq) [n,a] -> SolvedIf [ pFin n, pCmp a ]

--- a/src/Cryptol/TypeCheck/Solver/Numeric/Interval.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric/Interval.hs
@@ -108,11 +108,11 @@ propInterval varInts prop = catMaybes
        x  <- tIsVar ty
        return (x,iAnyFin)
 
-  , do (l,r) <- pIsEq prop
+  , do (l,r) <- pIsEqual prop
        x     <- tIsVar l
        return (x,typeInterval varInts r)
 
-  , do (l,r) <- pIsEq prop
+  , do (l,r) <- pIsEqual prop
        x     <- tIsVar r
        return (x,typeInterval varInts l)
 

--- a/src/Cryptol/TypeCheck/TCon.hs
+++ b/src/Cryptol/TypeCheck/TCon.hs
@@ -67,6 +67,7 @@ builtInType nm =
     , "Integral"          ~> PC PIntegral
     , "Field"             ~> PC PField
     , "Round"             ~> PC PRound
+    , "Eq"                ~> PC PEq
     , "Cmp"               ~> PC PCmp
     , "SignedCmp"         ~> PC PSignedCmp
     , "Literal"           ~> PC PLiteral
@@ -147,6 +148,7 @@ instance HasKind PC where
       PIntegral  -> KType :-> KProp
       PField     -> KType :-> KProp
       PRound     -> KType :-> KProp
+      PEq        -> KType :-> KProp
       PCmp       -> KType :-> KProp
       PSignedCmp -> KType :-> KProp
       PLiteral   -> KNum :-> KType :-> KProp
@@ -193,6 +195,7 @@ data PC     = PEqual        -- ^ @_ == _@
             | PIntegral     -- ^ @Integral _@
             | PField        -- ^ @Field _@
             | PRound        -- ^ @Round _@
+            | PEq           -- ^ @Eq _@
             | PCmp          -- ^ @Cmp _@
             | PSignedCmp    -- ^ @SignedCmp _@
             | PLiteral      -- ^ @Literal _ _@
@@ -295,6 +298,7 @@ instance PP PC where
       PIntegral  -> text "Integral"
       PField     -> text "Field"
       PRound     -> text "Round"
+      PEq        -> text "Eq"
       PCmp       -> text "Cmp"
       PSignedCmp -> text "SignedCmp"
       PLiteral   -> text "Literal"
@@ -337,5 +341,3 @@ instance PP TFun where
       TCCeilDiv         -> text "/^"
       TCCeilMod         -> text "%^"
       TCLenFromThenTo   -> text "lengthFromThenTo"
-
-

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -290,13 +290,13 @@ superclassSet (TCon (PC p0) [t]) = go p0
   where
   super p = Set.insert (TCon (PC p) [t]) (go p)
 
-  go PRing     = super PZero
-  go PLogic    = super PZero
-  go PField    = super PRing
-  go PIntegral = super PRing
-  go PRound    = super PField <> super PCmp
---  go PCmp = super PEq
---  go PSignedCmp = super PEq
+  go PRing      = super PZero
+  go PLogic     = super PZero
+  go PField     = super PRing
+  go PIntegral  = super PRing
+  go PRound     = super PField <> super PCmp
+  go PCmp       = super PEq
+  go PSignedCmp = super PEq
   go _ = mempty
 
 superclassSet _ = mempty
@@ -430,10 +430,10 @@ pIsGeq ty = case tNoUser ty of
               TCon (PC PGeq) [t1,t2] -> Just (t1,t2)
               _                      -> Nothing
 
-pIsEq :: Prop -> Maybe (Type,Type)
-pIsEq ty = case tNoUser ty of
-             TCon (PC PEqual) [t1,t2] -> Just (t1,t2)
-             _                        -> Nothing
+pIsEqual :: Prop -> Maybe (Type,Type)
+pIsEqual ty = case tNoUser ty of
+                TCon (PC PEqual) [t1,t2] -> Just (t1,t2)
+                _                        -> Nothing
 
 pIsZero :: Prop -> Maybe Type
 pIsZero ty = case tNoUser ty of
@@ -464,6 +464,11 @@ pIsRound :: Prop -> Maybe Type
 pIsRound ty = case tNoUser ty of
                      TCon (PC PRound) [t1] -> Just t1
                      _                     -> Nothing
+
+pIsEq :: Prop -> Maybe Type
+pIsEq ty = case tNoUser ty of
+             TCon (PC PEq) [t1] -> Just t1
+             _                  -> Nothing
 
 pIsCmp :: Prop -> Maybe Type
 pIsCmp ty = case tNoUser ty of
@@ -643,6 +648,9 @@ pField t = TCon (PC PField) [t]
 
 pRound :: Type -> Prop
 pRound t = TCon (PC PRound) [t]
+
+pEq :: Type -> Prop
+pEq t = TCon (PC PEq) [t]
 
 pCmp :: Type -> Prop
 pCmp t = TCon (PC PCmp) [t]

--- a/tests/issues/issue226.icry.stdout
+++ b/tests/issues/issue226.icry.stdout
@@ -43,6 +43,7 @@ Primitive Types
     (^^) : # -> # -> #
     Bit : *
     Cmp : * -> Prop
+    Eq : * -> Prop
     Field : * -> Prop
     fin : # -> Prop
     Integer : *
@@ -76,10 +77,10 @@ Symbols
     (==>) : Bit -> Bit -> Bit
     (\/) : Bit -> Bit -> Bit
     (/\) : Bit -> Bit -> Bit
-    (!=) : {a} (Cmp a) => a -> a -> Bit
-    (!==) : {a, b} (Cmp b) => (a -> b) -> (a -> b) -> a -> Bit
-    (==) : {a} (Cmp a) => a -> a -> Bit
-    (===) : {a, b} (Cmp b) => (a -> b) -> (a -> b) -> a -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
     (<) : {a} (Cmp a) => a -> a -> Bit
     (<$) : {a} (SignedCmp a) => a -> a -> Bit
     (<=) : {a} (Cmp a) => a -> a -> Bit

--- a/tests/regression/superclass.icry.stdout
+++ b/tests/regression/superclass.icry.stdout
@@ -5,6 +5,6 @@ Loading module Main
 (trunc (recip (fromInteger 5))) : {a} (Round a) => Integer
 (\x -> x < fromInteger (floor (recip x))) : {a} (Round a) =>
                                               a -> Bit
-(\x -> x == zero /. x) : {a} (Cmp a, Field a) => a -> Bit
-(zero == ~zero) : {a} (Cmp a, Logic a) => Bit
+(\x -> x == zero /. x) : {a} (Eq a, Field a) => a -> Bit
+(zero == ~zero) : {a} (Eq a, Logic a) => Bit
 (\x -> toInteger (x + zero)) : {a} (Integral a) => a -> Integer


### PR DESCRIPTION
This PR implements a new `Eq` class that contains just the equality operations and sets is up as a superclass of `Cmp` and `SignedCmp`.  The `Z n` types become a member of `Eq`, but not `Cmp`.  Other types are unchanged.  The current comparisons on `Z n` can be recovered by explicitly passing to `Integer` via `fromZ`.
