### PR TITLE
Intmap types

### DIFF
--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -655,14 +655,14 @@ instance Semigroup (ListEnv sym) where
   l <> r = ListEnv
     { leVars   = IntMap.union (leVars  l)  (leVars  r)
     , leStatic = IntMap.union (leStatic l) (leStatic r)
-    , leTypes  = Map.union (leTypes l)  (leTypes r)
+    , leTypes  = IntMap.union (leTypes l)  (leTypes r)
     }
 
 instance Monoid (ListEnv sym) where
   mempty = ListEnv
     { leVars   = IntMap.empty
     , leStatic = IntMap.empty
-    , leTypes  = Map.empty
+    , leTypes  = IntMap.empty
     }
 
   mappend l r = l <> r

--- a/src/Cryptol/Eval/Env.hs
+++ b/src/Cryptol/Eval/Env.hs
@@ -25,7 +25,6 @@ import Cryptol.Utils.PP
 
 
 import qualified Data.IntMap.Strict as IntMap
-import qualified Data.Map.Strict as Map
 import Data.Semigroup
 
 import GHC.Generics (Generic)
@@ -43,13 +42,13 @@ data GenEvalEnv sym = EvalEnv
 instance Semigroup (GenEvalEnv sym) where
   l <> r = EvalEnv
     { envVars     = IntMap.union (envVars l) (envVars r)
-    , envTypes    = Map.union (envTypes l) (envTypes r)
+    , envTypes    = IntMap.union (envTypes l) (envTypes r)
     }
 
 instance Monoid (GenEvalEnv sym) where
   mempty = EvalEnv
     { envVars       = IntMap.empty
-    , envTypes      = Map.empty
+    , envTypes      = IntMap.empty
     }
 
   mappend l r = l <> r
@@ -96,10 +95,10 @@ lookupVar n env = IntMap.lookup (nameUnique n) (envVars env)
 -- | Bind a type variable of kind *.
 {-# INLINE bindType #-}
 bindType :: TVar -> Either Nat' TValue -> GenEvalEnv sym -> GenEvalEnv sym
-bindType p ty env = env { envTypes = Map.insert p ty (envTypes env) }
+bindType p ty env = env { envTypes = IntMap.insert (tvUnique p) ty (envTypes env) }
 
 -- | Lookup a type variable.
 {-# INLINE lookupType #-}
 lookupType :: TVar -> GenEvalEnv sym -> Maybe (Either Nat' TValue)
-lookupType p env = Map.lookup p (envTypes env)
+lookupType p env = IntMap.lookup (tvUnique p) (envTypes env)
 

--- a/src/Cryptol/Eval/Monad.hs
+++ b/src/Cryptol/Eval/Monad.hs
@@ -250,7 +250,7 @@ unDelay tv =
                   case res of
                     -- In this case, we claim the thunk.  Update the state to indicate
                     -- that we are working on it.
-                    Unforced nm backup -> writeTVar tv (UnderEvaluation tid backup)
+                    Unforced _ backup -> writeTVar tv (UnderEvaluation tid backup)
 
                     -- In this case, the thunk is already being evaluated.  If it is
                     -- under evaluation by this thread, we have to run the backup computation,

--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -27,6 +27,7 @@
 > import Data.Ord (comparing)
 > import Data.Map (Map)
 > import qualified Data.Map as Map
+> import qualified Data.IntMap as IntMap
 > import qualified Data.Text as T (pack)
 > import LibBF (BigFloat)
 > import qualified LibBF as FP
@@ -35,7 +36,7 @@
 > import Cryptol.TypeCheck.Solver.InfNat (Nat'(..), nAdd, nMin, nMul)
 > import Cryptol.TypeCheck.AST
 > import Cryptol.Eval.Monad (EvalError(..), PPOpts(..))
-> import Cryptol.Eval.Type (TValue(..), isTBit, evalValType, evalNumType)
+> import Cryptol.Eval.Type (TValue(..), isTBit, evalValType, evalNumType, TypeEnv)
 > import Cryptol.Eval.Concrete (mkBv, ppBV, lg2)
 > import Cryptol.Eval.Concrete.FloatHelpers (BF(..))
 > import qualified Cryptol.Eval.Concrete.FloatHelpers as FP
@@ -242,19 +243,19 @@ and type variables that are in scope at any point.
 
 > data Env = Env
 >   { envVars       :: !(Map Name (E Value))
->   , envTypes      :: !(Map TVar (Either Nat' TValue))
+>   , envTypes      :: !TypeEnv
 >   }
 >
 > instance Semigroup Env where
 >   l <> r = Env
 >     { envVars  = Map.union (envVars  l) (envVars  r)
->     , envTypes = Map.union (envTypes l) (envTypes r)
+>     , envTypes = IntMap.union (envTypes l) (envTypes r)
 >     }
 >
 > instance Monoid Env where
 >   mempty = Env
 >     { envVars  = Map.empty
->     , envTypes = Map.empty
+>     , envTypes = IntMap.empty
 >     }
 >   mappend l r = l <> r
 >
@@ -264,7 +265,7 @@ and type variables that are in scope at any point.
 >
 > -- | Bind a type variable of kind # or *.
 > bindType :: TVar -> Either Nat' TValue -> Env -> Env
-> bindType p ty env = env { envTypes = Map.insert p ty (envTypes env) }
+> bindType p ty env = env { envTypes = IntMap.insert (tvUnique p) ty (envTypes env) }
 
 
 Evaluation

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -125,6 +125,10 @@ tvInfo tv =
     TVFree _ _ _ d -> d
     TVBound tp     -> tpInfo tp
 
+tvUnique :: TVar -> Int
+tvUnique (TVFree u _ _ _) = u
+tvUnique (TVBound TParam { tpUnique = u }) = u
+
 data TVarInfo = TVarInfo { tvarSource :: Range -- ^ Source code that gave rise
                          , tvarDesc   :: TVarSource -- ^ Description
                          }


### PR DESCRIPTION
Use `IntMap` for type environments instead of Data.Map.

Fixes #886 