### PR TITLE
Include `cryptol-remote-api` in Cryptol builds

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -112,7 +112,7 @@ build() {
   cabal v2-update
   cabal v2-configure -j2 --minimize-conflict-set
   retry ./cry build exe:cryptol-html "$@" # retry due to flakiness with windows builds
-  cabal v2-build --allow-newer cryptol-remote-api
+  cabal v2-build cryptol-remote-api
 }
 
 install_system_deps() {

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -112,7 +112,7 @@ build() {
   cabal v2-update
   cabal v2-configure -j2 --minimize-conflict-set
   retry ./cry build exe:cryptol-html "$@" # retry due to flakiness with windows builds
-  cabal v2-build cryptol-remote-api
+  cabal v2-build --allow-newer cryptol-remote-api
 }
 
 install_system_deps() {

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -46,6 +46,7 @@ setup_dist_bins() {
   is_exe "dist/bin" "cryptol" && is_exe "dist/bin" "cryptol-html" && return
   extract_exe "cryptol" "dist/bin"
   extract_exe "cryptol-html" "dist/bin"
+  extract_exe "cryptol-remote-api" "dist/bin"
   strip dist/bin/cryptol* || echo "Strip failed: Ignoring harmless error"
 }
 

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -112,6 +112,7 @@ build() {
   cabal v2-update
   cabal v2-configure -j2 --minimize-conflict-set
   retry ./cry build exe:cryptol-html "$@" # retry due to flakiness with windows builds
+  cabal v2-build cryptol-remote-api
 }
 
 install_system_deps() {

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,7 @@ on:
     branches: ["actions/**"]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch
 
 jobs:
   outputs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ on:
     branches: ["actions/**"]
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   outputs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "examples/cryptol-specs"]
 	path = examples/cryptol-specs
 	url = https://github.com/GaloisInc/cryptol-specs.git
+[submodule "deps/argo"]
+	path = deps/argo
+	url = https://github.com/galoisinc/argo

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
 packages:
     cryptol.cabal
     tests
+    deps/argo/argo
+    deps/argo/cryptol-remote-api


### PR DESCRIPTION
This adds the `argo` repository as a submodule, which in turn allows us to build the RPC API server `cryptol-remote-api` as part of the normal Cryptol build process. Ultimately, the code for that server will migrate into the Cryptol repository itself, and `argo` may eventually become a Hackage dependency.