### PR TITLE
Enable docker builds for releases and nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,21 @@ jobs:
           name: ${{ needs.outputs.outputs.name }}-${{ runner.os }}-x86_64
           path: "cryptol.msi*"
 
+  docker:
+    runs-on: ubuntu-latest
+    needs: [outputs]
+    if: needs.outputs.outputs.release
+    steps:
+      - name: Publish to Registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.GITHUBCRYPTOL_USERNAME }}
+          password: ${{ secrets.GITHUBCRYPTOL }}
+          repository: galoisinc/cryptol
+          tags: "latest,${{ needs.outputs.outputs.cryptol-version }}"
+          add_git_labels: true
+          push: ${{ startsWith(github.ref, 'refs/heads/release-') }}
+
   release:
     needs: [outputs, bundle]
     if: needs.outputs.outputs.release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,9 @@ jobs:
     needs: [outputs]
     if: needs.outputs.outputs.release
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Publish to Registry
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       needs.outputs.outputs.release || contains(needs.outputs.outputs.changed, 'docs/')
     steps:
       - uses: actions/checkout@v2
-      - uses: docker://pandoc/latex:latest
+      - uses: docker://pandoc/latex:2.9.2
         with:
           args: >-
             sh -c

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,6 @@ jobs:
         run: |
           .github/ci.sh set_version
           .github/ci.sh output name cryptol-$(.github/ci.sh ver)-$(date -I)
-          .github/ci.sh output date $(date -I)
 
   docs:
     runs-on: ubuntu-latest
@@ -51,9 +50,10 @@ jobs:
           username: ${{ secrets.GITHUBCRYPTOL_USERNAME }}
           password: ${{ secrets.GITHUBCRYPTOL }}
           repository: galoisinc/cryptol
-          tags: "${{ needs.outputs.outputs.date }}"
+          tags: "nightly"
           add_git_labels: true
-          push: ${{ github.event_name == 'schedule' }}
+          # push: ${{ github.event_name == 'schedule' }}
+          push: true
 
   build:
     needs: [outputs, docs]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           .github/ci.sh set_version
           .github/ci.sh output name cryptol-$(.github/ci.sh ver)-$(date -I)
+          .github/ci.sh output date $(date -I)
 
   docs:
     runs-on: ubuntu-latest
@@ -37,17 +38,19 @@ jobs:
           path: docs
           name: docs
 
-  # docker:
-  #   runs-on: ubuntu-latest
-  #   needs: [outputs]
-  #   steps:
-  #     - name: Publish to Registry
-  #       uses: elgohr/Publish-Docker-Github-Action@master
-  #       with:
-  #         name: galoisinc/cryptol
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-  #         tags: "latest,${{ needs.outputs.outputs.cryptol-version }}"
+  docker:
+    runs-on: ubuntu-latest
+    needs: [outputs]
+    steps:
+      - name: Publish to Registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.GITHUBCRYPTOL_USERNAME }}
+          password: ${{ secrets.GITHUBCRYPTOL }}
+          repository: galoisinc/cryptol
+          tags: "${{ needs.outputs.outputs.date }}"
+          add_git_labels: true
+          push: ${{ github.event_name == 'schedule' }}
 
   build:
     needs: [outputs, docs]
@@ -63,8 +66,6 @@ jobs:
           submodules: true
 
       - uses: actions/setup-haskell@v1
-        with:
-          ghc-version: "8.10"
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [outputs]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Publish to Registry
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: docker://pandoc/latex:latest
+      - uses: docker://pandoc/latex:2.9.2
         with:
           args: >-
             sh -c


### PR DESCRIPTION
This enables docker builds for releases and nightlies. It also (*probably*) pushes them correctly to dockerhub.