### PR TITLE
Disable builds on windows for which there's a memory leak

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ghc: ["8.4.4", "8.6.5", "8.8.3", "8.10.1"]
+        exclude:
+          # The process-1.6.8 library contains a memory leak on windows,
+          # causing RAM constrained builds to sometimes fail.
+          # Technically, windows+GHC 8.10.1 should also likely be excluded, but
+          # we use GHC 8.10.1 for releases currently.
+          #
+          # https://gitlab.haskell.org/ghc/ghc/-/issues/17926
+          # TODO: remove when 8.8.4 and 8.10.2 are released
+          - os: windows-latest
+            ghc: 8.8.3
     name: Cryptol - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Look at me, submitting a PR that touches less than 20 files. What a concept.

[A bug in GHC](https://gitlab.haskell.org/ghc/ghc/-/issues/17926) (more accurately, `process-1.6.8`) makes building with ghc 8.8.3 on windows inside a RAM constrained environment somewhat finicky. This also technically affects 8.10 as well, but it seems to be more reliable about things so far, so we'll see how that one goes.

If necessary, I'll go back to building the releases with 8.6.5 so that we can turn off windows+ghc 8.8.3 without making the yaml files super ugly.