### PR TITLE
Bind an expression to the "it" variable _before_ evaluating it

### DIFF
--- a/tests/regression/itreuse.icry
+++ b/tests/regression/itreuse.icry
@@ -1,0 +1,2 @@
+traceVal "doing some work" (42 : Integer)
+it

--- a/tests/regression/itreuse.icry.stdout
+++ b/tests/regression/itreuse.icry.stdout
@@ -1,0 +1,4 @@
+Loading module Cryptol
+doing some work 42
+42
+42


### PR DESCRIPTION
so we can cache the value via it's thunk.  This prevents reevaluating
the term when the "it" variable is referenced later.

Fixes #881