### PR TITLE
Issue851

### DIFF
--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -393,6 +393,18 @@ tIsIntMod ty = case tNoUser ty of
                  TCon (TC TCIntMod) [n] -> Just n
                  _                      -> Nothing
 
+tIsRational :: Type -> Bool
+tIsRational ty =
+  case tNoUser ty of
+    TCon (TC TCRational) [] -> True
+    _                       -> False
+
+tIsFloat :: Type -> Maybe (Type, Type)
+tIsFloat ty =
+  case tNoUser ty of
+    TCon (TC TCFloat) [e, p] -> Just (e, p)
+    _                        -> Nothing
+
 tIsTuple :: Type -> Maybe [Type]
 tIsTuple ty = case tNoUser ty of
                 TCon (TC (TCTuple _)) ts -> Just ts

--- a/tests/issues/issue851.cry
+++ b/tests/issues/issue851.cry
@@ -1,0 +1,16 @@
+type base t = { zero: t }
+
+B: base Bool
+B = { zero = False }
+
+foo: {t,k} (fin k) => base t -> [k]t
+foo b = repeat b.zero
+
+bar: {t,k} (fin k, k>=1) => [k]t -> [k]t -> [k]t -> [k]t
+bar p q m = p
+
+baz: {k,t} (fin k, k >= 1) => [k]t -> [k]t -> [k]t
+baz p q = q
+
+property problem p =
+  p != foo B ==> bar p (baz p 0x03) 0x03 == foo B

--- a/tests/issues/issue851.icry
+++ b/tests/issues/issue851.icry
@@ -1,0 +1,2 @@
+:l issue851.cry
+:exhaust problem

--- a/tests/issues/issue851.icry.stdout
+++ b/tests/issues/issue851.icry.stdout
@@ -1,0 +1,5 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+Using exhaustive testing.
+Testing... problem 0x01 = False


### PR DESCRIPTION
Rewrite function `toExpr` using a complete pattern match.

Fixes #851.

I'm still a little unsure about where exactly we should be using `panic` in this function, and where we should be using `fail`/`guard`/`mzero`.