### PR TITLE
Symbolic refactor

### DIFF
--- a/src/Cryptol/Eval/Backend.hs
+++ b/src/Cryptol/Eval/Backend.hs
@@ -34,6 +34,8 @@ import Control.Monad.IO.Class
 import Data.Kind (Type)
 import Data.Ratio ( (%), numerator, denominator )
 
+import Cryptol.Eval.Concrete.FloatHelpers (BF)
+
 import Cryptol.Eval.Monad
 import Cryptol.TypeCheck.AST(Name)
 import Cryptol.Utils.PP
@@ -316,11 +318,14 @@ class MonadIO (SEval sym) => Backend sym where
     Rational {- ^ The rational -} ->
     SEval sym (SFloat sym)
 
+  -- | Construct a floating point value from the given bit-precise
+  --   floating-point representation.
+  fpExactLit :: sym -> BF -> SEval sym (SFloat sym)
+
   -- ==== If/then/else operations ====
   iteBit :: sym -> SBit sym -> SBit sym -> SBit sym -> SEval sym (SBit sym)
   iteWord :: sym -> SBit sym -> SWord sym -> SWord sym -> SEval sym (SWord sym)
   iteInteger :: sym -> SBit sym -> SInteger sym -> SInteger sym -> SEval sym (SInteger sym)
-
 
   -- ==== Bit operations ====
   bitEq  :: sym -> SBit sym -> SBit sym -> SEval sym (SBit sym)
@@ -675,6 +680,8 @@ class MonadIO (SEval sym) => Backend sym where
   fpLessThan    :: sym -> SFloat sym -> SFloat sym -> SEval sym (SBit sym)
   fpGreaterThan :: sym -> SFloat sym -> SFloat sym -> SEval sym (SBit sym)
 
+  fpLogicalEq   :: sym -> SFloat sym -> SFloat sym -> SEval sym (SBit sym)
+
   fpPlus, fpMinus, fpMult, fpDiv :: FPArith2 sym
   fpNeg :: sym -> SFloat sym -> SEval sym (SFloat sym)
 
@@ -698,8 +705,3 @@ type FPArith2 sym =
   SFloat sym ->
   SFloat sym ->
   SEval sym (SFloat sym)
-
-
-
-
-

--- a/src/Cryptol/Eval/Concrete/Value.hs
+++ b/src/Cryptol/Eval/Concrete/Value.hs
@@ -325,7 +325,9 @@ instance Backend Concrete where
   ------------------------------------------------------------------------
   -- Floating Point
   fpLit _sym e p rat     = pure (FP.fpLit e p rat)
+  fpExactLit _sym bf     = pure bf
   fpEq _sym x y          = pure (FP.bfValue x == FP.bfValue y)
+  fpLogicalEq _sym x y   = pure (FP.bfCompare (FP.bfValue x) (FP.bfValue y) == EQ)
   fpLessThan _sym x y    = pure (FP.bfValue x <  FP.bfValue y)
   fpGreaterThan _sym x y = pure (FP.bfValue x >  FP.bfValue y)
   fpPlus  = fpBinArith FP.bfAdd

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -325,7 +325,9 @@ instance Backend SBV where
   znNegate sym m a  = sModNegate sym m a
 
   ppFloat _ _ _           = text "[?]"
+  fpExactLit _ _          = unsupported "fpExactLit"
   fpLit _ _ _ _           = unsupported "fpLit"
+  fpLogicalEq _ _ _       = unsupported "fpLogicalEq"
   fpEq _ _ _              = unsupported "fpEq"
   fpLessThan _ _ _        = unsupported "fpLessThan"
   fpGreaterThan _ _ _     = unsupported "fpGreaterThan"

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -19,12 +19,14 @@ module Cryptol.Eval.SBV
   ( SBV(..), Value
   , SBVEval(..), SBVResult(..)
   , primTable
-  , forallBV_, existsBV_
-  , forallSBool_, existsSBool_
-  , forallSInteger_, existsSInteger_
+  , literalSWord
+  , freshSBool_
+  , freshBV_
+  , freshSInteger_
   ) where
 
 import qualified Control.Exception as X
+import           Control.Concurrent.MVar
 import           Control.Monad (join)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Data.Bits (bit, complement, shiftL)
