### PR TITLE
Allow release branches to actually release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
           fetch-depth: 0
       - id: env
         if: |
-          (startsWith(github.head_ref, 'release-')
-            || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'actions/')))
+          startsWith(github.ref, 'release-')
+            || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'actions/'))
         run: .github/ci.sh output release 1
       - id: outputs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Cryptol
 on:
   push:
-    branches: [master, "release-**"]
+    branches:
+      - master
+      - release-**
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           startsWith(github.ref, 'release-')
             || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'actions/'))
         run: .github/ci.sh output release 1
+      - run: echo ${{ github.ref }}
       - id: outputs
         run: |
           .github/ci.sh set_files ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 name: Cryptol
 on:
   push:
-    branches:
-      - master
-      - release-**
+    branches: [master, "release-**"]
   pull_request:
 
 jobs:
@@ -20,10 +18,9 @@ jobs:
           fetch-depth: 0
       - id: env
         if: |
-          startsWith(github.ref, 'release-')
+          startsWith(github.ref, 'refs/heads/release-')
             || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'actions/'))
         run: .github/ci.sh output release 1
-      - run: echo ${{ github.ref }}
       - id: outputs
         run: |
           .github/ci.sh set_files ${{ github.sha }}


### PR DESCRIPTION
The documentation around github.ref leaves a little to be desired, and I apparently wasn't reading it closely enough. This allows the release workflow to actually trigger on the release branches.