### PR TITLE
Implement `roundToEven` and `roundAway`

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -395,13 +395,20 @@ primitive floor : {a} (Round a) => a -> Integer
 primitive trunc : {a} (Round a) => a -> Integer
 
 /**
- * Round to the nearest integer.
+ * Round to the nearest integer, ties away from 0.
  *
  * Ties are broken away from 0.  For nonnegative 'x'
  * this is 'floor (x + 0.5)'.  For negative 'x' this
  * is 'ceiling (x - 0.5)'.
  */
-primitive round : {a} (Round a) => a -> Integer
+primitive roundAway : {a} (Round a) => a -> Integer
+
+/**
+ * Round to the nearest integer, ties to even.
+ *
+ * Ties are broken to the nearest even integer.
+ */
+primitive roundToEven : {a} (Round a) => a -> Integer
 
 
 // The Eq class ----------------------------------------------------

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -172,8 +172,10 @@ primTable = let sym = Concrete in
                     unary (ceilingV sym))
   , ("trunc"      , {-# SCC "Prelude::trunc" #-}
                     unary (truncV sym))
-  , ("round"      , {-# SCC "Prelude::round" #-}
-                    unary (roundV sym))
+  , ("roundAway"  , {-# SCC "Prelude::roundAway" #-}
+                    unary (roundAwayV sym))
+  , ("roundToEven", {-# SCC "Prelude::roundToEven" #-}
+                    unary (roundToEvenV sym))
 
     -- Bitvector specific operations
   , ("/$"         , {-# SCC "Prelude::(/$)" #-}

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -552,11 +552,17 @@ truncV sym = roundOp sym "trunc" opq
   where
   opq = rationalTrunc sym
 
-{-# INLINE roundV #-}
-roundV :: Backend sym => sym -> Unary sym
-roundV sym = roundOp sym "round" opq
+{-# INLINE roundAwayV #-}
+roundAwayV :: Backend sym => sym -> Unary sym
+roundAwayV sym = roundOp sym "roundAway" opq
   where
-  opq = rationalRound sym
+  opq = rationalRoundAway sym
+
+{-# INLINE roundToEvenV #-}
+roundToEvenV :: Backend sym => sym -> Unary sym
+roundToEvenV sym = roundOp sym "roundToEven" opq
+  where
+  opq = rationalRoundToEven sym
 
 --------------------------------------------------------------
 -- Logic

--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -619,7 +619,8 @@ by corresponding typeclasses
 >   , ("floor"      , unary (roundUnary floor))
 >   , ("ceiling"    , unary (roundUnary ceiling))
 >   , ("trunc"      , unary (roundUnary truncate))
->   , ("round"      , unary (roundUnary roundRat))
+>   , ("roundAway"  , unary (roundUnary roundAwayRat))
+>   , ("roundToEven", unary (roundUnary round))
 >
 >   -- Comparison
 >   , ("<"          , binary (cmpOrder (\o -> o == LT)))
@@ -1117,8 +1118,8 @@ Round
 Haskell's definition of "round" is slightly different, as it does
 "round to even" on ties.
 
-> roundRat :: Rational -> Integer
-> roundRat x
+> roundAwayRat :: Rational -> Integer
+> roundAwayRat x
 >   | x >= 0    = floor (x + 0.5)
 >   | otherwise = ceiling (x - 0.5)
 

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -379,7 +379,8 @@ primTable  = let sym = SBV in
   , ("floor"       , unary (floorV sym))
   , ("ceiling"     , unary (ceilingV sym))
   , ("trunc"       , unary (truncV sym))
-  , ("round"       , unary (roundV sym))
+  , ("roundAway"   , unary (roundAwayV sym))
+  , ("roundToEven" , unary (roundToEvenV sym))
 
     -- Word operations
   , ("/$"          , sdivV sym)

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -435,7 +435,8 @@ primTable w4sym = let sym = What4 w4sym in
   , ("floor"       , unary (floorV sym))
   , ("ceiling"     , unary (ceilingV sym))
   , ("trunc"       , unary (truncV sym))
-  , ("round"       , unary (roundV sym))
+  , ("roundAway"   , unary (roundAwayV sym))
+  , ("roundToEven" , unary (roundToEvenV sym))
 
     -- Word operations
   , ("/$"          , sdivV sym)

--- a/src/Cryptol/Prelude.hs
+++ b/src/Cryptol/Prelude.hs
@@ -32,4 +32,3 @@ arrayContents = B.pack [there|lib/Array.cry|]
 
 cryptolTcContents :: String
 cryptolTcContents = [there|lib/CryptolTC.z3|]
-

--- a/tests/issues/T146.icry.stdout
+++ b/tests/issues/T146.icry.stdout
@@ -3,14 +3,14 @@ Loading module Cryptol
 Loading module Main
 
 [error] at T146.cry:1:18--6:10:
-  The type ?fv`950 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`934
+  The type ?fv`951 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`935
   where
-  ?fv`950 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
-  fv`934 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`951 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
+  fv`935 is signature variable 'fv' at T146.cry:11:10--11:12
 [error] at T146.cry:5:19--5:24:
-  The type ?fv`952 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`934
+  The type ?fv`953 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`935
   where
-  ?fv`952 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
-  fv`934 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`953 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
+  fv`935 is signature variable 'fv' at T146.cry:11:10--11:12

--- a/tests/issues/issue226.icry.stdout
+++ b/tests/issues/issue226.icry.stdout
@@ -167,7 +167,8 @@ Symbols
     recip : {a} (Field a) => a -> a
     repeat : {n, a} a -> [n]a
     reverse : {n, a} (fin n) => [n]a -> [n]a
-    round : {a} (Round a) => a -> Integer
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
     sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
     scanl : {n, b, a} (b -> a -> b) -> b -> [n]a -> [1 + n]b
     scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b

--- a/tests/issues/issue290v2.icry.stdout
+++ b/tests/issues/issue290v2.icry.stdout
@@ -4,9 +4,9 @@ Loading module Main
 
 [error] at issue290v2.cry:2:1--2:19:
   Unsolved constraints:
-    • n`931 == 1
+    • n`932 == 1
         arising from
         checking a pattern: type of 1st argument of Main::minMax
         at issue290v2.cry:2:8--2:11
   where
-  n`931 is signature variable 'n' at issue290v2.cry:1:11--1:12
+  n`932 is signature variable 'n' at issue290v2.cry:1:11--1:12

--- a/tests/issues/issue723.icry.stdout
+++ b/tests/issues/issue723.icry.stdout
@@ -12,9 +12,9 @@ Loading module Main
       assuming
         • fin k
       the following constraints hold:
-        • k >= n`931
+        • k >= n`932
             arising from
             matching types
             at issue723.cry:7:17--7:19
   where
-  n`931 is signature variable 'n' at issue723.cry:1:6--1:7
+  n`932 is signature variable 'n' at issue723.cry:1:6--1:7


### PR DESCRIPTION
The old `round` operation is renamed into `roundAway` to make its
semantics more obvious.