### PR TITLE
Issue485

### DIFF
--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -871,8 +871,16 @@ instance PP (WithNames Type) where
       _ | Just tinf <- isTInfix ty0 -> optParens (prec > 2)
                                      $ ppInfix 2 isTInfix tinf
 
-      TUser c [] _ -> pp c
-      TUser c ts _ -> optParens (prec > 3) $ pp c <+> fsep (map (go 4) ts)
+      TUser c ts t ->
+        withNameDisp $ \disp ->
+        case nameInfo c of
+          Declared m _
+            | NotInScope <- getNameFormat m (nameIdent c) disp ->
+              go prec t -- unfold type synonym if not in scope
+          _ ->
+            case ts of
+              [] -> pp c
+              _ -> optParens (prec > 3) $ pp c <+> fsep (map (go 4) ts)
 
       TCon (TC tc) ts ->
         case (tc,ts) of

--- a/tests/issues/issue177.icry.stdout
+++ b/tests/issues/issue177.icry.stdout
@@ -7,4 +7,4 @@ Loading module issue177
 w : Byte
 x : Word16
 y : B::Word32
-z : issue177C::Word64
+z : [64]

--- a/tests/issues/issue485.icry
+++ b/tests/issues/issue485.icry
@@ -1,0 +1,4 @@
+:l issue485b.cry
+:t foo
+:t bar
+:t baz

--- a/tests/issues/issue485.icry.stdout
+++ b/tests/issues/issue485.icry.stdout
@@ -1,0 +1,8 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Float
+Loading module issue485a
+Loading module issue485b
+foo : [3]
+bar : [8] -> [8]
+baz : [8] -> [8] -> [8]

--- a/tests/issues/issue485a.cry
+++ b/tests/issues/issue485a.cry
@@ -1,0 +1,16 @@
+module issue485a where
+
+import Float
+
+private type A = [8] -> [8]
+
+private type ByteFun t = [8] -> t
+
+foo : RoundingMode
+foo = 0
+
+bar : A
+bar x = x
+
+baz : ByteFun (ByteFun [8])
+baz = (+)

--- a/tests/issues/issue485b.cry
+++ b/tests/issues/issue485b.cry
@@ -1,0 +1,3 @@
+module issue485b where
+
+import issue485a

--- a/tests/regression/float.icry.stdout
+++ b/tests/regression/float.icry.stdout
@@ -76,7 +76,7 @@ IEEE-754 floating point numbers.
         arising from
         use of expression fraction
         at <interactive>:1:1--1:6
-    • Reason: 5/1 cannot be represented in FloatTests::Small
+    • Reason: 5/1 cannot be represented in Float 3 2
 0x1.3p0
 0x2.0p-4
 0x2.0p-4
@@ -88,7 +88,7 @@ IEEE-754 floating point numbers.
         arising from
         use of literal or demoted expression
         at <interactive>:1:1--1:2
-    • Reason: 7 cannot be represented in FloatTests::Small
+    • Reason: 7 cannot be represented in Float 3 2
 "-- NaN------------------------------------------------------------------------"
 
     fpNaN : {e, p} (ValidFloat e p) => Float e p


### PR DESCRIPTION
Make pretty printer unfold type synonyms when not in scope.
    
Fixes #485.