### PR TITLE
Suppress the `Must be at least` line of defaulting error

### DIFF
--- a/tests/mono-binds/test05.icry.stdout
+++ b/tests/mono-binds/test05.icry.stdout
@@ -51,4 +51,3 @@ Loading module test05
 
 [error] at test05.cry:14:11--14:21:
   Ambiguous numeric type: type argument 'front' of '(#)'
-  Must be at least: 0


### PR DESCRIPTION
messages when the calculated bound is 0.