### PR TITLE
Parameterize module system over filesystem access

### DIFF
--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -1645,7 +1645,7 @@ This module implements the core functionality of the `:eval
 running the reference evaluator on an expression.
 
 > evaluate :: Expr -> M.ModuleCmd Value
-> evaluate expr (_,modEnv) = return (Right (evalExpr env expr, modEnv), [])
+> evaluate expr (_, _, modEnv) = return (Right (evalExpr env expr, modEnv), [])
 >   where
 >     extDgs = concatMap mDecls (M.loadedModules modEnv)
 >     env = foldl evalDeclGroup mempty extDgs

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -55,7 +55,6 @@ import Cryptol.Transform.MonoValues (rewModule)
 
 import qualified Control.Exception as X
 import Control.Monad (unless,when)
-import qualified Data.ByteString as B
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text.Encoding (decodeUtf8')
@@ -112,9 +111,10 @@ noPat a = do
 
 parseModule :: ModulePath -> ModuleM (Fingerprint, P.Module PName)
 parseModule path = do
+  getBytes <- getByteReader
 
   bytesRes <- case path of
-                InFile p -> io (X.try (B.readFile p))
+                InFile p -> io (X.try (getBytes p))
                 InMem _ bs -> pure (Right bs)
 
   bytes <- case bytesRes of
@@ -412,7 +412,9 @@ checkSingleModule how isrc path m = do
   -- this is a more-or-less obsolete feature, we are just not doing
   -- ot for now.
   e   <- case path of
-           InFile p -> io (removeIncludesModule p m)
+           InFile p -> do
+             r <- getByteReader
+             io (removeIncludesModule r p m)
            InMem {} -> pure (Right m)
 
   nim <- case e of

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1548,7 +1548,7 @@ liftModuleCmd :: M.ModuleCmd a -> REPL a
 liftModuleCmd cmd =
   do evo <- getEvalOpts
      env <- getModuleEnv
-     moduleCmdResult =<< io (cmd (evo,env))
+     moduleCmdResult =<< io (cmd (evo, BS.readFile, env))
 
 moduleCmdResult :: M.ModuleRes a -> REPL a
 moduleCmdResult (res,ws0) = do

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -160,7 +160,7 @@ thmSMTResults :: SBV.ThmResult -> [SBV.SMTResult]
 thmSMTResults (SBV.ThmResult r) = [r]
 
 proverError :: String -> M.ModuleCmd (Maybe String, ProverResult)
-proverError msg (_,modEnv) =
+proverError msg (_, _, modEnv) =
   return (Right ((Nothing, ProverError msg), modEnv), [])
 
 
@@ -403,9 +403,9 @@ processResults evo ProverCommand{..} ts results =
 --   of executing the query.
 satProve :: SBVProverConfig -> ProverCommand -> M.ModuleCmd (Maybe String, ProverResult)
 satProve proverCfg pc@ProverCommand {..} =
-  protectStack proverError $ \(evo,modEnv) ->
+  protectStack proverError $ \(evo, byteReader, modEnv) ->
 
-  M.runModuleM (evo,modEnv) $ do
+  M.runModuleM (evo, byteReader, modEnv) $ do
 
   let lPutStrLn = logPutStrLn (Eval.evalLogger evo)
 
@@ -424,8 +424,8 @@ satProve proverCfg pc@ProverCommand {..} =
 --   the SMT input file corresponding to the given prover command.
 satProveOffline :: SBVProverConfig -> ProverCommand -> M.ModuleCmd (Either String String)
 satProveOffline _proverCfg pc@ProverCommand {..} =
-  protectStack (\msg (_,modEnv) -> return (Right (Left msg, modEnv), [])) $
-  \(evOpts,modEnv) -> do
+  protectStack (\msg (_,_,modEnv) -> return (Right (Left msg, modEnv), [])) $
+  \(evOpts, _, modEnv) -> do
     let isSat = case pcQueryType of
           ProveQuery -> False
           SafetyQuery -> False

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -194,7 +194,7 @@ setupProver nm =
 
 
 proverError :: String -> M.ModuleCmd (Maybe String, ProverResult)
-proverError msg (_,modEnv) =
+proverError msg (_, _, modEnv) =
   return (Right ((Nothing, ProverError msg), modEnv), [])
 
 
@@ -285,8 +285,8 @@ satProve ::
   M.ModuleCmd (Maybe String, ProverResult)
 
 satProve solverCfg hashConsing ProverCommand {..} =
-  protectStack proverError \(evo, modEnv) ->
-  M.runModuleM (evo,modEnv)
+  protectStack proverError \(evo, byteReader, modEnv) ->
+  M.runModuleM (evo, byteReader, modEnv)
   do sym     <- liftIO makeSym
      logData <- M.withLogger doLog ()
      start   <- liftIO getCurrentTime
@@ -343,8 +343,8 @@ satProveOffline (W4Portfolio (p:|_)) hashConsing cmd outputContinuation =
   satProveOffline (W4ProverConfig p) hashConsing cmd outputContinuation
 
 satProveOffline (W4ProverConfig (AnAdapter adpt)) hashConsing ProverCommand {..} outputContinuation =
-  protectStack onError \(evo,modEnv) ->
-  M.runModuleM (evo,modEnv)
+  protectStack onError \(evo,byteReader,modEnv) ->
+  M.runModuleM (evo,byteReader,modEnv)
    do sym <- liftIO makeSym
       ok  <- prepareQuery sym ProverCommand { .. }
       liftIO
@@ -363,7 +363,7 @@ satProveOffline (W4ProverConfig (AnAdapter adpt)) hashConsing ProverCommand {..}
        when hashConsing  (W4.startCaching sym)
        pure sym
 
-  onError msg (_,modEnv) = pure (Right (Just msg, modEnv), [])
+  onError msg (_,_,modEnv) = pure (Right (Just msg, modEnv), [])
 
 
 decSatNum :: SatNum -> SatNum

--- a/src/Cryptol/Transform/Specialize.hs
+++ b/src/Cryptol/Transform/Specialize.hs
@@ -59,13 +59,13 @@ modify f = get >>= (set . f)
 -- type-specialized versions of all functions called (transitively) by
 -- the body of the expression.
 specialize :: Expr -> M.ModuleCmd Expr
-specialize expr (ev,modEnv) = run $ do
+specialize expr (ev, byteReader, modEnv) = run $ do
   let extDgs = allDeclGroups modEnv
   let (tparams, expr') = destETAbs expr
   spec' <- specializeEWhere expr' extDgs
   return (foldr ETAbs spec' tparams)
   where
-  run = M.runModuleT (ev,modEnv) . fmap fst . runSpecT Map.empty
+  run = M.runModuleT (ev, byteReader, modEnv) . fmap fst . runSpecT Map.empty
 
 specializeExpr :: Expr -> SpecM Expr
 specializeExpr expr =


### PR DESCRIPTION
This PR adds the ability for clients of Cryptol-the-library to provide their own means of accessing files on disk, as a sort of lightweight VFS. This will be used for caching multiple concurrent states in the SAW RPC interface. 