### PR TITLE
Issue894

### DIFF
--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -50,7 +50,7 @@ import Cryptol.TypeCheck.TypeMap
 import qualified Cryptol.TypeCheck.SimpType as Simp
 import qualified Cryptol.TypeCheck.SimpleSolver as Simp
 import Cryptol.Utils.Panic(panic)
-import Cryptol.Utils.Misc(anyJust)
+import Cryptol.Utils.Misc (anyJust, anyJust2)
 
 -- | A 'Subst' value represents a substitution that maps each 'TVar'
 -- to a 'Type'.
@@ -237,8 +237,7 @@ apSubstMaybe su ty =
            _    -> Just (TCon t ss)
 
     TUser f ts t ->
-      do t1 <- apSubstMaybe su t
-         let !ts1 = fmap' (apSubst su) ts
+      do (ts1, t1) <- anyJust2 (anyJust (apSubstMaybe su)) (apSubstMaybe su) (ts, t)
          Just (TUser f ts1 t1)
 
     TRec fs       -> TRec `fmap` (anyJust (apSubstMaybe su) fs)

--- a/src/Cryptol/Utils/Misc.hs
+++ b/src/Cryptol/Utils/Misc.hs
@@ -10,7 +10,6 @@
 module Cryptol.Utils.Misc where
 
 import MonadLib
-import Data.Maybe(fromMaybe)
 
 import Prelude ()
 import Prelude.Compat
@@ -32,4 +31,6 @@ anyJust2 :: (a -> Maybe a) -> (b -> Maybe b) -> (a,b) -> Maybe (a,b)
 anyJust2 f g (a,b) =
   case (f a, g b) of
     (Nothing, Nothing) -> Nothing
-    (x,y)              -> Just (fromMaybe a x, fromMaybe b y)
+    (Just x , Nothing) -> Just (x, b)
+    (Nothing, Just y ) -> Just (a, y)
+    (Just x , Just y ) -> Just (x, y)

--- a/tests/issues/issue894.cry
+++ b/tests/issues/issue894.cry
@@ -1,0 +1,4 @@
+type Int n = Integer
+
+foo : {n} (fin n) => [n] -> Int n
+foo x = `n

--- a/tests/issues/issue894.icry
+++ b/tests/issues/issue894.icry
@@ -1,0 +1,2 @@
+:l issue894.cry
+:t foo 0x1

--- a/tests/issues/issue894.icry.stdout
+++ b/tests/issues/issue894.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+[warning] at issue894.cry:1:10--1:11 Unused name: n
+[warning] at issue894.cry:1:6--1:9:
+  Assuming  n to have a numeric type
+foo 0x1 : Int 4


### PR DESCRIPTION
Fix bug in definition of `apSubstMaybe`. Fixes #894.
    
We also needed to rewrite `anyJust2` to make it more strict, to avoid reintroducing the space leak of issue #888.