### PR TITLE
Implement and use a new RecordMap type

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -91,6 +91,7 @@ library
 
                        Cryptol.Utils.Fixity,
                        Cryptol.Utils.Ident,
+                       Cryptol.Utils.RecordMap,
                        Cryptol.Utils.PP,
                        Cryptol.Utils.Panic,
                        Cryptol.Utils.Debug,

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -52,7 +52,6 @@ import Cryptol.Utils.PP
 import Cryptol.Utils.RecordMap
 
 import           Control.Monad
-import           Data.Functor.Identity
 import           Data.List
 import           Data.Maybe
 import qualified Data.Map.Strict as Map
@@ -466,9 +465,8 @@ etaDelay sym msg env0 Forall{ sVars = vs0, sType = tp0 } = goTpVars env0 vs0
       TVRec fs ->
           do v' <- sDelay sym (Just msg) (fromVRecord <$> v)
              let err f = evalPanic "expected record value with field" [show f]
-             let eta f t = Identity (go t =<< (fromMaybe (err f) . lookupField f <$> v'))
-             let fs' = runIdentity (traverseRecordMap eta fs)
-             return $ VRecord fs'
+             let eta f t = go t =<< (fromMaybe (err f) . lookupField f <$> v')
+             return $ VRecord (mapWithFieldName eta fs)
 
       TVAbstract {} -> v
 

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -715,9 +715,9 @@ cmpValue sym fb fw fi fz fq ff = cmp
                                [ "Functions are not comparable" ]
         TVTuple tys   -> cmpValues tys (fromVTuple v1) (fromVTuple v2) k
         TVRec fields  -> cmpValues
-                            (map snd (canonicalFields fields))
-                            (map snd (canonicalFields (fromVRecord v1)))
-                            (map snd (canonicalFields (fromVRecord v2)))
+                            (recordElements fields)
+                            (recordElements (fromVRecord v1))
+                            (recordElements (fromVRecord v2))
                             k
         TVAbstract {} -> evalPanic "cmpValue"
                           [ "Abstract type not in `Cmp`" ]

--- a/src/Cryptol/IR/FreeVars.hs
+++ b/src/Cryptol/IR/FreeVars.hs
@@ -101,7 +101,7 @@ instance FreeVars Expr where
     case expr of
       EList es t        -> freeVars es <> freeVars t
       ETuple es         -> freeVars es
-      ERec fs           -> freeVars (map snd (canonicalFields fs))
+      ERec fs           -> freeVars (recordElements fs)
       ESel e _          -> freeVars e
       ESet e _ v        -> freeVars [e,v]
       EIf e1 e2 e3      -> freeVars [e1,e2,e3]
@@ -138,7 +138,7 @@ instance FreeVars Type where
       TVar tv -> freeVars tv
 
       TUser _ _ t -> freeVars t
-      TRec fs     -> freeVars (map snd (canonicalFields fs))
+      TRec fs     -> freeVars (recordElements fs)
 
 
 instance FreeVars TVar where

--- a/src/Cryptol/IR/FreeVars.hs
+++ b/src/Cryptol/IR/FreeVars.hs
@@ -11,6 +11,7 @@ import           Data.Map ( Map )
 import qualified Data.Map as Map
 
 import Cryptol.TypeCheck.AST
+import Cryptol.Utils.RecordMap
 
 data Deps = Deps { valDeps  :: Set Name
                    -- ^ Undefined value names
@@ -100,7 +101,7 @@ instance FreeVars Expr where
     case expr of
       EList es t        -> freeVars es <> freeVars t
       ETuple es         -> freeVars es
-      ERec fs           -> freeVars (map snd fs)
+      ERec fs           -> freeVars (map snd (canonicalFields fs))
       ESel e _          -> freeVars e
       ESet e _ v        -> freeVars [e,v]
       EIf e1 e2 e3      -> freeVars [e1,e2,e3]
@@ -137,7 +138,7 @@ instance FreeVars Type where
       TVar tv -> freeVars tv
 
       TUser _ _ t -> freeVars t
-      TRec fs     -> freeVars (map snd fs)
+      TRec fs     -> freeVars (map snd (canonicalFields fs))
 
 
 instance FreeVars TVar where

--- a/src/Cryptol/ModuleSystem/InstantiateModule.hs
+++ b/src/Cryptol/ModuleSystem/InstantiateModule.hs
@@ -184,7 +184,7 @@ instance Inst Expr where
 
         EList xs t                -> EList (inst env xs) (inst env t)
         ETuple es                 -> ETuple (inst env es)
-        ERec xs                   -> ERec [ (f,go e) | (f,e) <- xs ]
+        ERec xs                   -> ERec (fmap go xs)
         ESel e s                  -> ESel (go e) s
         ESet e x v                -> ESet (go e) x (go v)
         EIf e1 e2 e3              -> EIf (go e1) (go e2) (go e3)
@@ -240,7 +240,7 @@ instance Inst Type where
           _ -> ty
       TUser x ts t  -> TUser y (inst env ts) (inst env t)
         where y = Map.findWithDefault x x (tyNameMap env)
-      TRec fs       -> TRec [ (f, inst env t) | (f,t) <- fs ]
+      TRec fs       -> TRec (fmap (inst env) fs)
 
 instance Inst TCon where
   inst env tc =

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -844,7 +844,7 @@ patternEnv  = go
 
   go PWild            = return mempty
   go (PTuple ps)      = bindVars ps
-  go (PRecord fs)     = bindVars (fmap (snd . snd) (canonicalFields fs))
+  go (PRecord fs)     = bindVars (fmap snd (recordElements fs))
   go (PList ps)       = foldMap go ps
   go (PTyped p ty)    = go p `mappend` typeEnv ty
   go (PSplit a b)     = go a `mappend` go b
@@ -889,7 +889,7 @@ patternEnv  = go
                 n   <- liftSupply (mkParameter (getIdent pn) loc)
                 return (singletonT pn n)
 
-  typeEnv (TRecord fs)      = bindTypes (map (snd.snd) (canonicalFields fs))
+  typeEnv (TRecord fs)      = bindTypes (map snd (recordElements fs))
   typeEnv (TTyApp fs)       = bindTypes (map value fs)
   typeEnv (TTuple ts)       = bindTypes ts
   typeEnv TWild             = return mempty

--- a/src/Cryptol/Parser/Names.hs
+++ b/src/Cryptol/Parser/Names.hs
@@ -78,7 +78,7 @@ namesE expr =
     EComplement e -> namesE e
     EGenerate e   -> namesE e
     ETuple es     -> Set.unions (map namesE es)
-    ERecord fs    -> Set.unions (map (namesE . snd . snd) (canonicalFields fs))
+    ERecord fs    -> Set.unions (map (namesE . snd) (recordElements fs))
     ESel e _      -> namesE e
     EUpd mb fs    -> let e = maybe Set.empty namesE mb
                      in Set.unions (e : map namesUF fs)
@@ -116,7 +116,7 @@ namesP pat =
     PVar x        -> [x]
     PWild         -> []
     PTuple ps     -> namesPs ps
-    PRecord fs    -> namesPs (map (snd . snd) (canonicalFields fs))
+    PRecord fs    -> namesPs (map snd (recordElements fs))
     PList ps      -> namesPs ps
     PTyped p _    -> namesP p
     PSplit p1 p2  -> namesPs [p1,p2]
@@ -194,7 +194,7 @@ tnamesE expr =
     EComplement e   -> tnamesE e
     EGenerate e     -> tnamesE e
     ETuple es       -> Set.unions (map tnamesE es)
-    ERecord fs      -> Set.unions (map (tnamesE . snd . snd) (canonicalFields fs))
+    ERecord fs      -> Set.unions (map (tnamesE . snd) (recordElements fs))
     ESel e _        -> tnamesE e
     EUpd mb fs      -> let e = maybe Set.empty tnamesE mb
                        in Set.unions (e : map tnamesUF fs)
@@ -233,7 +233,7 @@ tnamesP pat =
     PVar _        -> Set.empty
     PWild         -> Set.empty
     PTuple ps     -> Set.unions (map tnamesP ps)
-    PRecord fs    -> Set.unions (map (tnamesP . snd . snd) (canonicalFields fs))
+    PRecord fs    -> Set.unions (map (tnamesP . snd) (recordElements fs))
     PList ps      -> Set.unions (map tnamesP ps)
     PTyped p t    -> Set.union (tnamesP p) (tnamesT t)
     PSplit p1 p2  -> Set.union (tnamesP p1) (tnamesP p2)
@@ -267,7 +267,7 @@ tnamesT ty =
     TNum _        -> Set.empty
     TChar __      -> Set.empty
     TTuple ts     -> Set.unions (map tnamesT ts)
-    TRecord fs    -> Set.unions (map (tnamesT . snd . snd) (canonicalFields fs))
+    TRecord fs    -> Set.unions (map (tnamesT . snd) (recordElements fs))
     TTyApp fs     -> Set.unions (map (tnamesT . value) fs)
     TLocated t _  -> tnamesT t
     TUser x ts    -> Set.insert x (Set.unions (map tnamesT ts))

--- a/src/Cryptol/Parser/NoPat.hs
+++ b/src/Cryptol/Parser/NoPat.hs
@@ -99,12 +99,12 @@ noPat pat =
          return (pTy r x ty, zipWith getN as [0..] ++ concat dss)
 
     PRecord fs ->
-      do (as,dss) <- unzip `fmap` mapM (noPat . snd . snd) (canonicalFields fs)
+      do let (shape, els) = unzip (canonicalFields fs)
+         (as,dss) <- unzip `fmap` mapM (noPat . snd) els
          x <- newName
          r <- getRange
-         let shape    = map fst (canonicalFields fs)
-             ty       = TRecord (fmap (\(rng,_) -> (rng,TWild)) fs)
-             getN a n = sel a x (RecordSel n (Just shape))
+         let ty           = TRecord (fmap (\(rng,_) -> (rng,TWild)) fs)
+             getN a n     = sel a x (RecordSel n (Just shape))
          return (pTy r x ty, zipWith getN as shape ++ concat dss)
 
     PTyped p t ->

--- a/src/Cryptol/Parser/Position.hs
+++ b/src/Cryptol/Parser/Position.hs
@@ -22,7 +22,7 @@ import Control.DeepSeq
 import Cryptol.Utils.PP
 
 data Located a  = Located { srcRange :: !Range, thing :: !a }
-                  deriving (Eq, Show, Generic, NFData)
+                  deriving (Eq, Ord, Show, Generic, NFData)
 
 
 data Position   = Position { line :: !Int, col :: !Int }
@@ -31,7 +31,7 @@ data Position   = Position { line :: !Int, col :: !Int }
 data Range      = Range { from   :: !Position
                         , to     :: !Position
                         , source :: FilePath }
-                  deriving (Eq, Show, Generic, NFData)
+                  deriving (Eq, Ord, Show, Generic, NFData)
 
 -- | An empty range.
 --

--- a/src/Cryptol/Parser/Utils.hs
+++ b/src/Cryptol/Parser/Utils.hs
@@ -18,7 +18,6 @@ module Cryptol.Parser.Utils
 
 import Cryptol.Parser.AST
 
-
 widthIdent :: Ident
 widthIdent  = mkIdent "width"
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -75,9 +75,10 @@ import qualified Cryptol.TypeCheck.Parseable as T
 import qualified Cryptol.TypeCheck.Subst as T
 import           Cryptol.TypeCheck.Solve(defaultReplExpr)
 import qualified Cryptol.TypeCheck.Solver.SMT as SMT
-import Cryptol.TypeCheck.PP (dump,ppWithNames,emptyNameMap)
-import Cryptol.Utils.PP
-import Cryptol.Utils.Panic(panic)
+import           Cryptol.TypeCheck.PP (dump,ppWithNames,emptyNameMap)
+import           Cryptol.Utils.PP
+import           Cryptol.Utils.Panic(panic)
+import           Cryptol.Utils.RecordMap
 import qualified Cryptol.Parser.AST as P
 import qualified Cryptol.Transform.Specialize as S
 import Cryptol.Symbolic
@@ -488,8 +489,8 @@ qcCmd qcMode str =
         case (tys,vs) of
           ([t],[v]) -> bindItVariableVal t v
           _ -> let fs = [ M.packIdent ("arg" ++ show (i::Int)) | i <- [ 1 .. ] ]
-                   t = T.TRec (zip fs tys)
-                   v = E.VRecord (Map.fromList (zip fs (map return vs)))
+                   t = T.TRec (recordFromFields (zip fs tys))
+                   v = E.VRecord (recordFromFields (zip fs (map return vs)))
                in bindItVariableVal t v
 
       FailError err [] -> do
@@ -802,8 +803,8 @@ mkSolverResult thing result earg =
          eFalse = T.ePrim prims (M.prelPrim "False")
          resultE = if result then eTrue else eFalse
 
-         rty = T.TRec $ [(rIdent, T.tBit )] ++ map fst argF
-         re  = T.ERec $ [(rIdent, resultE)] ++ map snd argF
+         rty = T.TRec (recordFromFields $ [(rIdent, T.tBit )] ++ map fst argF)
+         re  = T.ERec (recordFromFields $ [(rIdent, resultE)] ++ map snd argF)
 
      return (rty, re)
   where

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -374,7 +374,7 @@ varBlockingPred sym evalFn v =
 
     VarFinSeq _n vs -> computeBlockingPred sym evalFn vs
     VarTuple vs     -> computeBlockingPred sym evalFn vs
-    VarRecord fs    -> computeBlockingPred sym evalFn (map snd (canonicalFields fs))
+    VarRecord fs    -> computeBlockingPred sym evalFn (recordElements fs)
 
 computeModel ::
   Eval.EvalOpts ->

--- a/src/Cryptol/Transform/AddModParams.hs
+++ b/src/Cryptol/Transform/AddModParams.hs
@@ -16,6 +16,7 @@ import Cryptol.Parser.Position(thing)
 import Cryptol.ModuleSystem.Name(toParamInstName,asParamName,nameIdent
                                 ,paramModRecParam)
 import Cryptol.Utils.Ident(paramInstModName)
+import Cryptol.Utils.RecordMap(recordFromFields)
 
 {-
 Note that we have to be careful when doing this transformation on
@@ -182,7 +183,7 @@ type Inp = (Set Name, Params)
 
 
 paramRecTy :: Params -> Type
-paramRecTy ps = tRec [ (nameIdent x, t) | (x,t) <- pFuns ps ]
+paramRecTy ps = tRec (recordFromFields [ (nameIdent x, t) | (x,t) <- pFuns ps ])
 
 
 nameInst :: Inp -> Name -> [Type] -> Int -> Expr
@@ -231,7 +232,7 @@ instance Inst Expr where
 
      EList es t -> EList (inst ps es) (inst ps t)
      ETuple es -> ETuple (inst ps es)
-     ERec fs   -> ERec [ (f,inst ps e) | (f,e) <- fs ]
+     ERec fs   -> ERec (fmap (inst ps) fs)
      ESel e s  -> ESel (inst ps e) s
      ESet e s v -> ESet (inst ps e) s (inst ps v)
 
@@ -301,7 +302,7 @@ instance Inst Type where
       TVar x | Just x' <- isTParam ps x -> TVar (TVBound x')
              | otherwise  -> ty
 
-      TRec xs -> TRec [ (f,inst ps t) | (f,t) <- xs ]
+      TRec xs -> TRec (fmap (inst ps) xs)
 
 instance Inst TySyn where
   inst ps ts = ts { tsConstraints = inst ps (tsConstraints ts)

--- a/src/Cryptol/Transform/MonoValues.hs
+++ b/src/Cryptol/Transform/MonoValues.hs
@@ -181,8 +181,7 @@ rewE rews = go
 
       EList es t      -> EList   <$> mapM go es <*> return t
       ETuple es       -> ETuple  <$> mapM go es
-      ERec fs         -> ERec    <$> (forM fs $ \(f,e) -> do e1 <- go e
-                                                             return (f,e1))
+      ERec fs         -> ERec    <$> traverse go fs
       ESel e s        -> ESel    <$> go e  <*> return s
       ESet e s v      -> ESet    <$> go e  <*> return s <*> go v
       EIf e1 e2 e3    -> EIf     <$> go e1 <*> go e2 <*> go e3

--- a/src/Cryptol/Transform/Specialize.hs
+++ b/src/Cryptol/Transform/Specialize.hs
@@ -72,7 +72,7 @@ specializeExpr expr =
   case expr of
     EList es t    -> EList <$> traverse specializeExpr es <*> pure t
     ETuple es     -> ETuple <$> traverse specializeExpr es
-    ERec fs       -> ERec <$> traverse (traverseSnd specializeExpr) fs
+    ERec fs       -> ERec <$> traverse specializeExpr fs
     ESel e s      -> ESel <$> specializeExpr e <*> pure s
     ESet e s v    -> ESet <$> specializeExpr e <*> pure s <*> specializeExpr v
     EIf e1 e2 e3  -> EIf <$> specializeExpr e1 <*> specializeExpr e2 <*> specializeExpr e3

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -37,6 +37,7 @@ import Cryptol.Parser.AST ( Selector(..),Pragma(..)
                           , Import(..), ImportSpec(..), ExportType(..)
                           , Fixity(..))
 import Cryptol.Utils.Ident (Ident,isInfixIdent,ModName,PrimIdent,prelPrim)
+import Cryptol.Utils.RecordMap
 import Cryptol.TypeCheck.PP
 import Cryptol.TypeCheck.Type
 
@@ -103,7 +104,7 @@ data ModVParam = ModVParam
 
 data Expr   = EList [Expr] Type         -- ^ List value (with type of elements)
             | ETuple [Expr]             -- ^ Tuple value
-            | ERec [(Ident,Expr)]       -- ^ Record value
+            | ERec (RecordMap Ident Expr) -- ^ Record value
             | ESel Expr Selector        -- ^ Elimination for tuple/record/list
             | ESet Expr Selector Expr   -- ^ Change the value of a field.
 
@@ -206,7 +207,7 @@ instance PP (WithNames Expr) where
       ETuple es     -> parens $ sep $ punctuate comma $ map ppW es
 
       ERec fs       -> braces $ sep $ punctuate comma
-                        [ pp f <+> text "=" <+> ppW e | (f,e) <- fs ]
+                        [ pp f <+> text "=" <+> ppW e | (f,e) <- displayFields fs ]
 
       ESel e sel    -> ppWP 4 e <+> text "." <.> pp sel
 

--- a/src/Cryptol/TypeCheck/Error.hs
+++ b/src/Cryptol/TypeCheck/Error.hs
@@ -18,6 +18,7 @@ import Cryptol.TypeCheck.InferTypes
 import Cryptol.TypeCheck.Subst
 import Cryptol.ModuleSystem.Name(Name)
 import Cryptol.Utils.Ident(Ident)
+import Cryptol.Utils.RecordMap
 
 cleanupErrors :: [(Range,Error)] -> [(Range,Error)]
 cleanupErrors = dropErrorsFromSameLoc
@@ -327,8 +328,8 @@ instance PP (WithNames Error) where
     mismatchHint (TRec fs1) (TRec fs2) =
       hint "Missing" missing $$ hint "Unexpected" extra
       where
-        missing = map fst fs1 \\ map fst fs2
-        extra   = map fst fs2 \\ map fst fs1
+        missing = displayOrder fs1 \\ displayOrder fs2
+        extra   = displayOrder fs2 \\ displayOrder fs1
         hint _ []  = mempty
         hint s [x] = text s <+> text "field" <+> pp x
         hint s xs  = text s <+> text "fields" <+> commaSep (map pp xs)

--- a/src/Cryptol/TypeCheck/Parseable.hs
+++ b/src/Cryptol/TypeCheck/Parseable.hs
@@ -19,6 +19,7 @@ module Cryptol.TypeCheck.Parseable
 
 import Cryptol.TypeCheck.AST
 import Cryptol.Utils.Ident (Ident,unpackIdent)
+import Cryptol.Utils.RecordMap (canonicalFields)
 import Cryptol.Parser.AST ( Located(..))
 import Cryptol.ModuleSystem.Name
 import Text.PrettyPrint hiding ((<>))
@@ -32,7 +33,7 @@ class ShowParseable t where
 instance ShowParseable Expr where
   showParseable (EList es _) = parens (text "EList" <+> showParseable es)
   showParseable (ETuple es) = parens (text "ETuple" <+> showParseable es)
-  showParseable (ERec ides) = parens (text "ERec" <+> showParseable ides)
+  showParseable (ERec ides) = parens (text "ERec" <+> showParseable (canonicalFields ides))
   showParseable (ESel e s) = parens (text "ESel" <+> showParseable e <+> showParseable s)
   showParseable (ESet e s v) = parens (text "ESet" <+>
                                 showParseable e <+> showParseable s
@@ -61,7 +62,7 @@ instance ShowParseable Ident where
 
 instance ShowParseable Type where
   showParseable (TUser n lt t) = parens (text "TUser" <+> showParseable n <+> showParseable lt <+> showParseable t)
-  showParseable (TRec lidt) = parens (text "TRec" <+> showParseable lidt)
+  showParseable (TRec lidt) = parens (text "TRec" <+> showParseable (canonicalFields lidt))
   showParseable t = parens $ text $ show t
 
 instance ShowParseable Selector where

--- a/src/Cryptol/TypeCheck/Sanity.hs
+++ b/src/Cryptol/TypeCheck/Sanity.hs
@@ -71,7 +71,7 @@ checkType ty =
     TVar tv -> lookupTVar tv
 
     TRec fs ->
-      do forM_ (canonicalFields fs) $ \(_,t) ->
+      do forM_ fs $ \t ->
            do k <- checkType t
               unless (k == KType) $ reportError $ KindMismatch KType k
          return KType
@@ -296,7 +296,7 @@ checkHas t sel =
           do case mb of
                Nothing -> return ()
                Just fs1 ->
-                 do let ns  = map fst $ canonicalFields fs
+                 do let ns  = Set.toList (fieldSet fs)
                         ns1 = sort fs1
                     unless (ns == ns1) $
                       reportError $ UnexpectedRecordShape ns1 ns
@@ -369,10 +369,8 @@ convertible t1 t2 = go t1 t2
          TRec fs ->
            case other of
              TRec gs ->
-               do let fs1   = canonicalFields fs
-                      gs1   = canonicalFields gs
-                  unless (map fst fs1 == map fst gs1) err
-                  goMany (map snd fs1) (map snd gs1)
+               do unless (fieldSet fs == fieldSet gs) err
+                  goMany (recordElements fs) (recordElements gs)
              _ -> err
 
 

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -19,7 +19,7 @@ tRebuild' withUser = go
         | withUser  -> TUser x xs (go t)
         | otherwise -> go t
       TVar _        -> ty
-      TRec xs       -> TRec [ (x, go y) | (x, y) <- xs ]
+      TRec xs       -> TRec (fmap go xs)
       TCon tc ts    -> tCon tc (map go ts)
 
 tRebuild :: Type -> Type

--- a/src/Cryptol/TypeCheck/Solver/Class.hs
+++ b/src/Cryptol/TypeCheck/Solver/Class.hs
@@ -30,7 +30,7 @@ import Cryptol.TypeCheck.Type
 import Cryptol.TypeCheck.SimpType (tAdd,tWidth)
 import Cryptol.TypeCheck.Solver.Types
 import Cryptol.TypeCheck.PP
-
+import Cryptol.Utils.RecordMap
 
 {- | This places constraints on the floating point numbers that
 we can work with.  This is a bit of an odd check, as it is really
@@ -98,7 +98,7 @@ solveZeroInst ty = case tNoUser ty of
   TCon (TC (TCTuple _)) es -> SolvedIf [ pZero e | e <- es ]
 
   -- (Zero a, Zero b) => Zero { x1 : a, x2 : b }
-  TRec fs -> SolvedIf [ pZero ety | (_,ety) <- fs ]
+  TRec fs -> SolvedIf [ pZero ety | (_,ety) <- canonicalFields fs ]
 
   _ -> Unsolved
 
@@ -122,7 +122,7 @@ solveLogicInst ty = case tNoUser ty of
   TCon (TC (TCTuple _)) es -> SolvedIf [ pLogic e | e <- es ]
 
   -- (Logic a, Logic b) => Logic { x1 : a, x2 : b }
-  TRec fs -> SolvedIf [ pLogic ety | (_,ety) <- fs ]
+  TRec fs -> SolvedIf [ pLogic ety | (_,ety) <- canonicalFields fs ]
 
   _ -> Unsolved
 
@@ -159,7 +159,7 @@ solveRingInst ty = case tNoUser ty of
   TCon (TC TCFloat) [e,p] -> SolvedIf [ pValidFloat e p ]
 
   -- (Ring a, Ring b) => Ring { x1 : a, x2 : b }
-  TRec fs -> SolvedIf [ pRing ety | (_,ety) <- fs ]
+  TRec fs -> SolvedIf [ pRing ety | (_,ety) <- canonicalFields fs ]
 
   _ -> Unsolved
 
@@ -284,7 +284,7 @@ solveEqInst ty = case tNoUser ty of
     Unsolvable $ TCErrorMessage "Comparisons may not be performed on functions."
 
   -- (Eq a, Eq b) => Eq { x:a, y:b }
-  TRec fs -> SolvedIf [ pEq e | (_,e) <- fs ]
+  TRec fs -> SolvedIf [ pEq e | (_,e) <- canonicalFields fs ]
 
   _ -> Unsolved
 
@@ -323,7 +323,7 @@ solveCmpInst ty = case tNoUser ty of
     Unsolvable $ TCErrorMessage "Comparisons may not be performed on functions."
 
   -- (Cmp a, Cmp b) => Cmp { x:a, y:b }
-  TRec fs -> SolvedIf [ pCmp e | (_,e) <- fs ]
+  TRec fs -> SolvedIf [ pCmp e | (_,e) <- canonicalFields fs ]
 
   _ -> Unsolved
 
@@ -364,7 +364,7 @@ solveSignedCmpInst ty = case tNoUser ty of
     Unsolvable $ TCErrorMessage "Signed comparisons may not be performed on functions."
 
   -- (SignedCmp a, SignedCmp b) => SignedCmp { x:a, y:b }
-  TRec fs -> SolvedIf [ pSignedCmp e | (_,e) <- fs ]
+  TRec fs -> SolvedIf [ pSignedCmp e | (_,e) <- canonicalFields fs ]
 
   _ -> Unsolved
 

--- a/src/Cryptol/TypeCheck/Solver/Class.hs
+++ b/src/Cryptol/TypeCheck/Solver/Class.hs
@@ -98,7 +98,7 @@ solveZeroInst ty = case tNoUser ty of
   TCon (TC (TCTuple _)) es -> SolvedIf [ pZero e | e <- es ]
 
   -- (Zero a, Zero b) => Zero { x1 : a, x2 : b }
-  TRec fs -> SolvedIf [ pZero ety | (_,ety) <- canonicalFields fs ]
+  TRec fs -> SolvedIf [ pZero ety | ety <- recordElements fs ]
 
   _ -> Unsolved
 
@@ -122,7 +122,7 @@ solveLogicInst ty = case tNoUser ty of
   TCon (TC (TCTuple _)) es -> SolvedIf [ pLogic e | e <- es ]
 
   -- (Logic a, Logic b) => Logic { x1 : a, x2 : b }
-  TRec fs -> SolvedIf [ pLogic ety | (_,ety) <- canonicalFields fs ]
+  TRec fs -> SolvedIf [ pLogic ety | ety <- recordElements fs ]
 
   _ -> Unsolved
 
@@ -159,7 +159,7 @@ solveRingInst ty = case tNoUser ty of
   TCon (TC TCFloat) [e,p] -> SolvedIf [ pValidFloat e p ]
 
   -- (Ring a, Ring b) => Ring { x1 : a, x2 : b }
-  TRec fs -> SolvedIf [ pRing ety | (_,ety) <- canonicalFields fs ]
+  TRec fs -> SolvedIf [ pRing ety | ety <- recordElements fs ]
 
   _ -> Unsolved
 
@@ -284,7 +284,7 @@ solveEqInst ty = case tNoUser ty of
     Unsolvable $ TCErrorMessage "Comparisons may not be performed on functions."
 
   -- (Eq a, Eq b) => Eq { x:a, y:b }
-  TRec fs -> SolvedIf [ pEq e | (_,e) <- canonicalFields fs ]
+  TRec fs -> SolvedIf [ pEq e | e <- recordElements fs ]
 
   _ -> Unsolved
 
@@ -323,7 +323,7 @@ solveCmpInst ty = case tNoUser ty of
     Unsolvable $ TCErrorMessage "Comparisons may not be performed on functions."
 
   -- (Cmp a, Cmp b) => Cmp { x:a, y:b }
-  TRec fs -> SolvedIf [ pCmp e | (_,e) <- canonicalFields fs ]
+  TRec fs -> SolvedIf [ pCmp e | e <- recordElements fs ]
 
   _ -> Unsolved
 
@@ -364,7 +364,7 @@ solveSignedCmpInst ty = case tNoUser ty of
     Unsolvable $ TCErrorMessage "Signed comparisons may not be performed on functions."
 
   -- (SignedCmp a, SignedCmp b) => SignedCmp { x:a, y:b }
-  TRec fs -> SolvedIf [ pSignedCmp e | (_,e) <- canonicalFields fs ]
+  TRec fs -> SolvedIf [ pSignedCmp e | e <- recordElements fs ]
 
   _ -> Unsolved
 

--- a/src/Cryptol/TypeCheck/Solver/Selector.hs
+++ b/src/Cryptol/TypeCheck/Solver/Selector.hs
@@ -17,6 +17,7 @@ import Cryptol.TypeCheck.Monad( InferM, unify, newGoals, lookupNewtype
 import Cryptol.TypeCheck.Subst (listParamSubst, apSubst)
 import Cryptol.Utils.Ident (Ident, packIdent)
 import Cryptol.Utils.Panic(panic)
+import Cryptol.Utils.RecordMap
 
 import Control.Monad(forM,guard)
 
@@ -26,7 +27,7 @@ recordType labels =
   do fields <- forM labels $ \l ->
         do t <- newType (TypeOfRecordField l) KType
            return (l,t)
-     return (TRec fields)
+     return (TRec (recordFromFields fields))
 
 tupleType :: Int -> InferM Type
 tupleType n =
@@ -64,7 +65,7 @@ solveSelector sel outerT =
 
     (RecordSel l _, ty) ->
       case ty of
-        TRec fs  -> return (lookup l fs)
+        TRec fs  -> return (lookupField l fs)
         TCon (TC TCSeq) [len,el] -> liftSeq len el
         TCon (TC TCFun) [t1,t2]  -> liftFun t1 t2
         TCon (TC (TCNewtype (UserTC x _))) ts ->

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -211,9 +211,7 @@ apSubstMaybe su ty =
 
     TUser f ts t  -> do t1 <- apSubstMaybe su t
                         return (TUser f (map (apSubst su) ts) t1)
-    TRec fs       -> TRec `fmap` anyJust fld fs
-      where fld (x,t) = do t1 <- apSubstMaybe su t
-                           return (x,t1)
+    TRec fs       -> TRec `fmap` (anyJust (apSubstMaybe su) fs)
     TVar x -> applySubstToVar su x
 
 lookupSubst :: TVar -> Subst -> Maybe Type
@@ -336,7 +334,7 @@ instance TVars Expr where
         EVar {}       -> expr
 
         ETuple es     -> ETuple (map go es)
-        ERec fs       -> ERec [ (f, go e) | (f,e) <- fs ]
+        ERec fs       -> ERec (fmap go fs)
         ESet e x v    -> ESet (go e) x (go v)
         EList es t    -> EList (map go es) (apSubst su t)
         ESel e s      -> ESel (go e) s

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -732,7 +732,7 @@ instance FVS Type where
         TCon _ ts   -> fvs ts
         TVar x      -> Set.singleton x
         TUser _ _ t -> go t
-        TRec fs     -> fvs (map snd (canonicalFields fs))
+        TRec fs     -> fvs (recordElements fs)
 
 instance FVS a => FVS (Maybe a) where
   fvs Nothing  = Set.empty

--- a/src/Cryptol/TypeCheck/TypeMap.hs
+++ b/src/Cryptol/TypeCheck/TypeMap.hs
@@ -145,6 +145,9 @@ instance TrieMap TypeMap Type where
     [ (TVar x,           v) | (x,v)   <- toListTM (tvar m) ] ++
     [ (TCon c ts,        v) | (c,m1)  <- toListTM (tcon m)
                             , (ts,v)  <- toListTM m1 ] ++
+
+    -- NB: this step loses 'displayOrder' information.
+    --  It's not clear if we should try to fix this.
     [ (TRec (recordFromFields (zip fs ts)), v)
           | (fs,m1) <- toListTM (trec m)
           , (ts,v)  <- toListTM m1 ]
@@ -160,6 +163,8 @@ instance TrieMap TypeMap Type where
                              (\ts a -> f (TCon c ts) a) l) (tcon m)
        , trec = mapWithKeyTM (\fs l -> mapMaybeWithKeyTM
                              (\ts a -> f (TRec (recordFromFields (zip fs ts))) a) l) (trec m)
+                               -- NB: this step loses 'displayOrder' information.
+                               --  It's not clear if we should try to fix this.
        }
 
 

--- a/src/Cryptol/TypeCheck/TypePat.hs
+++ b/src/Cryptol/TypeCheck/TypePat.hs
@@ -32,6 +32,7 @@ import Control.Applicative((<|>))
 import Control.Monad
 import Cryptol.Utils.Ident (Ident)
 import Cryptol.Utils.Patterns
+import Cryptol.Utils.RecordMap
 import Cryptol.TypeCheck.Type
 import Cryptol.TypeCheck.Solver.InfNat
 
@@ -147,7 +148,7 @@ aTuple = \a -> case tNoUser a of
                  TCon (TC (TCTuple _)) ts -> return ts
                  _                        -> mzero
 
-aRec :: Pat Type [(Ident, Type)]
+aRec :: Pat Type (RecordMap Ident Type)
 aRec = \a -> case tNoUser a of
                TRec fs -> return fs
                _       -> mzero

--- a/src/Cryptol/TypeCheck/Unify.hs
+++ b/src/Cryptol/TypeCheck/Unify.hs
@@ -72,10 +72,7 @@ mgu t1 t2
   isNum = k1 == KNum
 
 mgu (TRec fs1) (TRec fs2)
-  | ns1 == ns2 = mguMany ts1 ts2
-  where
-  (ns1,ts1)  = unzip (canonicalFields fs1)
-  (ns2,ts2)  = unzip (canonicalFields fs2)
+  | fieldSet fs1 == fieldSet fs2 = mguMany (recordElements fs1) (recordElements fs2)
 
 mgu t1 t2
   | not (k1 == k2)  = uniError $ UniKindMismatch k1 k2

--- a/src/Cryptol/TypeCheck/Unify.hs
+++ b/src/Cryptol/TypeCheck/Unify.hs
@@ -13,10 +13,9 @@ module Cryptol.TypeCheck.Unify where
 
 import Cryptol.TypeCheck.AST
 import Cryptol.TypeCheck.Subst
+import Cryptol.Utils.RecordMap
 
 import Control.Monad.Writer (Writer, writer, runWriter)
-import Data.Ord(comparing)
-import Data.List(sortBy)
 import qualified Data.Set as Set
 
 import Prelude ()
@@ -75,9 +74,8 @@ mgu t1 t2
 mgu (TRec fs1) (TRec fs2)
   | ns1 == ns2 = mguMany ts1 ts2
   where
-  (ns1,ts1)  = sortFields fs1
-  (ns2,ts2)  = sortFields fs2
-  sortFields = unzip . sortBy (comparing fst)
+  (ns1,ts1)  = unzip (canonicalFields fs1)
+  (ns2,ts2)  = unzip (canonicalFields fs2)
 
 mgu t1 t2
   | not (k1 == k2)  = uniError $ UniKindMismatch k1 k2

--- a/src/Cryptol/Utils/RecordMap.hs
+++ b/src/Cryptol/Utils/RecordMap.hs
@@ -18,24 +18,26 @@
 module Cryptol.Utils.RecordMap
   ( RecordMap
   , displayOrder
+  , canonicalFields
+  , displayFields
+  , recordElements
+  , fieldSet
   , recordFromFields
   , recordFromFieldsErr
   , recordFromFieldsWithDisplay
-  , canonicalFields
-  , displayFields
   , lookupField
   , adjustField
   , traverseRecordMap
-  , mapRecordFields
+  , mapWithFieldName
   , zipRecordsM
   , zipRecords
   , recordMapAccum
-  )
-where
+  ) where
 
 import           Control.DeepSeq
 import           Control.Monad.Except
 import           Data.Functor.Identity
+import           Data.Set (Set)
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Map.Merge.Strict as Map
@@ -50,9 +52,12 @@ import Cryptol.Utils.Panic
 data RecordMap a b =
   RecordMap
   { recordMap :: !(Map a b)
-  , displayOrder :: [a]
-    -- ^ The order in which the fields originally appeared
+  , _displayOrder :: [a]
   }
+-- RecordMap Invariant:
+--   The `displayOrder` field should contain exactly the
+--   same set of field names as the keys of `recordMap`.
+--   Moreover, each field name should occur at most once.
 
 instance (Ord a, Eq b) => Eq (RecordMap a b) where
   a == b = recordMap a == recordMap b
@@ -65,6 +70,38 @@ instance (Show a, Ord a, Show b) => Show (RecordMap a b) where
 
 instance (NFData a, NFData b) => NFData (RecordMap a b) where
   rnf = rnf . canonicalFields 
+
+
+-- | Return the fields in this record as a set.
+fieldSet :: Ord a => RecordMap a b -> Set a
+fieldSet r = Map.keysSet (recordMap r)
+
+-- | The order in which the fields originally appeared.
+displayOrder :: RecordMap a b -> [a]
+displayOrder r = _displayOrder r
+
+-- | Retrieve the elements of the record in canonical order
+--   of the field names
+recordElements :: RecordMap a b -> [b]
+recordElements = map snd . canonicalFields
+
+-- | Return a list of field/value pairs in canonical order.
+canonicalFields :: RecordMap a b -> [(a,b)]
+canonicalFields = Map.toList . recordMap
+
+-- | Return a list of field/value pairs in display order.
+displayFields :: (Show a, Ord a) => RecordMap a b -> [(a,b)]
+displayFields r = map find (displayOrder r)
+  where
+  find x =
+    case Map.lookup x (recordMap r) of
+      Just v -> (x, v)
+      Nothing ->
+         panic "displayFields"
+               ["Could not find field in recordMap " ++ show x
+               , "Display order: " ++ show (displayOrder r)
+               , "Canonical order:" ++ show (map fst (canonicalFields r))
+               ]
 
 -- | Generate a record from a list of field/value pairs.
 --   Precondition: each field identifier appears at most
@@ -94,14 +131,13 @@ recordFromFieldsErr xs0 = loop mempty xs0
 --   list, and a field name appears in the display order iff it appears
 --   in the field list.
 recordFromFieldsWithDisplay :: (Show a, Ord a) => [a] -> [(a,b)] -> RecordMap a b
-recordFromFieldsWithDisplay dOrd fs = r { displayOrder = dOrd }
+recordFromFieldsWithDisplay dOrd fs = r { _displayOrder = dOrd }
   where
   r = recordFromFields fs
 
 -- | Lookup the value of a field
 lookupField :: Ord a => a -> RecordMap a b -> Maybe b
 lookupField x m = Map.lookup x (recordMap m)
-
 
 -- | Update the value of a field by applying the given function.
 --   If the field is not present in the record, return Nothing.
@@ -114,41 +150,25 @@ adjustField x f r = mkRec <$> Map.alterF f' x (recordMap r)
   f' Nothing = Nothing
   f' (Just v) = Just (Just (f v))
 
--- | Return a list of field/value pairs in canonical order
-canonicalFields :: RecordMap a b -> [(a,b)]
-canonicalFields = Map.toList . recordMap
-
--- | Return a list of field/value pairs in display order
-displayFields :: (Show a, Ord a) => RecordMap a b -> [(a,b)]
-displayFields r = map find (displayOrder r)
-  where
-  find x =
-    case Map.lookup x (recordMap r) of
-      Just v -> (x, v)
-      Nothing ->
-         panic "displayFields"
-               ["Could not find field in recordMap " ++ show x
-               , "Display order: " ++ show (displayOrder r)
-               , "Canonical order:" ++ show (map fst (canonicalFields r))
-               ]
-
+-- | Traverse the elements of the given record map in canonical
+--   order, applying the given action.
 traverseRecordMap :: Applicative t =>
   (a -> b -> t c) -> RecordMap a b -> t (RecordMap a c)
 traverseRecordMap f r =
   (\m -> RecordMap m (displayOrder r)) <$> Map.traverseWithKey f (recordMap r)
 
+-- | Apply the given function to each element of a record.
+mapWithFieldName :: (a -> b -> c) -> RecordMap a b -> RecordMap a c
+mapWithFieldName f = runIdentity . traverseRecordMap (\a b -> Identity (f a b))
+
 instance Functor (RecordMap a) where
-  fmap f = runIdentity . traverseRecordMap (\_ -> Identity . f)
+  fmap f = mapWithFieldName (\_ -> f)
 
 instance Foldable (RecordMap a) where
   foldMap f = foldMap (f . snd) . canonicalFields
 
 instance Traversable (RecordMap a) where
   traverse f = traverseRecordMap (\_ -> f)
-
-mapRecordFields :: Ord b => (a -> b) -> RecordMap a c -> RecordMap b c
-mapRecordFields f r =
-  RecordMap { recordMap = Map.mapKeys f (recordMap r), displayOrder = map f (displayOrder r) }
 
 -- | The function recordMapAccum threads an accumulating argument through
 --   the map in canonical order of fields.
@@ -176,6 +196,7 @@ zipRecordsM f r1 r2 = runExceptT (mkRec <$> zipMap (recordMap r1) (recordMap r2)
   missingRight = Map.traverseMissing (\a _c -> throwError (Right a))
   matched = Map.zipWithAMatched (\a b c -> lift (f a b c))
 
+-- | Pure version of `zipRecordsM`
 zipRecords :: forall a b c d. Ord a =>
   (a -> b -> c -> d) -> RecordMap a b -> RecordMap a c -> Either (Either a a) (RecordMap a d)
 zipRecords f r1 r2 = runIdentity (zipRecordsM (\a b c -> Identity (f a b c)) r1 r2)

--- a/src/Cryptol/Utils/RecordMap.hs
+++ b/src/Cryptol/Utils/RecordMap.hs
@@ -1,0 +1,181 @@
+-- |
+-- Module      :  Cryptol.Utils.PP
+-- Copyright   :  (c) 2020 Galois, Inc.
+-- License     :  BSD3
+-- Maintainer  :  cryptol@galois.com
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- This module implements an "order insensitive" datastructure for
+-- record types and values.  For most purposes, we want to deal with
+-- record fields in a canonical order; but for user interaction
+-- purposes, we generally want to display the fields in the order they
+-- were specified by the user (in source files, at the REPL, etc.).
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cryptol.Utils.RecordMap
+  ( RecordMap
+  , displayOrder
+  , recordFromFields
+  , recordFromFieldsErr
+  , recordFromFieldsWithDisplay
+  , canonicalFields
+  , displayFields
+  , lookupField
+  , adjustField
+  , traverseRecordMap
+  , mapRecordFields
+  , zipRecordsM
+  , zipRecords
+  , recordMapAccum
+  )
+where
+
+import           Control.DeepSeq
+import           Control.Monad.Except
+import           Data.Functor.Identity
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Map.Merge.Strict as Map
+
+import Cryptol.Utils.Panic
+
+-- | An "order insensitive" datastructure.
+--   The fields can be accesed either according
+--   to a "canonical" order, or based on a
+--   "display" order, which matches the order
+--   in which the fields were originally specified.
+data RecordMap a b =
+  RecordMap
+  { recordMap :: !(Map a b)
+  , displayOrder :: [a]
+    -- ^ The order in which the fields originally appeared
+  }
+
+instance (Ord a, Eq b) => Eq (RecordMap a b) where
+  a == b = recordMap a == recordMap b
+
+instance (Ord a, Ord b) => Ord (RecordMap a b) where
+  compare a b = compare (recordMap a) (recordMap b)
+
+instance (Show a, Ord a, Show b) => Show (RecordMap a b) where
+  show = show . displayFields
+
+instance (NFData a, NFData b) => NFData (RecordMap a b) where
+  rnf = rnf . canonicalFields 
+
+-- | Generate a record from a list of field/value pairs.
+--   Precondition: each field identifier appears at most
+--   once in the given list.
+recordFromFields :: (Show a, Ord a) => [(a,b)] -> RecordMap a b
+recordFromFields xs =
+  case recordFromFieldsErr xs of
+    Left (x,_) -> 
+          panic "recordFromFields"
+                ["Repeated field value: " ++ show x]
+    Right r -> r
+
+-- | Generate a record from a list of field/value pairs.
+--   If any field name is repeated, the first repeated name/value
+--   pair is returned.  Otherwise the constructed record is returned.
+recordFromFieldsErr :: (Show a, Ord a) => [(a,b)] -> Either (a,b) (RecordMap a b)
+recordFromFieldsErr xs0 = loop mempty xs0
+  where
+  loop m [] = Right (RecordMap m (map fst xs0))
+  loop m ((x,v):xs)
+    | Just _ <- Map.lookup x m = Left (x,v)
+    | otherwise = loop (Map.insert x v m) xs
+
+-- | Generate a record from a list of field/value pairs,
+--   and also provide the "display" order for the fields directly.
+--   Precondition: each field identifier appears at most once in each
+--   list, and a field name appears in the display order iff it appears
+--   in the field list.
+recordFromFieldsWithDisplay :: (Show a, Ord a) => [a] -> [(a,b)] -> RecordMap a b
+recordFromFieldsWithDisplay dOrd fs = r { displayOrder = dOrd }
+  where
+  r = recordFromFields fs
+
+-- | Lookup the value of a field
+lookupField :: Ord a => a -> RecordMap a b -> Maybe b
+lookupField x m = Map.lookup x (recordMap m)
+
+
+-- | Update the value of a field by applying the given function.
+--   If the field is not present in the record, return Nothing.
+adjustField :: forall a b. Ord a => a -> (b -> b) -> RecordMap a b -> Maybe (RecordMap a b)
+adjustField x f r = mkRec <$> Map.alterF f' x (recordMap r)
+  where
+  mkRec m = r{ recordMap = m }
+
+  f' :: Maybe b -> Maybe (Maybe b)
+  f' Nothing = Nothing
+  f' (Just v) = Just (Just (f v))
+
+-- | Return a list of field/value pairs in canonical order
+canonicalFields :: RecordMap a b -> [(a,b)]
+canonicalFields = Map.toList . recordMap
+
+-- | Return a list of field/value pairs in display order
+displayFields :: (Show a, Ord a) => RecordMap a b -> [(a,b)]
+displayFields r = map find (displayOrder r)
+  where
+  find x =
+    case Map.lookup x (recordMap r) of
+      Just v -> (x, v)
+      Nothing ->
+         panic "displayFields"
+               ["Could not find field in recordMap " ++ show x
+               , "Display order: " ++ show (displayOrder r)
+               , "Canonical order:" ++ show (map fst (canonicalFields r))
+               ]
+
+traverseRecordMap :: Applicative t =>
+  (a -> b -> t c) -> RecordMap a b -> t (RecordMap a c)
+traverseRecordMap f r =
+  (\m -> RecordMap m (displayOrder r)) <$> Map.traverseWithKey f (recordMap r)
+
+instance Functor (RecordMap a) where
+  fmap f = runIdentity . traverseRecordMap (\_ -> Identity . f)
+
+instance Foldable (RecordMap a) where
+  foldMap f = foldMap (f . snd) . canonicalFields
+
+instance Traversable (RecordMap a) where
+  traverse f = traverseRecordMap (\_ -> f)
+
+mapRecordFields :: Ord b => (a -> b) -> RecordMap a c -> RecordMap b c
+mapRecordFields f r =
+  RecordMap { recordMap = Map.mapKeys f (recordMap r), displayOrder = map f (displayOrder r) }
+
+-- | The function recordMapAccum threads an accumulating argument through
+--   the map in canonical order of fields.
+recordMapAccum :: (a -> b -> (a,c)) -> a -> RecordMap k b -> (a, RecordMap k c)
+recordMapAccum f z r = (a, r{ recordMap = m' })
+  where
+  (a, m') = Map.mapAccum f z (recordMap r)
+
+-- | Zip together the fields of two records using the provided action.
+--   If some field is present in one record, but not the other,
+--   an @Either a a@ will be returned, indicating which record is missing
+--   the field, and returning the name of the missing field.
+--
+--   The @displayOrder@ of the resulting record will be taken from the first
+--   argument (rather arbitrarily).
+zipRecordsM :: forall t a b c d. (Ord a, Monad t) =>
+  (a -> b -> c -> t d) -> RecordMap a b -> RecordMap a c -> t (Either (Either a a) (RecordMap a d))
+zipRecordsM f r1 r2 = runExceptT (mkRec <$> zipMap (recordMap r1) (recordMap r2))
+  where
+  mkRec m = RecordMap m (displayOrder r1)
+
+  zipMap :: Map a b -> Map a c -> ExceptT (Either a a) t (Map a d)
+  zipMap = Map.mergeA missingLeft missingRight matched
+  missingLeft  = Map.traverseMissing (\a _b -> throwError (Left a))
+  missingRight = Map.traverseMissing (\a _c -> throwError (Right a))
+  matched = Map.zipWithAMatched (\a b c -> lift (f a b c))
+
+zipRecords :: forall a b c d. Ord a =>
+  (a -> b -> c -> d) -> RecordMap a b -> RecordMap a c -> Either (Either a a) (RecordMap a d)
+zipRecords f r1 r2 = runIdentity (zipRecordsM (\a b c -> Identity (f a b c)) r1 r2)

--- a/src/Cryptol/Utils/RecordMap.hs
+++ b/src/Cryptol/Utils/RecordMap.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      :  Cryptol.Utils.PP
+-- Module      :  Cryptol.Utils.RecordMap
 -- Copyright   :  (c) 2020 Galois, Inc.
 -- License     :  BSD3
 -- Maintainer  :  cryptol@galois.com
@@ -43,7 +43,7 @@ import qualified Data.Map.Merge.Strict as Map
 import Cryptol.Utils.Panic
 
 -- | An "order insensitive" datastructure.
---   The fields can be accesed either according
+--   The fields can be accessed either according
 --   to a "canonical" order, or based on a
 --   "display" order, which matches the order
 --   in which the fields were originally specified.

--- a/tests/issues/issue066.icry.stdout
+++ b/tests/issues/issue066.icry.stdout
@@ -7,12 +7,12 @@ True
 Counterexample
 f 0xc = False
 it : {result : Bit, arg1 : [4]}
-{arg1 = 0xc, result = False}
+{result = False, arg1 = 0xc}
 False
 Satisfiable
 f 0x3 = True
 it : {result : Bit, arg1 : [4]}
-{arg1 = 0x3, result = True}
+{result = True, arg1 = 0x3}
 True
 Unsatisfiable
 it : {result : Bit, arg1 : [4]}
@@ -21,18 +21,18 @@ Run-time error: no satisfying assignment available
 Counterexample
 g {x = 0xffffffff, y = 0x00000000} = False
 it : {result : Bit, arg1 : {x : [32], y : [32]}}
-{arg1 = {x = 0xffffffff, y = 0x00000000}, result = False}
+{result = False, arg1 = {x = 0xffffffff, y = 0x00000000}}
 Satisfiable
 g {x = 0x00000000, y = 0x00000000} = True
 it : {result : Bit, arg1 : {x : [32], y : [32]}}
-{arg1 = {x = 0x00000000, y = 0x00000000}, result = True}
+{result = True, arg1 = {x = 0x00000000, y = 0x00000000}}
 Counterexample
 h 0x00 0x00 = False
 it : {result : Bit, arg1 : [8], arg2 : [8]}
-{arg1 = 0x00, arg2 = 0x00, result = False}
+{result = False, arg1 = 0x00, arg2 = 0x00}
 0x00
 0x00
 Satisfiable
 h 0x00 0x01 = True
 it : {result : Bit, arg1 : [8], arg2 : [8]}
-{arg1 = 0x00, arg2 = 0x01, result = True}
+{result = True, arg1 = 0x00, arg2 = 0x01}

--- a/tests/issues/issue702.icry.stdout
+++ b/tests/issues/issue702.icry.stdout
@@ -1,7 +1,7 @@
 Loading module Cryptol
 Satisfiable
 (\(x : {b : Bit, a : Bit}) -> x.a && x.b)
-  {a = True, b = True} = True
+  {b = True, a = True} = True
 Satisfiable
 (\(x : {b : [8], a : Bit}) -> x.b == 0 /\ x.a)
-  {a = True, b = 0x00} = True
+  {b = 0x00, a = True} = True

--- a/tests/regression/repeatFields.icry
+++ b/tests/regression/repeatFields.icry
@@ -1,0 +1,5 @@
+let z = { a = 0x08,  a = "asdf" }
+
+let g (x: { b : [8], b : String 4 }) = x.b
+
+let h { c = v, c = u } = zero#v == u

--- a/tests/regression/repeatFields.icry.stdout
+++ b/tests/regression/repeatFields.icry.stdout
@@ -1,0 +1,10 @@
+Loading module Cryptol
+
+Parse error at <interactive>:1:22--1:23
+  Record has repeated field: a
+
+Parse error at <interactive>:1:22--1:23
+  Record has repeated field: b
+
+Parse error at <interactive>:1:16--1:17
+  Record has repeated field: c


### PR DESCRIPTION
This type stores records as a finite map from field names to
values, while also remembering the original order of the fields
from when the record was generated (usually, from the program source).
For all "semantic" purposes, the fields are treated as appearing in
a canoical order (in sorted order of the field names).  However, for
user display purposes, records are presented in the order in which
the fields were originally stated.

In the course of implementing this, I discovered that we were not
previously checking for repeated fields in the parser or typechecker,
which would result in some rather strange situations and could probably
be used to break the type safety. This is now fixed and repeated fields
will result in either a parse error or a panic (for records generated
internally).

Fixes #706