### PR TITLE
Make `apSubst` more strict to avoid a space leak.

### DIFF
--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -6,6 +6,7 @@
 -- Stability   :  provisional
 -- Portability :  portable
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -136,7 +137,7 @@ runInferM info (IM m) = SMT.withSolver (inpSolverConfig info) $ \solver ->
 
      let theSu    = iSubst finalRW
          defSu    = defaultingSubst theSu
-         warns    = [(r,apSubst theSu w) | (r,w) <- iWarnings finalRW ]
+         warns    = fmap' (fmap' (apSubst theSu)) (iWarnings finalRW)
 
      case iErrors finalRW of
        [] ->

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -129,8 +129,8 @@ tvUnique :: TVar -> Int
 tvUnique (TVFree u _ _ _) = u
 tvUnique (TVBound TParam { tpUnique = u }) = u
 
-data TVarInfo = TVarInfo { tvarSource :: Range -- ^ Source code that gave rise
-                         , tvarDesc   :: TVarSource -- ^ Description
+data TVarInfo = TVarInfo { tvarSource :: !Range -- ^ Source code that gave rise
+                         , tvarDesc   :: !TVarSource -- ^ Description
                          }
               deriving (Show, Generic, NFData)
 

--- a/src/Cryptol/TypeCheck/TypeMap.hs
+++ b/src/Cryptol/TypeCheck/TypeMap.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances, FlexibleInstances #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
 module Cryptol.TypeCheck.TypeMap
   ( TypeMap(..), TypesMap, TrieMap(..)
   , insertTM, insertWithTM
@@ -64,7 +66,7 @@ mapMaybeTM f = mapMaybeWithKeyTM (\_ -> f)
 
 data List m a  = L { nil  :: Maybe a
                    , cons :: m (List m a)
-                   } deriving (Functor)
+                   } deriving (Functor, Foldable, Traversable)
 
 instance TrieMap m a => TrieMap (List m) [a] where
   emptyTM = L { nil = Nothing, cons = emptyTM }
@@ -116,7 +118,7 @@ type TypesMap = List TypeMap
 data TypeMap a = TM { tvar :: Map TVar a
                     , tcon :: Map TCon    (List TypeMap a)
                     , trec :: Map [Ident] (List TypeMap a)
-                    } deriving (Functor)
+                    } deriving (Functor, Foldable, Traversable)
 
 instance TrieMap TypeMap Type where
   emptyTM = TM { tvar = emptyTM, tcon = emptyTM, trec = emptyTM }

--- a/src/Cryptol/Utils/Misc.hs
+++ b/src/Cryptol/Utils/Misc.hs
@@ -18,7 +18,7 @@ import Prelude.Compat
 -- | Apply a function to all elements of a container.
 -- Returns `Nothing` if nothing changed, and @Just container@ otherwise.
 anyJust :: Traversable t => (a -> Maybe a) -> t a -> Maybe (t a)
-anyJust f m = mk $ runId $ runStateT False $ traverse upd m
+anyJust f m = mk $ runLift $ runStateT False $ traverse upd m
   where
   mk (a,changes) = if changes then Just a else Nothing
 


### PR DESCRIPTION
A few other constructor fields also needed to be made strict
to avoid space leaks.

Fixes #888.