### PR TITLE
Deepseq the result of typechecking a module to avoid a space leak.

### DIFF
--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -105,7 +105,7 @@ data InferOutput a
     -- ^ Type inference was successful.
 
 
-    deriving Show
+    deriving (Show, Generic, NFData)
 
 bumpCounter :: InferM ()
 bumpCounter = do RO { .. } <- IM ask


### PR DESCRIPTION
Previously, unevaluated `apSubst` thunks were retaining copies of
a very large `Subst` value.

Fixes #888.