### PR TITLE
Fix race conditions in thunk evaluation

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -66,6 +66,7 @@ library
                        random            >= 1.0.1,
                        sbv               >= 8.6,
                        simple-smt        >= 0.7.1,
+                       stm               >= 2.4,
                        strict,
                        text              >= 1.1,
                        tf-random         >= 0.5,

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -20,7 +20,7 @@
 {-# LANGUAGE ViewPatterns #-}
 module Cryptol.Eval.Concrete
   ( module Cryptol.Eval.Concrete.Value
-  , evalPrim
+  , primTable
   , toExpr
   ) where
 
@@ -131,11 +131,8 @@ floatToExpr prims eT pT f =
 
 -- Primitives ------------------------------------------------------------------
 
-evalPrim :: PrimIdent -> Maybe Value
-evalPrim prim = Map.lookup prim primTable
-
-primTable :: Map.Map PrimIdent Value
-primTable = let sym = Concrete in
+primTable :: EvalOpts -> Map.Map PrimIdent Value
+primTable eOpts = let sym = Concrete in
   Map.union (floatPrims sym) $
   Map.fromList $ map (\(n, v) -> (prelPrim n, v))
 
@@ -324,7 +321,7 @@ primTable = let sym = Concrete in
                       lam $ \x -> return $
                       lam $ \y -> do
                          msg <- valueToString sym =<< s
-                         EvalOpts { evalPPOpts, evalLogger } <- getEvalOpts
+                         let EvalOpts { evalPPOpts, evalLogger } = eOpts
                          doc <- ppValue sym evalPPOpts =<< x
                          yv <- y
                          io $ logPrint evalLogger

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -18,7 +18,7 @@
 module Cryptol.Eval.SBV
   ( SBV(..), Value
   , SBVEval(..), SBVResult(..)
-  , evalPrim
+  , primTable
   , forallBV_, existsBV_
   , forallSBool_, existsSBool_
   , forallSInteger_, existsSInteger_
@@ -355,9 +355,6 @@ evalPanic cxt = panic ("[Symbolic]" ++ cxt)
 
 
 -- Primitives ------------------------------------------------------------------
-
-evalPrim :: PrimIdent -> Maybe Value
-evalPrim prim = Map.lookup prim primTable
 
 -- See also Cryptol.Eval.Concrete.primTable
 primTable :: Map.Map PrimIdent Value

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -205,7 +205,7 @@ memoMap x = do
 
   doEval cache i = do
     v <- lookupSeqMap x i
-    liftIO $ modifyIORef' cache (Map.insert i v)
+    liftIO $ atomicModifyIORef' cache (\m -> (Map.insert i v m, ()))
     return v
 
 -- | Apply the given evaluation function pointwise to the two given

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -211,7 +211,7 @@ memoMap x = do
 -- | Apply the given evaluation function pointwise to the two given
 --   sequence maps.
 zipSeqMap ::
-  Backend sym => 
+  Backend sym =>
   (GenValue sym -> GenValue sym -> SEval sym (GenValue sym)) ->
   SeqMap sym ->
   SeqMap sym ->
@@ -221,7 +221,7 @@ zipSeqMap f x y =
 
 -- | Apply the given function to each value in the given sequence map
 mapSeqMap ::
-  Backend sym => 
+  Backend sym =>
   (GenValue sym -> SEval sym (GenValue sym)) ->
   SeqMap sym -> SEval sym (SeqMap sym)
 mapSeqMap f x =
@@ -281,7 +281,7 @@ indexWordValue sym (LargeBitsVal n xs) idx
 -- | Produce a new 'WordValue' from the one given by updating the @i@th bit with the
 --   given bit value.
 updateWordValue :: Backend sym => sym -> WordValue sym -> Integer -> SEval sym (SBit sym) -> SEval sym (WordValue sym)
-updateWordValue sym (WordVal w) idx b 
+updateWordValue sym (WordVal w) idx b
    | idx < 0 || idx >= wordLen sym w = invalidIndex sym idx
    | isReady sym b = WordVal <$> (wordUpdate sym w idx =<< b)
 
@@ -334,6 +334,7 @@ forceValue v = case v of
   VFun _      -> return ()
   VPoly _     -> return ()
   VNumPoly _  -> return ()
+
 
 
 instance Backend sym => Show (GenValue sym) where

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -13,7 +13,7 @@ module Cryptol.Eval.What4
   , W4Eval
   , w4Eval
   , Value
-  , evalPrim
+  , primTable
   ) where
 
 
@@ -30,10 +30,6 @@ import Cryptol.Eval.What4.Value
 import Cryptol.Eval.What4.Float(floatPrims)
 import Cryptol.Testing.Random( randomV )
 import Cryptol.Utils.Ident
-
-
-evalPrim :: W4.IsSymExprBuilder sym => sym -> PrimIdent -> Maybe (Value sym)
-evalPrim sym prim = Map.lookup prim (primTable sym)
 
 -- See also Cryptol.Prims.Eval.primTable
 primTable :: W4.IsSymExprBuilder sym => sym -> Map.Map PrimIdent (Value sym)
@@ -192,6 +188,3 @@ primTable w4sym = let sym = What4 w4sym in
          _ <- x
          y)
   ]
-
-
-

--- a/src/Cryptol/ModuleSystem/Monad.hs
+++ b/src/Cryptol/ModuleSystem/Monad.hs
@@ -488,8 +488,7 @@ modifyEvalEnv :: (EvalEnv -> E.Eval EvalEnv) -> ModuleM ()
 modifyEvalEnv f = ModuleT $ do
   env <- get
   let evalEnv = meEvalEnv env
-  evOpts <- unModuleT getEvalOpts
-  evalEnv' <- inBase $ E.runEval evOpts (f evalEnv)
+  evalEnv' <- inBase $ E.runEval (f evalEnv)
   set $! env { meEvalEnv = evalEnv' }
 
 getEvalEnv :: ModuleM EvalEnv


### PR DESCRIPTION
With the addition of `parmap`, it became possible to observe race conditions in the thunk evaluation lifecycle.  This PR reworks the evaluation monad so that threads will properly block and wait if they attempt to force a thunk that is already under evaluation by a different thread and uses transactional variables to ensure proper synchronization.