### PR TITLE
Check for negative integer indices when doing indexing-out-of-bounds checks

### DIFF
--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -1407,9 +1407,18 @@ assertIndexInBounds ::
   Either (SInteger sym) (WordValue sym) {- ^ Index value -} ->
   SEval sym ()
 
--- Can't index out of bounds for an infinite sequence
-assertIndexInBounds _sym Inf _ =
-  return ()
+-- Bitvectors can't index out of bounds for an infinite sequence
+assertIndexInBounds _sym Inf (Right _) = return ()
+
+-- All nonnegative integers are in bounds for an infinite sequence
+assertIndexInBounds sym Inf (Left idx) =
+  do ppos <- bitComplement sym =<< intLessThan sym idx =<< integerLit sym 0
+     assertSideCondition sym ppos (InvalidIndex (integerAsLit sym idx))
+
+-- If the index is concrete, test it directly
+assertIndexInBounds sym (Nat n) (Left idx)
+  | Just i <- integerAsLit sym idx
+  = unless (0 < i && i < n) (raiseError sym (InvalidIndex (Just i)))
 
 -- Can't index out of bounds for a sequence that is
 -- longer than the expressible index values
@@ -1418,20 +1427,17 @@ assertIndexInBounds sym (Nat n) (Right idx)
   = return ()
 
 -- If the index is concrete, test it directly
-assertIndexInBounds sym (Nat n) (Left idx)
-  | Just i <- integerAsLit sym idx
-  = unless (i < n) (raiseError sym (InvalidIndex (Just i)))
-
--- If the index is concrete, test it directly
 assertIndexInBounds sym (Nat n) (Right (WordVal idx))
   | Just (_w,i) <- wordAsLit sym idx
   = unless (i < n) (raiseError sym (InvalidIndex (Just i)))
 
 -- If the index is an integer, test that it
--- is less than the concrete value of n.
+-- is nonnegative and less than the concrete value of n.
 assertIndexInBounds sym (Nat n) (Left idx) =
   do n' <- integerLit sym n
-     p <- intLessThan sym idx n'
+     ppos <- bitComplement sym =<< intLessThan sym idx =<< integerLit sym 0
+     pn <- intLessThan sym idx n'
+     p <- bitAnd sym ppos pn
      assertSideCondition sym p (InvalidIndex Nothing)
 
 -- If the index is a packed word, test that it

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -1407,18 +1407,22 @@ assertIndexInBounds ::
   Either (SInteger sym) (WordValue sym) {- ^ Index value -} ->
   SEval sym ()
 
--- Bitvectors can't index out of bounds for an infinite sequence
-assertIndexInBounds _sym Inf (Right _) = return ()
-
 -- All nonnegative integers are in bounds for an infinite sequence
 assertIndexInBounds sym Inf (Left idx) =
   do ppos <- bitComplement sym =<< intLessThan sym idx =<< integerLit sym 0
      assertSideCondition sym ppos (InvalidIndex (integerAsLit sym idx))
 
--- If the index is concrete, test it directly
-assertIndexInBounds sym (Nat n) (Left idx)
-  | Just i <- integerAsLit sym idx
-  = unless (0 < i && i < n) (raiseError sym (InvalidIndex (Just i)))
+-- If the index is an integer, test that it
+-- is nonnegative and less than the concrete value of n.
+assertIndexInBounds sym (Nat n) (Left idx) =
+  do n' <- integerLit sym n
+     ppos <- bitComplement sym =<< intLessThan sym idx =<< integerLit sym 0
+     pn <- intLessThan sym idx n'
+     p <- bitAnd sym ppos pn
+     assertSideCondition sym p (InvalidIndex (integerAsLit sym idx))
+
+-- Bitvectors can't index out of bounds for an infinite sequence
+assertIndexInBounds _sym Inf (Right _) = return ()
 
 -- Can't index out of bounds for a sequence that is
 -- longer than the expressible index values
@@ -1430,15 +1434,6 @@ assertIndexInBounds sym (Nat n) (Right idx)
 assertIndexInBounds sym (Nat n) (Right (WordVal idx))
   | Just (_w,i) <- wordAsLit sym idx
   = unless (i < n) (raiseError sym (InvalidIndex (Just i)))
-
--- If the index is an integer, test that it
--- is nonnegative and less than the concrete value of n.
-assertIndexInBounds sym (Nat n) (Left idx) =
-  do n' <- integerLit sym n
-     ppos <- bitComplement sym =<< intLessThan sym idx =<< integerLit sym 0
-     pn <- intLessThan sym idx n'
-     p <- bitAnd sym ppos pn
-     assertSideCondition sym p (InvalidIndex Nothing)
 
 -- If the index is a packed word, test that it
 -- is less than the concrete value of n, which

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -272,21 +272,21 @@ wordValueSize _ (LargeBitsVal n _) = n
 -- | Select an individual bit from a word value
 indexWordValue :: Backend sym => sym -> WordValue sym -> Integer -> SEval sym (SBit sym)
 indexWordValue sym (WordVal w) idx