@@ -32,8 +34,8 @@ import           Data.List (foldl')
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
-import Data.SBV (symbolicEnv)
 import Data.SBV.Dynamic as SBV
+import qualified Data.SBV.Internals as SBV
 
 import Cryptol.Eval.Type (TValue(..), finNat')
 import Cryptol.Eval.Backend
@@ -50,7 +52,7 @@ import Cryptol.Utils.Ident
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.PP
 
-data SBV = SBV
+data SBV = SBV (MVar (SBV.State))
 
 -- Utility operations -------------------------------------------------------------
 
@@ -67,23 +69,17 @@ unpackSBV x = [ svTestBit x i | i <- reverse [0 .. intSizeOf x - 1] ]
 literalSWord :: Int -> Integer -> SWord SBV
 literalSWord w i = svInteger (KBounded False w) i
 
-forallBV_ :: Int -> Symbolic (SWord SBV)
-forallBV_ w = symbolicEnv >>= liftIO . svMkSymVar (Just ALL) (KBounded False w) Nothing
+freshBV_ :: SBV -> Int -> IO (SWord SBV)
+freshBV_ (SBV stateVar) w =
+  withMVar stateVar (svMkSymVar Nothing (KBounded False w) Nothing)
 
-existsBV_ :: Int -> Symbolic (SWord SBV)
-existsBV_ w = symbolicEnv >>= liftIO . svMkSymVar (Just EX) (KBounded False w) Nothing
+freshSBool_ :: SBV -> IO (SBit SBV)
+freshSBool_ (SBV stateVar) =
+  withMVar stateVar (svMkSymVar Nothing KBool Nothing)
 
-forallSBool_ :: Symbolic (SBit SBV)
-forallSBool_ = symbolicEnv >>= liftIO . svMkSymVar (Just ALL) KBool Nothing
-
-existsSBool_ :: Symbolic (SBit SBV)
-existsSBool_ = symbolicEnv >>= liftIO . svMkSymVar (Just EX) KBool Nothing
-
-forallSInteger_ :: Symbolic (SBit SBV)
-forallSInteger_ = symbolicEnv >>= liftIO . svMkSymVar (Just ALL) KUnbounded Nothing
-
-existsSInteger_ :: Symbolic (SBit SBV)
-existsSInteger_ = symbolicEnv >>= liftIO . svMkSymVar (Just EX) KUnbounded Nothing
+freshSInteger_ :: SBV -> IO (SBit SBV)
+freshSInteger_ (SBV stateVar) =
+  withMVar stateVar (svMkSymVar Nothing KUnbounded Nothing)
 
 -- Values ----------------------------------------------------------------------
 
@@ -190,8 +186,8 @@ instance Backend SBV where
   ppBit _ v
      | Just b <- svAsBool v = text $! if b then "True" else "False"
      | otherwise            = text "?"
-  ppWord _ opts v
-     | Just x <- svAsInteger v = ppBV opts (BV (wordLen SBV v) x)
+  ppWord sym opts v
+     | Just x <- svAsInteger v = ppBV opts (BV (wordLen sym v) x)
      | otherwise               = text "[?]"
   ppInteger _ _opts v
      | Just x <- svAsInteger v = integer x
@@ -311,12 +307,12 @@ instance Backend SBV where
        pure $! svRem a m'
 
   znEq _ 0 _ _ = evalPanic "znEq" ["0 modulus not allowed"]
-  znEq _ m a b = svDivisible m (SBV.svMinus a b)
+  znEq sym m a b = svDivisible sym m (SBV.svMinus a b)
 
-  znPlus  _ m a b = sModAdd m a b
-  znMinus _ m a b = sModSub m a b
-  znMult  _ m a b = sModMult m a b
-  znNegate _ m a  = sModNegate m a
+  znPlus  sym m a b = sModAdd sym m a b
+  znMinus sym m a b = sModSub sym m a b
+  znMult  sym m a b = sModMult sym m a b
+  znNegate sym m a  = sModNegate sym m a
 
   ppFloat _ _ _           = text "[?]"
   fpLit _ _ _ _           = unsupported "fpLit"
@@ -357,8 +353,8 @@ evalPanic cxt = panic ("[Symbolic]" ++ cxt)
 -- Primitives ------------------------------------------------------------------
 
 -- See also Cryptol.Eval.Concrete.primTable
-primTable :: Map.Map PrimIdent Value
-primTable  = let sym = SBV in
+primTable :: SBV -> Map.Map PrimIdent Value
+primTable sym =
   Map.fromList $ map (\(n, v) -> (prelPrim (T.pack n), v))
 
   [ -- Literals
@@ -408,7 +404,7 @@ primTable  = let sym = SBV in
   , ("/$"          , sdivV sym)
   , ("%$"          , smodV sym)
   , ("lg2"         , lg2V sym)
-  , (">>$"         , sshrV)
+  , (">>$"         , sshrV sym)
 
     -- Cmp
   , ("<"           , binary (lessThanV sym))
@@ -484,11 +480,11 @@ primTable  = let sym = SBV in
                        rotateRightReindex rotateLeftReindex)
 
     -- Indexing and updates
-  , ("@"           , indexPrim sym indexFront indexFront_bits indexFront)
-  , ("!"           , indexPrim sym indexBack indexBack_bits indexBack)
+  , ("@"           , indexPrim sym (indexFront sym) (indexFront_bits sym) (indexFront sym))
+  , ("!"           , indexPrim sym (indexBack sym) (indexBack_bits sym) (indexBack sym))
 
-  , ("update"      , updatePrim sym updateFrontSym_word updateFrontSym)
-  , ("updateEnd"   , updatePrim sym updateBackSym_word updateBackSym)
+  , ("update"      , updatePrim sym (updateFrontSym_word sym) (updateFrontSym sym))
+  , ("updateEnd"   , updatePrim sym (updateBackSym_word sym) (updateBackSym sym))
 
     -- Misc
 
@@ -537,13 +533,14 @@ primTable  = let sym = SBV in
 
 
 indexFront ::
+  SBV ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   SVal ->
   SEval SBV Value
-indexFront mblen a xs _ix idx
+indexFront sym mblen a xs _ix idx
   | Just i <- SBV.svAsInteger idx
   = lookupSeqMap xs i
 
@@ -552,7 +549,7 @@ indexFront mblen a xs _ix idx
   = do wvs <- traverse (fromWordVal "indexFront" =<<) (enumerateSeqMap n xs)
        case asWordList wvs of
          Just ws ->
-           do z <- wordLit SBV wlen 0
+           do z <- wordLit sym wlen 0
               return $ VWord wlen $ pure $ WordVal $ SBV.svSelect ws z idx
          Nothing -> folded
 
@@ -561,8 +558,8 @@ indexFront mblen a xs _ix idx
 
  where
     k = SBV.kindOf idx
-    def = zeroV SBV a
-    f n y = iteValue SBV (SBV.svEqual idx (SBV.svInteger k n)) (lookupSeqMap xs n) y
+    def = zeroV sym a
+    f n y = iteValue sym (SBV.svEqual idx (SBV.svInteger k n)) (lookupSeqMap xs n) y
     folded =
       case k of
         KBounded _ w ->
@@ -575,30 +572,32 @@ indexFront mblen a xs _ix idx
             Inf -> liftIO (X.throw (UnsupportedSymbolicOp "unbounded integer indexing"))
 
 indexBack ::
+  SBV ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   SWord SBV ->
   SEval SBV Value
-indexBack (Nat n) a xs ix idx = indexFront (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack"]
+indexBack sym (Nat n) a xs ix idx = indexFront sym (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack"]
 
 indexFront_bits ::
+  SBV ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   [SBit SBV] ->
   SEval SBV Value
-indexFront_bits mblen _a xs _ix bits0 = go 0 (length bits0) bits0
+indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
  where
   go :: Integer -> Int -> [SBit SBV] -> SEval SBV Value
   go i _k []
     -- For indices out of range, fail
     | Nat n <- mblen
     , i >= n
-    = raiseError SBV (InvalidIndex (Just i))
+    = raiseError sym (InvalidIndex (Just i))
 
     | otherwise
     = lookupSeqMap xs i
@@ -608,33 +607,34 @@ indexFront_bits mblen _a xs _ix bits0 = go 0 (length bits0) bits0
     -- are out of bounds
     | Nat n <- mblen
     , (i `shiftL` k) >= n
-    = raiseError SBV (InvalidIndex Nothing)
+    = raiseError sym (InvalidIndex Nothing)
 
     | otherwise
-    = iteValue SBV b
+    = iteValue sym b
          (go ((i `shiftL` 1) + 1) (k-1) bs)
          (go  (i `shiftL` 1)      (k-1) bs)
 
 
 indexBack_bits ::
+  SBV ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   [SBit SBV] ->
   SEval SBV Value
-indexBack_bits (Nat n) a xs ix idx = indexFront_bits (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack_bits Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_bits"]
+indexBack_bits sym (Nat n) a xs ix idx = indexFront_bits sym (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack_bits _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_bits"]
 
 
 -- | Compare a symbolic word value with a concrete integer.
-wordValueEqualsInteger :: WordValue SBV -> Integer -> SEval SBV (SBit SBV)
-wordValueEqualsInteger wv i
-  | wordValueSize SBV wv < widthInteger i = return SBV.svFalse
+wordValueEqualsInteger :: SBV -> WordValue SBV -> Integer -> SEval SBV (SBit SBV)
+wordValueEqualsInteger sym wv i
+  | wordValueSize sym wv < widthInteger i = return SBV.svFalse
   | otherwise =
     case wv of
       WordVal w -> return $ SBV.svEqual w (literalSWord (SBV.intSizeOf w) i)
-      _ -> bitsAre i <$> enumerateWordValueRev SBV wv -- little-endian
+      _ -> bitsAre i <$> enumerateWordValueRev sym wv -- little-endian
   where
     bitsAre :: Integer -> [SBit SBV] -> SBit SBV
     bitsAre n [] = SBV.svBool (n == 0)
@@ -645,49 +645,51 @@ wordValueEqualsInteger wv i
 
 
 updateFrontSym ::
+  SBV ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (SeqMap SBV)
-updateFrontSym _len _eltTy vs (Left idx) val =
+updateFrontSym sym _len _eltTy vs (Left idx) val =
   case SBV.svAsInteger idx of
     Just i -> return $ updateSeqMap vs i val
     Nothing -> return $ IndexSeqMap $ \i ->
-      do b <- intEq SBV idx =<< integerLit SBV i
-         iteValue SBV b val (lookupSeqMap vs i)
+      do b <- intEq sym idx =<< integerLit sym i
+         iteValue sym b val (lookupSeqMap vs i)
 
-updateFrontSym _len _eltTy vs (Right wv) val =
+updateFrontSym sym _len _eltTy vs (Right wv) val =
   case wv of
     WordVal w | Just j <- SBV.svAsInteger w ->
       return $ updateSeqMap vs j val
     _ ->
       return $ IndexSeqMap $ \i ->
-      do b <- wordValueEqualsInteger wv i
-         iteValue SBV b val (lookupSeqMap vs i)
+      do b <- wordValueEqualsInteger sym wv i
+         iteValue sym b val (lookupSeqMap vs i)
 
 updateFrontSym_word ::
+  SBV ->
   Nat' ->
   TValue ->
   WordValue SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (WordValue SBV)
-updateFrontSym_word Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateFrontSym_bits"]
+updateFrontSym_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateFrontSym_bits"]
 
-updateFrontSym_word (Nat _) eltTy (LargeBitsVal n bv) idx val =
-  LargeBitsVal n <$> updateFrontSym (Nat n) eltTy bv idx val
+updateFrontSym_word sym (Nat _) eltTy (LargeBitsVal n bv) idx val =
+  LargeBitsVal n <$> updateFrontSym sym (Nat n) eltTy bv idx val
 
-updateFrontSym_word (Nat n) eltTy (WordVal bv) (Left idx) val =
-  do idx' <- wordFromInt SBV n idx
-     updateFrontSym_word (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
+updateFrontSym_word sym (Nat n) eltTy (WordVal bv) (Left idx) val =
+  do idx' <- wordFromInt sym n idx
+     updateFrontSym_word sym (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
 
-updateFrontSym_word (Nat n) eltTy bv (Right wv) val =
+updateFrontSym_word sym (Nat n) eltTy bv (Right wv) val =
   case wv of
     WordVal idx
       | Just j <- SBV.svAsInteger idx ->
-          updateWordValue SBV bv j (fromVBit <$> val)
+          updateWordValue sym bv j (fromVBit <$> val)
 
       | WordVal bw <- bv ->
         WordVal <$>
@@ -700,55 +702,57 @@ updateFrontSym_word (Nat n) eltTy bv (Right wv) val =
              let bw'  = SBV.svAnd bw (SBV.svNot msk)
              return $! SBV.svXOr bw' (SBV.svAnd q msk)
 
-    _ -> LargeBitsVal n <$> updateFrontSym (Nat n) eltTy (asBitsMap SBV bv) (Right wv) val
+    _ -> LargeBitsVal n <$> updateFrontSym sym (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
 
 
 updateBackSym ::
+  SBV ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (SeqMap SBV)
-updateBackSym Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym"]
+updateBackSym _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym"]
 
-updateBackSym (Nat n) _eltTy vs (Left idx) val =
+updateBackSym sym (Nat n) _eltTy vs (Left idx) val =
   case SBV.svAsInteger idx of
     Just i -> return $ updateSeqMap vs (n - 1 - i) val
     Nothing -> return $ IndexSeqMap $ \i ->
-      do b <- intEq SBV idx =<< integerLit SBV (n - 1 - i)
-         iteValue SBV b val (lookupSeqMap vs i)
+      do b <- intEq sym idx =<< integerLit sym (n - 1 - i)
+         iteValue sym b val (lookupSeqMap vs i)
 
-updateBackSym (Nat n) _eltTy vs (Right wv) val =
+updateBackSym sym (Nat n) _eltTy vs (Right wv) val =
   case wv of
     WordVal w | Just j <- SBV.svAsInteger w ->
       return $ updateSeqMap vs (n - 1 - j) val
     _ ->
       return $ IndexSeqMap $ \i ->
-      do b <- wordValueEqualsInteger wv (n - 1 - i)
-         iteValue SBV b val (lookupSeqMap vs i)
+      do b <- wordValueEqualsInteger sym wv (n - 1 - i)
+         iteValue sym b val (lookupSeqMap vs i)
 
 updateBackSym_word ::
+  SBV ->
   Nat' ->
   TValue ->
   WordValue SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (WordValue SBV)
-updateBackSym_word Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym_bits"]
+updateBackSym_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym_bits"]
 
-updateBackSym_word (Nat _) eltTy (LargeBitsVal n bv) idx val =
-  LargeBitsVal n <$> updateBackSym (Nat n) eltTy bv idx val
+updateBackSym_word sym (Nat _) eltTy (LargeBitsVal n bv) idx val =
+  LargeBitsVal n <$> updateBackSym sym (Nat n) eltTy bv idx val
 
-updateBackSym_word (Nat n) eltTy (WordVal bv) (Left idx) val =
-  do idx' <- wordFromInt SBV n idx
-     updateBackSym_word (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
+updateBackSym_word sym (Nat n) eltTy (WordVal bv) (Left idx) val =
+  do idx' <- wordFromInt sym n idx
+     updateBackSym_word sym (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
 
-updateBackSym_word (Nat n) eltTy bv (Right wv) val = do
+updateBackSym_word sym (Nat n) eltTy bv (Right wv) val = do
   case wv of
     WordVal idx
       | Just j <- SBV.svAsInteger idx ->
-          updateWordValue SBV bv (n - 1 - j) (fromVBit <$> val)
+          updateWordValue sym bv (n - 1 - j) (fromVBit <$> val)
 
       | WordVal bw <- bv ->
         WordVal <$>
@@ -761,7 +765,7 @@ updateBackSym_word (Nat n) eltTy bv (Right wv) val = do
              let bw'  = SBV.svAnd bw (SBV.svNot msk)
              return $! SBV.svXOr bw' (SBV.svAnd q msk)
 
-    _ -> LargeBitsVal n <$> updateBackSym (Nat n) eltTy (asBitsMap SBV bv) (Right wv) val
+    _ -> LargeBitsVal n <$> updateBackSym sym (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
 
 
 asWordList :: [WordValue SBV] -> Maybe [SWord SBV]
@@ -772,32 +776,32 @@ asWordList = go id
        go _f (LargeBitsVal _ _ : _) = Nothing
 
 
-sModAdd :: Integer -> SInteger SBV -> SInteger SBV -> SEval SBV (SInteger SBV)
-sModAdd 0 _ _ = evalPanic "sModAdd" ["0 modulus not allowed"]
-sModAdd modulus x y =
+sModAdd :: SBV -> Integer -> SInteger SBV -> SInteger SBV -> SEval SBV (SInteger SBV)
+sModAdd _ 0 _ _ = evalPanic "sModAdd" ["0 modulus not allowed"]
+sModAdd sym modulus x y =
   case (SBV.svAsInteger x, SBV.svAsInteger y) of
-    (Just i, Just j) -> integerLit SBV ((i + j) `mod` modulus)
+    (Just i, Just j) -> integerLit sym ((i + j) `mod` modulus)
     _                -> pure $ SBV.svPlus x y
 
-sModSub :: Integer -> SInteger SBV -> SInteger SBV -> SEval SBV (SInteger SBV)
-sModSub 0 _ _ = evalPanic "sModSub" ["0 modulus not allowed"]
-sModSub modulus x y =
+sModSub :: SBV -> Integer -> SInteger SBV -> SInteger SBV -> SEval SBV (SInteger SBV)
+sModSub _ 0 _ _ = evalPanic "sModSub" ["0 modulus not allowed"]
+sModSub sym modulus x y =
   case (SBV.svAsInteger x, SBV.svAsInteger y) of
-    (Just i, Just j) -> integerLit SBV ((i - j) `mod` modulus)
+    (Just i, Just j) -> integerLit sym ((i - j) `mod` modulus)
     _                -> pure $ SBV.svMinus x y
 
-sModNegate :: Integer -> SInteger SBV -> SEval SBV (SInteger SBV)
-sModNegate 0 _ = evalPanic "sModNegate" ["0 modulus not allowed"]
-sModNegate modulus x =
+sModNegate :: SBV -> Integer -> SInteger SBV -> SEval SBV (SInteger SBV)
+sModNegate _ 0 _ = evalPanic "sModNegate" ["0 modulus not allowed"]
+sModNegate sym modulus x =
   case SBV.svAsInteger x of
-    Just i -> integerLit SBV ((negate i) `mod` modulus)
+    Just i -> integerLit sym ((negate i) `mod` modulus)
     _      -> pure $ SBV.svUNeg x
 
-sModMult :: Integer -> SInteger SBV -> SInteger SBV -> SEval SBV (SInteger SBV)
-sModMult 0 _ _ = evalPanic "sModMult" ["0 modulus not allowed"]
-sModMult modulus x y =
+sModMult :: SBV -> Integer -> SInteger SBV -> SInteger SBV -> SEval SBV (SInteger SBV)
+sModMult _ 0 _ _ = evalPanic "sModMult" ["0 modulus not allowed"]
+sModMult sym modulus x y =
   case (SBV.svAsInteger x, SBV.svAsInteger y) of
-    (Just i, Just j) -> integerLit SBV ((i * j) `mod` modulus)
+    (Just i, Just j) -> integerLit sym ((i * j) `mod` modulus)
     _                -> pure $ SBV.svTimes x y
 
 -- | Ceiling (log_2 x)
@@ -808,10 +812,10 @@ sLg2 x = pure $ go 0
     go i | i < SBV.intSizeOf x = SBV.svIte (SBV.svLessEq x (lit (2^i))) (lit (toInteger i)) (go (i + 1))
          | otherwise           = lit (toInteger i)
 
-svDivisible :: Integer -> SInteger SBV -> SEval SBV (SBit SBV)
-svDivisible m x =
-  do m' <- integerLit SBV m
-     z  <- integerLit SBV 0
+svDivisible :: SBV -> Integer -> SInteger SBV -> SEval SBV (SBit SBV)
+svDivisible sym m x =
+  do m' <- integerLit sym m
+     z  <- integerLit sym 0
      pure $ SBV.svEqual (SBV.svRem x m') z
 
 signedQuot :: SWord SBV -> SWord SBV -> SWord SBV
@@ -838,21 +842,21 @@ shl x idx =
     Just i  -> SBV.svShl x (fromInteger i)
     Nothing -> SBV.svShiftLeft x idx
 
-sshrV :: Value
-sshrV =
+sshrV :: SBV -> Value
+sshrV sym =
   nlam $ \n ->
   tlam $ \ix ->
-  wlam SBV $ \x -> return $
+  wlam sym $ \x -> return $
   lam $ \y ->
-   y >>= asIndex SBV ">>$" ix >>= \case
+   y >>= asIndex sym ">>$" ix >>= \case
      Left idx ->
        do let w = toInteger (SBV.intSizeOf x)
           let pneg = svLessThan idx (svInteger KUnbounded 0)
-          zneg <- shl x  . svFromInteger w <$> shiftShrink SBV n ix (SBV.svUNeg idx)
-          zpos <- ashr x . svFromInteger w <$> shiftShrink SBV n ix idx
+          zneg <- shl x  . svFromInteger w <$> shiftShrink sym n ix (SBV.svUNeg idx)
+          zpos <- ashr x . svFromInteger w <$> shiftShrink sym n ix idx
           let z = svSymbolicMerge (kindOf x) True pneg zneg zpos
           return . VWord w . pure . WordVal $ z
 
      Right wv ->
-       do z <- ashr x <$> asWordVal SBV wv
+       do z <- ashr x <$> asWordVal sym wv
           return . VWord (toInteger (SBV.intSizeOf x)) . pure . WordVal $ z

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -9,7 +9,6 @@
 module Cryptol.Eval.What4
   ( What4(..)
   , W4Result(..)
-  , W4Defs(..)
   , W4Eval
   , w4Eval
   , Value
@@ -32,8 +31,8 @@ import Cryptol.Testing.Random( randomV )
 import Cryptol.Utils.Ident
 
 -- See also Cryptol.Prims.Eval.primTable
-primTable :: W4.IsSymExprBuilder sym => sym -> Map.Map PrimIdent (Value sym)
-primTable w4sym = let sym = What4 w4sym in
+primTable :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Value sym)
+primTable sym@(What4 w4sym _) =
   Map.union (floatPrims sym) $
   Map.fromList $ map (\(n, v) -> (prelPrim n, v))
 
@@ -84,7 +83,7 @@ primTable w4sym = let sym = What4 w4sym in
   , ("/$"          , sdivV sym)
   , ("%$"          , smodV sym)
   , ("lg2"         , lg2V sym)
-  , (">>$"         , sshrV w4sym)
+  , (">>$"         , sshrV sym)
 
     -- Cmp
   , ("<"           , binary (lessThanV sym))
@@ -149,11 +148,11 @@ primTable w4sym = let sym = What4 w4sym in
                         rotateRightReindex rotateLeftReindex)
 
     -- Indexing and updates
-  , ("@"           , indexPrim sym (indexFront_int w4sym) (indexFront_bits w4sym) (indexFront_word w4sym))
-  , ("!"           , indexPrim sym (indexBack_int w4sym) (indexBack_bits w4sym) (indexBack_word w4sym))
+  , ("@"           , indexPrim sym (indexFront_int sym) (indexFront_bits sym) (indexFront_word sym))
+  , ("!"           , indexPrim sym (indexBack_int sym) (indexBack_bits sym) (indexBack_word sym))
 
-  , ("update"      , updatePrim sym (updateFrontSym_word w4sym) (updateFrontSym w4sym))
-  , ("updateEnd"   , updatePrim sym (updateBackSym_word w4sym)  (updateBackSym w4sym))
+  , ("update"      , updatePrim sym (updateFrontSym_word sym) (updateFrontSym sym))
+  , ("updateEnd"   , updatePrim sym (updateBackSym_word sym)  (updateBackSym sym))
 
     -- Misc
 

--- a/src/Cryptol/Eval/What4/Float.hs
+++ b/src/Cryptol/Eval/What4/Float.hs
@@ -17,40 +17,40 @@ import Cryptol.Utils.Ident(PrimIdent, floatPrim)
 
 -- | Table of floating point primitives
 floatPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map PrimIdent (Value sym)
-floatPrims sym4@(What4 sym) =
+floatPrims sym@(What4 w4sym _) =
   Map.fromList [ (floatPrim i,v) | (i,v) <- nonInfixTable ]
   where
   (~>) = (,)
 
   nonInfixTable =
-    [ "fpNaN"       ~> fpConst (W4.fpNaN sym)
-    , "fpPosInf"    ~> fpConst (W4.fpPosInf sym)
-    , "fpFromBits"  ~> ilam \e -> ilam \p -> wlam sym4 \w ->
-                       VFloat <$> liftIO (W4.fpFromBinary sym e p w)
+    [ "fpNaN"       ~> fpConst (W4.fpNaN w4sym)
+    , "fpPosInf"    ~> fpConst (W4.fpPosInf w4sym)
+    , "fpFromBits"  ~> ilam \e -> ilam \p -> wlam sym \w ->
+                       VFloat <$> liftIO (W4.fpFromBinary w4sym e p w)
     , "fpToBits"    ~> ilam \e -> ilam \p -> flam \x ->
                        pure $ VWord (e+p)
-                            $ WordVal <$> liftIO (W4.fpToBinary sym x)
+                            $ WordVal <$> liftIO (W4.fpToBinary w4sym x)
     , "=.="         ~> ilam \_ -> ilam \_ -> flam \x -> pure $ flam \y ->
-                       VBit <$> liftIO (W4.fpEq sym x y)
+                       VBit <$> liftIO (W4.fpEq w4sym x y)
     , "fpIsFinite"  ~> ilam \_ -> ilam \_ -> flam \x ->
-                       VBit <$> liftIO do inf <- W4.fpIsInf sym x
-                                          nan <- W4.fpIsNaN sym x
-                                          weird <- W4.orPred sym inf nan
-                                          W4.notPred sym weird
+                       VBit <$> liftIO do inf <- W4.fpIsInf w4sym x
+                                          nan <- W4.fpIsNaN w4sym x
+                                          weird <- W4.orPred w4sym inf nan
+                                          W4.notPred w4sym weird
 
-    , "fpAdd"       ~> fpBinArithV sym4 fpPlus
-    , "fpSub"       ~> fpBinArithV sym4 fpMinus
-    , "fpMul"       ~> fpBinArithV sym4 fpMult
-    , "fpDiv"       ~> fpBinArithV sym4 fpDiv
+    , "fpAdd"       ~> fpBinArithV sym fpPlus
+    , "fpSub"       ~> fpBinArithV sym fpMinus
+    , "fpMul"       ~> fpBinArithV sym fpMult
+    , "fpDiv"       ~> fpBinArithV sym fpDiv
 
     , "fpFromRational" ~>
-       ilam \e -> ilam \p -> wlam sym4 \r -> pure $ lam \x ->
+       ilam \e -> ilam \p -> wlam sym \r -> pure $ lam \x ->
        do rat <- fromVRational <$> x
-          VFloat <$> fpCvtFromRational sym4 e p r rat
+          VFloat <$> fpCvtFromRational sym e p r rat
 
     , "fpToRational" ~>
        ilam \_e -> ilam \_p -> flam \fp ->
-       VRational <$> fpCvtToRational sym4 fp
+       VRational <$> fpCvtToRational sym fp
     ]
 
 

--- a/src/Cryptol/Eval/What4/SFloat.hs
+++ b/src/Cryptol/Eval/What4/SFloat.hs
@@ -11,6 +11,7 @@ module Cryptol.Eval.What4.SFloat
     SFloat(..)
   , fpReprOf
   , fpSize
+  , fpRepr
 
     -- * Constants
   , fpFresh

--- a/src/Cryptol/Eval/What4/Value.hs
+++ b/src/Cryptol/Eval/What4/Value.hs
@@ -946,20 +946,20 @@ fpCvtToInteger sym@(What4 sy _) fun r x =
 fpCvtToRational ::
   (W4.IsSymExprBuilder sy, sym ~ What4 sy) =>
   sym -> SFloat sym -> SEval sym (SRational sym)
-fpCvtToRational sym@(What4 sy _) fp =
+fpCvtToRational sym@(What4 w4sym _) fp =
   do grd <- liftIO
-            do bad1 <- FP.fpIsInf sy fp
-               bad2 <- FP.fpIsNaN sy fp
-               W4.notPred sy =<< W4.orPred sy bad1 bad2
+            do bad1 <- FP.fpIsInf w4sym fp
+               bad2 <- FP.fpIsNaN w4sym fp
+               W4.notPred w4sym =<< W4.orPred w4sym bad1 bad2
      assertSideCondition sym grd (BadValue "fpToRational")
-     (rel,x,y) <- liftIO (FP.fpToRational sy fp)
-     addDefEqn sym rel
+     (rel,x,y) <- liftIO (FP.fpToRational w4sym fp)
+     addDefEqn sym =<< liftIO (W4.impliesPred w4sym grd rel)
      ratio sym x y
 
 fpCvtFromRational ::
   (W4.IsExprBuilder sy, sym ~ What4 sy) =>
   sym -> Integer -> Integer -> SWord sym ->
   SRational sym -> SEval sym (SFloat sym)
-fpCvtFromRational sym@(What4 sy _) e p r rat =
+fpCvtFromRational sym@(What4 w4sym _) e p r rat =
   do rnd <- fpRoundingMode sym r
-     liftIO (FP.fpFromRational sy e p rnd (sNum rat) (sDenom rat))
+     liftIO (FP.fpFromRational w4sym e p rnd (sNum rat) (sDenom rat))

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -36,21 +37,24 @@ module Cryptol.Symbolic
  , FreshVarFns(..)
  , modelPred
  , varModelPred
+ , varToExpr
  ) where
 
 
 import Control.Monad (foldM)
 import Data.IORef(IORef)
 import Data.List (genericReplicate)
+import Data.Ratio
+import qualified LibBF as FP
 
 
 import           Cryptol.Eval.Backend
 import qualified Cryptol.Eval.Concrete as Concrete
+import           Cryptol.Eval.Concrete.FloatHelpers(bfValue)
 import           Cryptol.Eval.Value
 import           Cryptol.TypeCheck.AST
 import           Cryptol.Eval.Type (TValue(..), evalType)
-import           Cryptol.Eval.Monad (runEval)
-import           Cryptol.Utils.Ident (Ident)
+import           Cryptol.Utils.Ident (Ident,prelPrim,floatPrim)
 import           Cryptol.Utils.RecordMap
 import           Cryptol.Utils.Panic
 import           Cryptol.Utils.PP
@@ -182,6 +186,22 @@ data VarShape sym
   | VarTuple [VarShape sym]
   | VarRecord (RecordMap Ident (VarShape sym))
 
+ppVarShape :: Backend sym => sym -> VarShape sym -> Doc
+ppVarShape sym (VarBit b) = ppBit sym b
+ppVarShape sym (VarInteger i) = ppInteger sym defaultPPOpts i
+ppVarShape sym (VarFloat f) = ppFloat sym defaultPPOpts f
+ppVarShape sym (VarRational n d) =
+  text "(ratio" <+> ppInteger sym defaultPPOpts n <+> ppInteger sym defaultPPOpts d <+> text ")"
+ppVarShape sym (VarWord w) = ppWord sym defaultPPOpts w
+ppVarShape sym (VarFinSeq _ xs) =
+  brackets (fsep (punctuate comma (map (ppVarShape sym) xs)))
+ppVarShape sym (VarTuple xs) =
+  parens (sep (punctuate comma (map (ppVarShape sym) xs)))
+ppVarShape sym (VarRecord fs) =
+  braces (sep (punctuate comma (map ppField (displayFields fs))))
+ where
+  ppField (f,v) = pp f <+> char '=' <+> ppVarShape sym v
+
 
 varShapeToValue :: Backend sym => sym -> VarShape sym -> GenValue sym
 varShapeToValue sym var =
@@ -213,28 +233,23 @@ freshVar fns tp = case tp of
     FTIntMod 0    -> panic "freshVariable" ["0 modulus not allowed"]
     FTIntMod m    -> VarInteger  <$> freshIntegerVar fns (Just 0) (Just (m-1))
     FTFloat e p   -> VarFloat    <$> freshFloatVar fns e p
-    FTSeq n FTBit -> VarWord     <$> freshWordVar fns (toInteger n)
+    FTSeq n FTBit | n > 0 -> VarWord     <$> freshWordVar fns (toInteger n)
     FTSeq n t     -> VarFinSeq (toInteger n) <$> sequence (genericReplicate n (freshVar fns t))
     FTTuple ts    -> VarTuple    <$> mapM (freshVar fns) ts
     FTRecord fs   -> VarRecord   <$> traverse (freshVar fns) fs
-
-
-
 
 computeModel ::
   PrimMap ->
   [FinType] ->
   [VarShape Concrete.Concrete] ->
-  IO [(Type, Expr, Concrete.Value)]
-computeModel _ [] [] = return []
+  [(Type, Expr, Concrete.Value)]
+computeModel _ [] [] = []
 computeModel primMap (t:ts) (v:vs) =
   do let v' = varShapeToValue Concrete.Concrete v
      let t' = unFinType t
-     e <- runEval (Concrete.toExpr primMap t' v') >>= \case
-             Nothing -> panic "computeModel" ["could not compute counterexample expression"]
-             Just e  -> pure e
-     zs <- computeModel primMap ts vs
-     return ((t',e,v'):zs)
+     let e  = varToExpr primMap t v
+     let zs = computeModel primMap ts vs
+      in ((t',e,v'):zs)
 computeModel _ _ _ = panic "computeModel" ["type/value list mismatch"]
 
 
@@ -277,3 +292,75 @@ varModelPred sym vx =
     (VarTuple vs, VarTuple xs) -> modelPred sym vs xs
     (VarRecord vs, VarRecord xs) -> modelPred sym (recordElements vs) (recordElements xs)
     _ -> panic "varModelPred" ["variable shape mismatch!"]
+
+
+varToExpr :: PrimMap -> FinType -> VarShape Concrete.Concrete -> Expr
+varToExpr prims = go
+  where
+
+  prim n = ePrim prims (prelPrim n)
+
+  go :: FinType -> VarShape Concrete.Concrete -> Expr
+  go ty val =
+    case (ty,val) of
+      (FTRecord tfs, VarRecord vfs) ->
+        let res = zipRecords (\_lbl v t -> go t v) vfs tfs
+         in case res of
+              Left _ -> mismatch -- different fields
+              Right efs -> ERec efs
+      (FTTuple ts, VarTuple tvs) ->
+        ETuple (zipWith go ts tvs)
+
+      (FTBit, VarBit b) ->
+        prim (if b then "True" else "False")
+
+      (FTInteger, VarInteger i) ->
+        -- This works uniformly for values of type Integer or Z n
+        ETApp (ETApp (prim "number") (tNum i)) (unFinType ty)
+
+      (FTIntMod _, VarInteger i) ->
+        -- This works uniformly for values of type Integer or Z n
+        ETApp (ETApp (prim "number") (tNum i)) (unFinType ty)
+
+      (FTRational, VarRational n d) ->
+        let n' = ETApp (ETApp (prim "number") (tNum n)) tInteger
+            d' = ETApp (ETApp (prim "number") (tNum d)) tInteger
+         in EApp (EApp (prim "ratio") n') d'
+
+      (FTFloat e p, VarFloat f) ->
+        floatToExpr prims e p (bfValue f)
+
+      (FTSeq _ FTBit, VarWord (Concrete.BV _ v)) ->
+        ETApp (ETApp (prim "number") (tNum v)) (unFinType ty)
+
+      (FTSeq _ t, VarFinSeq _ svs) ->
+        EList (map (go t) svs) (unFinType t)
+
+      _ -> mismatch
+    where
+      mismatch =
+           panic "Cryptol.Symbolic.varToExpr"
+             ["type mismatch:"
+             , show (pp (unFinType ty))
+             , show (ppVarShape Concrete.Concrete val)
+             ]
+
+floatToExpr :: PrimMap -> Integer -> Integer -> FP.BigFloat -> Expr
+floatToExpr prims e p f =
+  case FP.bfToRep f of
+    FP.BFNaN -> mkP "fpNaN"
+    FP.BFRep sign num ->
+      case (sign,num) of
+        (FP.Pos, FP.Zero)   -> mkP "fpPosZero"
+        (FP.Neg, FP.Zero)   -> mkP "fpNegZero"
+        (FP.Pos, FP.Inf)    -> mkP "fpPosInf"
+        (FP.Neg, FP.Inf)    -> mkP "fpNegInf"
+        (_, FP.Num m ex) ->
+            let r = toRational m * (2 ^^ ex)
+            in EProofApp $ ePrim prims (prelPrim "fraction")
+                          `ETApp` tNum (numerator r)
+                          `ETApp` tNum (denominator r)
+                          `ETApp` tNum (0 :: Int)
+                          `ETApp` tFloat (tNum e) (tNum p)
+  where
+  mkP n = EProofApp $ ePrim prims (floatPrim n) `ETApp` (tNum e) `ETApp` (tNum p)

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -218,7 +218,12 @@ runMultiProvers pc lPutStrLn provers callSolver processResult e = do
 
 -- | Select the appropriate solver or solvers from the given prover command,
 --   and invoke those solvers on the given symbolic value.
-runProver :: SBVProverConfig -> ProverCommand -> (String -> IO ()) -> SBV.Symbolic SBV.SVal -> IO (Maybe String, [SBV.SMTResult])
+runProver ::
+  SBVProverConfig ->
+  ProverCommand ->
+  (String -> IO ()) ->
+  SBV.Symbolic SBV.SVal ->
+  IO (Maybe String, [SBV.SMTResult])
 runProver proverConfig pc@ProverCommand{..} lPutStrLn x =
   do let mSatNum = case pcQueryType of
                      SatQuery (SomeSat n) -> Just n
@@ -304,7 +309,7 @@ prepareQuery evo modEnv ProverCommand{..} =
                  let ?evalPrim = \i -> Map.lookup i tbl
                  -- Compute the symbolic inputs, and any domain constraints needed
                  -- according to their types.
-                 args <- map (varShapeToValue sym) <$>
+                 args <- map (pure . varShapeToValue sym) <$>
                      liftIO (mapM (freshVar (sbvFreshFns sym)) ts)
                  -- Run the main symbolic computation.  First we populate the
                  -- evaluation environment, then we compute the value, finally
@@ -312,7 +317,7 @@ prepareQuery evo modEnv ProverCommand{..} =
                  (safety,b) <- doSBVEval $
                      do env <- Eval.evalDecls sym extDgs mempty
                         v <- Eval.evalExpr sym env pcExpr
-                        appliedVal <- foldM Eval.fromVFun v (map pure args)
+                        appliedVal <- foldM Eval.fromVFun v args
                         case pcQueryType of
                           SafetyQuery ->
                             do Eval.forceValue appliedVal
@@ -487,7 +492,6 @@ parseValue (FTFloat e p) cvs =
    , cvs
    )
    -- XXX: NOT IMPLEMENTED
-
 
 
 freshBoundedInt :: SBV -> Maybe Integer -> Maybe Integer -> IO SBV.SVal

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -195,11 +195,6 @@ proverError msg (_, _, modEnv) =
 data CryptolState t = CryptolState
 
 
-
--- TODO? move this?
-allDeclGroups :: M.ModuleEnv -> [DeclGroup]
-allDeclGroups = concatMap mDecls . M.loadedNonParamModules
-
 setupAdapterOptions :: W4ProverConfig -> W4.ExprBuilder t CryptolState fs -> IO ()
 setupAdapterOptions cfg sym =
    case cfg of
@@ -264,7 +259,7 @@ prepareQuery sym ProverCommand { .. } =
        doW4Eval sym
          do let tbl = primTable sym
             let ?evalPrim = \i -> Map.lookup i tbl
-            let extDgs = allDeclGroups modEnv ++ pcExtraDecls
+            let extDgs = M.allDeclGroups modEnv ++ pcExtraDecls
             env <- Eval.evalDecls (What4 sym) extDgs mempty
             v   <- Eval.evalExpr  (What4 sym) env    pcExpr
             appliedVal <-

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -498,7 +498,7 @@ computeModel' ::
   [VarShape (What4 (W4.ExprBuilder t CryptolState fm))] ->
   IO [(Type, Expr, Concrete.Value)]
 computeModel' prims evalFn ftys vs =
-  computeModel prims ftys =<< mapM (varShapeToConcrete evalFn) vs
+  computeModel prims ftys <$> mapM (varShapeToConcrete evalFn) vs
 
 varShapeToConcrete ::
   W4.GroundEvalFn t ->


### PR DESCRIPTION
Refactor some of the symbolic backend code.  This brings the What4 and SBV backends closer together in terms of structure. We also fix some bugs regarding the use of defining equations in the What4 backend, and give the SBV backend the same basic defining equation ability.