-   | idx < wordLen sym w = wordBit sym w idx
+   | 0 <= idx && idx < wordLen sym w = wordBit sym w idx
    | otherwise = invalidIndex sym idx
 indexWordValue sym (LargeBitsVal n xs) idx
-   | idx < n   = fromVBit <$> lookupSeqMap xs idx
+   | 0 <= idx && idx < n = fromVBit <$> lookupSeqMap xs idx
    | otherwise = invalidIndex sym idx
 
 -- | Produce a new 'WordValue' from the one given by updating the @i@th bit with the
 --   given bit value.
 updateWordValue :: Backend sym => sym -> WordValue sym -> Integer -> SEval sym (SBit sym) -> SEval sym (WordValue sym)
 updateWordValue sym (WordVal w) idx b 
-   | idx >= wordLen sym w = invalidIndex sym idx
+   | idx < 0 || idx >= wordLen sym w = invalidIndex sym idx
    | isReady sym b = WordVal <$> (wordUpdate sym w idx =<< b)
 
 updateWordValue sym wv idx b
-   | idx < wordValueSize sym wv =
+   | 0 <= idx && idx < wordValueSize sym wv =
         pure $ LargeBitsVal (wordValueSize sym wv) $ updateSeqMap (asBitsMap sym wv) idx (VBit <$> b)
    | otherwise = invalidIndex sym idx
 

--- a/tests/issues/issue861.cry
+++ b/tests/issues/issue861.cry
@@ -1,6 +1,0 @@
-atXis0:
-    {n, a, w}
-    (fin n, Eq a, Zero a, Cmp w, Integral w, Literal n w) =>
-    [n]a -> w -> Bit
-property atXis0 seq i =
-    zero == seq ==> i < `n ==> seq @ i == zero

--- a/tests/issues/issue861.cry
+++ b/tests/issues/issue861.cry
@@ -1,0 +1,6 @@
+atXis0:
+    {n, a, w}
+    (fin n, Eq a, Zero a, Cmp w, Integral w, Literal n w) =>
+    [n]a -> w -> Bit
+property atXis0 seq i =
+    zero == seq ==> i < `n ==> seq @ i == zero

--- a/tests/issues/issue861.icry
+++ b/tests/issues/issue861.icry
@@ -1,0 +1,31 @@
+:l issue861.cry
+
+:set tests=1000
+
+:check atXis0`{4, Char, Integer}
+
+let xs = [0,1,2] : [3]Integer
+
+xs@0
+xs@1
+xs@2
+xs@3
+xs@(-1)
+
+xs!0
+xs!1
+xs!2
+xs!3
+xs!(-1)
+
+update xs 0 5
+update xs 1 5
+update xs 2 5
+update xs 3 5
+update xs (-1) 5
+
+updateEnd xs 0 5
+updateEnd xs 1 5
+updateEnd xs 2 5
+updateEnd xs 3 5
+updateEnd xs (-1) 5

--- a/tests/issues/issue861.icry
+++ b/tests/issues/issue861.icry
@@ -1,8 +1,3 @@
-:l issue861.cry
-
-:set tests=1000
-
-:check atXis0`{4, Char, Integer}
 
 let xs = [0,1,2] : [3]Integer
 

--- a/tests/issues/issue861.icry.stdout
+++ b/tests/issues/issue861.icry.stdout
@@ -1,8 +1,4 @@
 Loading module Cryptol
-Loading module Cryptol
-Loading module Main
-Using random testing.
-Testing... Passed 1000 tests.
 0
 1
 2

--- a/tests/issues/issue861.icry.stdout
+++ b/tests/issues/issue861.icry.stdout
@@ -1,0 +1,33 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+Using random testing.
+Testing... Passed 1000 tests.
+0
+1
+2
+
+invalid sequence index: 3
+
+invalid sequence index: -1
+2
+1
+0
+
+invalid sequence index: 3
+
+invalid sequence index: -1
+[5, 1, 2]
+[0, 5, 2]
+[0, 1, 5]
+
+invalid sequence index: 3
+
+invalid sequence index: -1
+[0, 1, 5]
+[0, 5, 2]
+[5, 1, 2]
+
+invalid sequence index: 3
+
+invalid sequence index: -1


### PR DESCRIPTION
Fixes #861

I'd like to add some tests and do some additional checking, but I think this fixes the issue.

Related, however: `:check` should probably fail when we encounter an error condition, the same way that `:prove` does.  Right now, I think it just accepts crashing test cases as passing.
