### PR TITLE
Fast F2 polynomial arithmetic

### DIFF
--- a/cryptol-remote-api/src/CryptolServer/Data/Expression.hs
+++ b/cryptol-remote-api/src/CryptolServer/Data/Expression.hs
@@ -317,7 +317,7 @@ typeNum _ = empty
 readBack :: PrimMap -> TC.Type -> Value -> Eval Expression
 readBack prims ty val =
   let tbl = primTable theEvalOpts in
-  let ?evalPrim = \i -> Map.lookup i tbl in
+  let ?evalPrim = \i -> Right <$> Map.lookup i tbl in
   case TC.tNoUser ty of
     TC.TRec tfs ->
       Record . HM.fromList <$>

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -180,6 +180,7 @@ library
                        Cryptol.Eval.What4,
 
                        Cryptol.AES,
+                       Cryptol.F2,
                        Cryptol.SHA,
                        Cryptol.PrimeEC,
 

--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -928,6 +928,10 @@ pmod x y = if y == 0 then 0/0 else last zs
     zs = [0] # [ z ^ (if xi then tail p else 0) | xi <- reverse x | p <- powers | z <- zs ]
 
 
+primitive fast_pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + u + v]
+primitive fast_pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+primitive fast_pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+
 // Experimental primitives ------------------------------------------------------------
 
 /**
@@ -1158,5 +1162,3 @@ curry f = \a b -> f (a, b)
 iterate : {a} (a -> a) -> a -> [inf]a
 iterate f x = xs
   where xs = [x] # [ f v | v <- xs ]
-
-

--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -888,49 +888,17 @@ generate f = [ f i | i <- [0 .. n-1] ]
 /**
  * Performs multiplication of polynomials over GF(2).
  */
-pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + u + v]
-pmult x y = last zs
-  where
-    zs = [0] # [ (z << 1) ^ (if yi then 0 # x else 0) | yi <- y | z <- zs ]
+primitive pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + u + v]
 
 /**
  * Performs division of polynomials over GF(2).
  */
-pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
-pdiv x y = [ z ! degree | z <- zs ]
-  where
-    degree : [width v]
-    degree = last (ds : [1 + v]_)
-      where ds = [0/0] # [if yi then i else d | yi <- reverse y | i <- [0..v] | d <- ds ]
-
-    reduce : [v] -> [v]
-    reduce u = if u ! degree then u ^ y else u
-
-    zs : [u][v]
-    zs = [ tail (reduce z # [xi]) | z <- [0] # zs | xi <- x ]
+primitive pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
 
 /**
  * Performs modulus of polynomials over GF(2).
  */
-pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
-pmod x y = if y == 0 then 0/0 else last zs
-  where
-    degree : [width v]
-    degree = last (ds : [2 + v]_)
-      where ds = [0/0] # [if yi then i else d | yi <- reverse y | i <- [0..v] | d <- ds ]
-
-    reduce : [1 + v] -> [1 + v]
-    reduce u = if u ! degree then u ^ y else u
-
-    powers : [inf][1 + v]
-    powers = [reduce 1] # [ reduce (p << 1) | p <- powers ]
-
-    zs = [0] # [ z ^ (if xi then tail p else 0) | xi <- reverse x | p <- powers | z <- zs ]
-
-
-primitive fast_pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + u + v]
-primitive fast_pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
-primitive fast_pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+primitive pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
 
 // Experimental primitives ------------------------------------------------------------
 

--- a/lib/Cryptol/Reference.cry
+++ b/lib/Cryptol/Reference.cry
@@ -1,0 +1,46 @@
+module Cryptol::Reference where
+
+/**
+ * Performs multiplication of polynomials over GF(2).
+ * Reference implementation.
+ */
+pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + u + v]
+pmult x y = last zs
+  where
+    zs = [0] # [ (z << 1) ^ (if yi then 0 # x else 0) | yi <- y | z <- zs ]
+
+/**
+ * Performs division of polynomials over GF(2).
+ * Reference implementation.
+ */
+pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+pdiv x y = [ z ! degree | z <- zs ]
+  where
+    degree : [width v]
+    degree = last (ds : [1 + v]_)
+      where ds = [0/0] # [if yi then i else d | yi <- reverse y | i <- [0..v] | d <- ds ]
+
+    reduce : [v] -> [v]
+    reduce u = if u ! degree then u ^ y else u
+
+    zs : [u][v]
+    zs = [ tail (reduce z # [xi]) | z <- [0] # zs | xi <- x ]
+
+/**
+ * Performs modulus of polynomials over GF(2).
+ * Reference implementation.
+ */
+pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+pmod x y = if y == 0 then 0/0 else last zs
+  where
+    degree : [width v]
+    degree = last (ds : [2 + v]_)
+      where ds = [0/0] # [if yi then i else d | yi <- reverse y | i <- [0..v] | d <- ds ]
+
+    reduce : [1 + v] -> [1 + v]
+    reduce u = if u ! degree then u ^ y else u
+
+    powers : [inf][1 + v]
+    powers = [reduce 1] # [ reduce (p << 1) | p <- powers ]
+
+    zs = [0] # [ z ^ (if xi then tail p else 0) | xi <- reverse x | p <- powers | z <- zs ]

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -145,6 +145,7 @@ primTable eOpts = let sym = Concrete in
   Map.union (floatPrims sym) $
   Map.union suiteBPrims $
   Map.union primeECPrims $
+
   Map.fromList $ map (\(n, v) -> (prelPrim n, v))
 
   [ -- Literals
@@ -353,7 +354,7 @@ primTable eOpts = let sym = Concrete in
                              $ if null msg then doc else text msg <+> doc
                          return yv)
 
-   , ("fast_pmult",
+   , ("pmult",
         ilam $ \u ->
         ilam $ \v ->
           wlam Concrete $ \(BV _ x) -> return $
@@ -364,14 +365,14 @@ primTable eOpts = let sym = Concrete in
                       F2.pmult (fromInteger (v+1)) y x
              in return . VWord (1+u+v) . pure . WordVal . mkBv (1+u+v) $! z)
 
-   , ("fast_pmod",
+   , ("pmod",
         ilam $ \_u ->
         ilam $ \v ->
         wlam Concrete $ \(BV w x) -> return $
         wlam Concrete $ \(BV _ m) ->
           return . VWord v . pure . WordVal . mkBv v $! F2.pmod (fromInteger w) x m)
 
-  , ("fast_pdiv",
+  , ("pdiv",
         ilam $ \_u ->
         ilam $ \_v ->
         wlam Concrete $ \(BV w x) -> return $

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -31,6 +31,7 @@ import Data.Ratio((%),numerator,denominator)
 import Data.Word(Word32, Word64)
 import MonadLib( ChoiceT, findOne, lift )
 import qualified LibBF as FP
+import qualified Cryptol.F2 as F2
 
 import qualified Data.Map.Strict as Map
 import Data.Map(Map)
@@ -352,6 +353,30 @@ primTable eOpts = let sym = Concrete in
                              $ if null msg then doc else text msg <+> doc
                          return yv)
 
+   , ("fast_pmult",
+        ilam $ \u ->
+        ilam $ \v ->
+          wlam Concrete $ \(BV _ x) -> return $
+          wlam Concrete $ \(BV _ y) ->
+            let z = if u <= v then
+                      F2.pmult (fromInteger (u+1)) x y
+                    else
+                      F2.pmult (fromInteger (v+1)) y x
+             in return . VWord (1+u+v) . pure . WordVal . mkBv (1+u+v) $! z)
+
+   , ("fast_pmod",
+        ilam $ \_u ->
+        ilam $ \v ->
+        wlam Concrete $ \(BV w x) -> return $
+        wlam Concrete $ \(BV _ m) ->
+          return . VWord v . pure . WordVal . mkBv v $! F2.pmod (fromInteger w) x m)
+
+  , ("fast_pdiv",
+        ilam $ \_u ->
+        ilam $ \_v ->
+        wlam Concrete $ \(BV w x) -> return $
+        wlam Concrete $ \(BV _ m) ->
+          return . VWord w . pure . WordVal . mkBv w $! F2.pdiv (fromInteger w) x m)
   ]
 
 

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -370,14 +370,16 @@ primTable eOpts = let sym = Concrete in
         ilam $ \v ->
         wlam Concrete $ \(BV w x) -> return $
         wlam Concrete $ \(BV _ m) ->
-          return . VWord v . pure . WordVal . mkBv v $! F2.pmod (fromInteger w) x m)
+          do assertSideCondition sym (m /= 0) DivideByZero
+             return . VWord v . pure . WordVal . mkBv v $! F2.pmod (fromInteger w) x m)
 
   , ("pdiv",
         ilam $ \_u ->
         ilam $ \_v ->
         wlam Concrete $ \(BV w x) -> return $
         wlam Concrete $ \(BV _ m) ->
-          return . VWord w . pure . WordVal . mkBv w $! F2.pdiv (fromInteger w) x m)
+          do assertSideCondition sym (m /= 0) DivideByZero
+             return . VWord w . pure . WordVal . mkBv w $! F2.pdiv (fromInteger w) x m)
   ]
 
 

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -132,7 +132,7 @@ lookupSeqMap (UpdateSeqMap m f) i =
 -- | An arbitrarily-chosen number of elements where we switch from a dense
 --   sequence representation of bit-level words to 'SeqMap' representation.
 largeBitSize :: Integer
-largeBitSize = 1 `shiftL` 16
+largeBitSize = 1 `shiftL` 48
 
 -- | Generate a finite sequence map from a list of values
 finiteSeqMap :: Backend sym => sym -> [SEval sym (GenValue sym)] -> SeqMap sym

--- a/src/Cryptol/F2.hs
+++ b/src/Cryptol/F2.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
+module Cryptol.F2 where
+
+import Data.Bits
+import Cryptol.TypeCheck.Solver.InfNat (widthInteger)
+
+pmult :: Int -> Integer -> Integer -> Integer
+pmult w x y = go (w-1) 0
+  where
+    go !i !z
+      | i >= 0    = go (i-1) (if testBit x i then (z `shiftL` 1) `xor` y else (z `shiftL` 1))
+      | otherwise = z
+
+pdiv :: Int -> Integer -> Integer -> Integer
+pdiv w x m = go (w-1) 0 0
+  where
+    degree :: Int
+    degree = fromInteger (widthInteger m - 1)
+
+    reduce :: Integer -> Integer
+    reduce u = if testBit u degree then u `xor` m else u
+    {-# INLINE reduce #-}
+
+    go !i !z !r
+      | i >= 0    = go (i-1) z' r'
+      | otherwise = r
+     where
+      zred = reduce z
+      z'   = if testBit x  i      then (zred `shiftL` 1) .|. 1 else zred `shiftL` 1
+      r'   = if testBit z' degree then (r    `shiftL` 1) .|. 1 else r    `shiftL` 1
+
+
+pmod :: Int -> Integer -> Integer -> Integer
+pmod w x m = mask .&. go 0 0 (reduce 1)
+  where
+    degree :: Int
+    degree = fromInteger (widthInteger m - 1)
+
+    reduce :: Integer -> Integer
+    reduce u = if testBit u degree then u `xor` m else u
+    {-# INLINE reduce #-}
+
+    mask = bit degree - 1
+
+    go !i !z !p
+      | i < w     = go (i+1) (if testBit x i then z `xor` p else z) (reduce (p `shiftL` 1))
+      | otherwise = z

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -75,7 +75,7 @@ loadModuleByName :: P.ModName -> ModuleCmd (ModulePath,T.Module)
 loadModuleByName n (evo, byteReader, env) =
   runModuleM (evo, byteReader, resetModuleEnv env) $ do
     unloadModule ((n ==) . lmName)
-    (path,m') <- Base.loadModuleFrom (FromModule n)
+    (path,m') <- Base.loadModuleFrom False (FromModule n)
     setFocusedModule (T.mName m')
     return (path,m')
 

--- a/src/Cryptol/Prelude.hs
+++ b/src/Cryptol/Prelude.hs
@@ -15,6 +15,7 @@
 
 module Cryptol.Prelude
   ( preludeContents
+  , preludeReferenceContents
   , floatContents
   , arrayContents
   , suiteBContents
@@ -29,6 +30,9 @@ import Text.Heredoc (there)
 
 preludeContents :: ByteString
 preludeContents = B.pack [there|lib/Cryptol.cry|]
+
+preludeReferenceContents :: ByteString
+preludeReferenceContents = B.pack [there|lib/Cryptol/Reference.cry|]
 
 floatContents :: ByteString
 floatContents = B.pack [there|lib/Float.cry|]

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -288,7 +288,7 @@ prepareQuery ::
   ProverCommand ->
   M.ModuleT IO (Either String ([FinType], SBV.Symbolic SBV.SVal))
 prepareQuery evo ProverCommand{..} =
-  do ds <- do (_mp, m) <- M.loadModuleFrom (M.FromModule preludeReferenceName)
+  do ds <- do (_mp, m) <- M.loadModuleFrom True (M.FromModule preludeReferenceName)
               let decls = mDecls m
               let nms = fst <$> Map.toList (M.ifDecls (M.ifPublic (M.genIface m)))
               let ds = Map.fromList [ (prelPrim (identText (M.nameIdent nm)), EWhere (EVar nm) decls) | nm <- nms ]

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -262,7 +262,7 @@ prepareQuery sym ProverCommand { .. } =
     do let lPutStrLn = M.withLogger logPutStrLn
        when pcVerbose (lPutStrLn "Simulating...")
 
-       ds <- do (_mp, m) <- M.loadModuleFrom (M.FromModule preludeReferenceName)
+       ds <- do (_mp, m) <- M.loadModuleFrom True (M.FromModule preludeReferenceName)
                 let decls = mDecls m
                 let nms = fst <$> Map.toList (M.ifDecls (M.ifPublic (M.genIface m)))
                 let ds = Map.fromList [ (prelPrim (identText (M.nameIdent nm)), EWhere (EVar nm) decls) | nm <- nms ]

--- a/src/Cryptol/Utils/Ident.hs
+++ b/src/Cryptol/Utils/Ident.hs
@@ -16,6 +16,7 @@ module Cryptol.Utils.Ident
   , modNameChunks
   , packModName
   , preludeName
+  , preludeReferenceName
   , floatName
   , suiteBName
   , arrayName
@@ -110,6 +111,9 @@ modInstPref = "`"
 
 preludeName :: ModName
 preludeName  = packModName ["Cryptol"]
+
+preludeReferenceName :: ModName
+preludeReferenceName = packModName ["Cryptol","Reference"]
 
 floatName :: ModName
 floatName = packModName ["Float"]

--- a/tests/issues/T146.icry.stdout
+++ b/tests/issues/T146.icry.stdout
@@ -3,16 +3,16 @@ Loading module Cryptol
 Loading module Main
 
 [error] at T146.cry:1:18--6:10:
-  The type ?fv`980 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`964
+  The type ?fv`786 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`770
     When checking type of field 'v0'
   where
-  ?fv`980 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
-  fv`964 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`786 is type argument 'fv' of 'Main::ec_v1' at T146.cry:4:19--4:24
+  fv`770 is signature variable 'fv' at T146.cry:11:10--11:12
 [error] at T146.cry:5:19--5:24:
-  The type ?fv`982 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: fv`964
+  The type ?fv`788 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: fv`770
     When checking signature variable 'fv'
   where
-  ?fv`982 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
-  fv`964 is signature variable 'fv' at T146.cry:11:10--11:12
+  ?fv`788 is type argument 'fv' of 'Main::ec_v2' at T146.cry:5:19--5:24
+  fv`770 is signature variable 'fv' at T146.cry:11:10--11:12

--- a/tests/issues/T820.icry.stdout
+++ b/tests/issues/T820.icry.stdout
@@ -5,14 +5,14 @@ Showing a specific instance of polymorphic result:
 
 [error] at <interactive>:1:1--1:8:
   Unsolvable constraints:
-    • Integral ?a`970
+    • Integral ?a`776
         arising from
         use of expression (/)
         at <interactive>:1:1--1:8
-    • FLiteral 1 1 0 ?a`970
+    • FLiteral 1 1 0 ?a`776
         arising from
         use of fractional literal
         at <interactive>:1:1--1:8
     • Reason: Mutually exclusive goals
   where
-  ?a`970 is type argument 'a' of 'fraction' at <interactive>:1:1--1:8
+  ?a`776 is type argument 'a' of 'fraction' at <interactive>:1:1--1:8

--- a/tests/issues/issue290v2.icry.stdout
+++ b/tests/issues/issue290v2.icry.stdout
@@ -4,9 +4,9 @@ Loading module Main
 
 [error] at issue290v2.cry:2:1--2:19:
   Unsolved constraints:
-    • n`961 == 1
+    • n`767 == 1
         arising from
         checking a pattern: type of 1st argument of Main::minMax
         at issue290v2.cry:2:8--2:11
   where
-  n`961 is signature variable 'n' at issue290v2.cry:1:11--1:12
+  n`767 is signature variable 'n' at issue290v2.cry:1:11--1:12

--- a/tests/issues/issue723.icry.stdout
+++ b/tests/issues/issue723.icry.stdout
@@ -10,9 +10,9 @@ Loading module Main
       assuming
         • fin k
       the following constraints hold:
-        • k == n`961
+        • k == n`767
             arising from
             matching types
             at issue723.cry:7:17--7:19
   where
-  n`961 is signature variable 'n' at issue723.cry:1:6--1:7
+  n`767 is signature variable 'n' at issue723.cry:1:6--1:7

--- a/tests/issues/issue910.icry.stdout
+++ b/tests/issues/issue910.icry.stdout
@@ -2,28 +2,28 @@ Loading module Cryptol
 
 [error] at <interactive>:1:1--1:21:
   Unsolvable constraints:
-    • Integral ?a`972
+    • Integral ?a`778
         arising from
         use of expression (@)
         at <interactive>:1:8--1:21
-    • Field ?a`972
+    • Field ?a`778
         arising from
         use of expression (/.)
         at <interactive>:1:14--1:20
     • Reason: Mutually exclusive goals
   where
-  ?a`972 is type argument 'a' of '(/.)' at <interactive>:1:14--1:20
+  ?a`778 is type argument 'a' of '(/.)' at <interactive>:1:14--1:20
 
 [error] at <interactive>:1:1--1:16:
   Unsolvable constraints:
-    • Integral ?a`970
+    • Integral ?a`776
         arising from
         use of expression (@)
         at <interactive>:1:8--1:16
-    • FLiteral 6 5 0 ?a`970
+    • FLiteral 6 5 0 ?a`776
         arising from
         use of fractional literal
         at <interactive>:1:13--1:16
     • Reason: Mutually exclusive goals
   where
-  ?a`970 is type argument 'a' of 'fraction' at <interactive>:1:13--1:16
+  ?a`776 is type argument 'a' of 'fraction' at <interactive>:1:13--1:16

--- a/tests/regression/f2polytest.cry
+++ b/tests/regression/f2polytest.cry
@@ -1,0 +1,33 @@
+import Cryptol::Reference as Ref
+
+pmult_equiv : {u, v} (fin u, fin v) => [1+u] -> [1+v] -> Bit
+pmult_equiv x y = pmult x y == Ref::pmult x y
+
+pdiv_equiv : {u, v} (fin u, fin v) => [u] -> [v] -> Bit
+pdiv_equiv x y = y == 0 \/ pdiv x y == Ref::pdiv x y
+
+pmod_equiv : {u, v} (fin u, fin v) => [u] -> [1+v] -> Bit
+pmod_equiv x y = y == 0 \/ pmod x y == Ref::pmod x y
+
+// an arbitrary collection of test sizes
+
+property mult3_9   = pmult_equiv`{3,9}
+property mult9_3   = pmult_equiv`{9,3}
+property mult8_8   = pmult_equiv`{8,8}
+property mult28_11 = pmult_equiv`{28,11}
+property mult32_32 = pmult_equiv`{32,32}
+property mult64_64 = pmult_equiv`{64,64}
+
+property div3_9   = pdiv_equiv`{3,9}
+property div9_3   = pdiv_equiv`{9,3}
+property div8_8   = pdiv_equiv`{8,8}
+property div28_11 = pdiv_equiv`{28,11}
+property div32_32 = pdiv_equiv`{32,32}
+property div64_64 = pdiv_equiv`{64,64}
+
+property mod3_9   = pmod_equiv`{3,9}
+property mod9_3   = pmod_equiv`{9,3}
+property mod8_8   = pmod_equiv`{8,8}
+property mod28_11 = pmod_equiv`{28,11}
+property mod32_32 = pmod_equiv`{32,32}
+property mod64_64 = pmod_equiv`{64,64}

--- a/tests/regression/f2polytest.icry
+++ b/tests/regression/f2polytest.icry
@@ -1,0 +1,6 @@
+:l f2polytest.cry
+:set tests=2000
+
+:check
+
+:prove

--- a/tests/regression/f2polytest.icry.stdout
+++ b/tests/regression/f2polytest.icry.stdout
@@ -1,0 +1,94 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Cryptol::Reference
+Loading module Main
+property mult3_9 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 11.49% (1883 of 16384 values)
+property mult9_3 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 11.49% (1883 of 16384 values)
+property mult8_8 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.76% (1992 of 262144 values)
+property mult28_11 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^41 values)
+property mult32_32 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^66 values)
+property mult64_64 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^130 values)
+property div3_9 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 38.64% (1583 of 4096 values)
+property div9_3 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 38.64% (1583 of 4096 values)
+property div8_8 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 3.01% (1970 of 65536 values)
+property div28_11 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^39 values)
+property div32_32 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^64 values)
+property div64_64 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^128 values)
+property mod3_9 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 21.66% (1775 of 8192 values)
+property mod9_3 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 21.66% (1775 of 8192 values)
+property mod8_8 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 1.51% (1985 of 131072 values)
+property mod28_11 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^40 values)
+property mod32_32 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^65 values)
+property mod64_64 Using random testing.
+Testing... Passed 2000 tests.
+Expected test coverage: 0.00% (2000 of 2^^129 values)
+:prove mult3_9
+	Q.E.D.
+:prove mult9_3
+	Q.E.D.
+:prove mult8_8
+	Q.E.D.
+:prove mult28_11
+	Q.E.D.
+:prove mult32_32
+	Q.E.D.
+:prove mult64_64
+	Q.E.D.
+:prove div3_9
+	Q.E.D.
+:prove div9_3
+	Q.E.D.
+:prove div8_8
+	Q.E.D.
+:prove div28_11
+	Q.E.D.
+:prove div32_32
+	Q.E.D.
+:prove div64_64
+	Q.E.D.
+:prove mod3_9
+	Q.E.D.
+:prove mod9_3
+	Q.E.D.
+:prove mod8_8
+	Q.E.D.
+:prove mod28_11
+	Q.E.D.
+:prove mod32_32
+	Q.E.D.
+:prove mod64_64
+	Q.E.D.

--- a/tests/regression/instance.icry.stdout
+++ b/tests/regression/instance.icry.stdout
@@ -33,13 +33,13 @@ complement`{Bit} : Bit -> Bit
 
 [error] at <interactive>:1:1--1:11:
   Unsolvable constraints:
-    • Logic (Z ?n`1205)
+    • Logic (Z ?n`1011)
         arising from
         use of expression complement
         at <interactive>:1:1--1:11
     • Reason: Type 'Z' does not support logical operations.
   where
-  ?n`1205 is type wildcard (_) at <interactive>:1:15--1:16
+  ?n`1011 is type wildcard (_) at <interactive>:1:15--1:16
 complement`{[_]_} : {n, a} (Logic a) => [n]a -> [n]a
 complement`{(_ -> _)} : {a, b} (Logic b) => (a -> b) -> a -> b
 complement`{()} : () -> ()
@@ -50,14 +50,14 @@ complement`{{x : _, y : _}} : {a, b} (Logic b, Logic a) =>
 
 [error] at <interactive>:1:1--1:11:
   Unsolvable constraints:
-    • Logic (Float ?n`1219 ?n`1220)
+    • Logic (Float ?n`1025 ?n`1026)
         arising from
         use of expression complement
         at <interactive>:1:1--1:11
     • Reason: Type 'Float' does not support logical operations.
   where
-  ?n`1219 is type wildcard (_) at <interactive>:1:19--1:20
-  ?n`1220 is type wildcard (_) at <interactive>:1:21--1:22
+  ?n`1025 is type wildcard (_) at <interactive>:1:19--1:20
+  ?n`1026 is type wildcard (_) at <interactive>:1:21--1:22
 
 [error] at <interactive>:1:1--1:7:
   Unsolvable constraints:
@@ -99,25 +99,25 @@ negate`{Float _ _} : {n, m} (ValidFloat n m) =>
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Integral (Z ?n`1243)
+    • Integral (Z ?n`1049)
         arising from
         use of expression (%)
         at <interactive>:1:1--1:4
-    • Reason: Type 'Z ?n`1243' is not an integral type.
+    • Reason: Type 'Z ?n`1049' is not an integral type.
   where
-  ?n`1243 is type wildcard (_) at <interactive>:1:8--1:9
+  ?n`1049 is type wildcard (_) at <interactive>:1:8--1:9
 (%)`{[_]_} : {n, a} (Integral ([n]a)) => [n]a -> [n]a -> [n]a
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Integral (?a`1246 -> ?a`1247)
+    • Integral (?a`1052 -> ?a`1053)
         arising from
         use of expression (%)
         at <interactive>:1:1--1:4
-    • Reason: Type '?a`1246 -> ?a`1247' is not an integral type.
+    • Reason: Type '?a`1052 -> ?a`1053' is not an integral type.
   where
-  ?a`1246 is type wildcard (_) at <interactive>:1:7--1:8
-  ?a`1247 is type wildcard (_) at <interactive>:1:12--1:13
+  ?a`1052 is type wildcard (_) at <interactive>:1:7--1:8
+  ?a`1053 is type wildcard (_) at <interactive>:1:12--1:13
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
@@ -129,14 +129,14 @@ negate`{Float _ _} : {n, m} (ValidFloat n m) =>
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Integral (?a`1246, ?a`1247)
+    • Integral (?a`1052, ?a`1053)
         arising from
         use of expression (%)
         at <interactive>:1:1--1:4
-    • Reason: Type '(?a`1246, ?a`1247)' is not an integral type.
+    • Reason: Type '(?a`1052, ?a`1053)' is not an integral type.
   where
-  ?a`1246 is type wildcard (_) at <interactive>:1:7--1:8
-  ?a`1247 is type wildcard (_) at <interactive>:1:10--1:11
+  ?a`1052 is type wildcard (_) at <interactive>:1:7--1:8
+  ?a`1053 is type wildcard (_) at <interactive>:1:10--1:11
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
@@ -148,25 +148,25 @@ negate`{Float _ _} : {n, m} (ValidFloat n m) =>
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Integral {x : ?a`1246, y : ?a`1247}
+    • Integral {x : ?a`1052, y : ?a`1053}
         arising from
         use of expression (%)
         at <interactive>:1:1--1:4
-    • Reason: Type '{x : ?a`1246, y : ?a`1247}' is not an integral type.
+    • Reason: Type '{x : ?a`1052, y : ?a`1053}' is not an integral type.
   where
-  ?a`1246 is type wildcard (_) at <interactive>:1:11--1:12
-  ?a`1247 is type wildcard (_) at <interactive>:1:18--1:19
+  ?a`1052 is type wildcard (_) at <interactive>:1:11--1:12
+  ?a`1053 is type wildcard (_) at <interactive>:1:18--1:19
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Integral (Float ?n`1246 ?n`1247)
+    • Integral (Float ?n`1052 ?n`1053)
         arising from
         use of expression (%)
         at <interactive>:1:1--1:4
-    • Reason: Type 'Float ?n`1246 ?n`1247' is not an integral type.
+    • Reason: Type 'Float ?n`1052 ?n`1053' is not an integral type.
   where
-  ?n`1246 is type wildcard (_) at <interactive>:1:12--1:13
-  ?n`1247 is type wildcard (_) at <interactive>:1:14--1:15
+  ?n`1052 is type wildcard (_) at <interactive>:1:12--1:13
+  ?n`1053 is type wildcard (_) at <interactive>:1:14--1:15
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
@@ -188,25 +188,25 @@ recip`{Z _} : {n} (prime n, n >= 1) => Z n -> Z n
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Field ([?n`1249]?a`1250)
+    • Field ([?n`1055]?a`1056)
         arising from
         use of expression recip
         at <interactive>:1:1--1:6
     • Reason: Sequence types do not support field operations.
   where
-  ?n`1249 is type wildcard (_) at <interactive>:1:9--1:10
-  ?a`1250 is type wildcard (_) at <interactive>:1:11--1:12
+  ?n`1055 is type wildcard (_) at <interactive>:1:9--1:10
+  ?a`1056 is type wildcard (_) at <interactive>:1:11--1:12
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Field (?a`1249 -> ?a`1250)
+    • Field (?a`1055 -> ?a`1056)
         arising from
         use of expression recip
         at <interactive>:1:1--1:6
     • Reason: Function types do not support field operations.
   where
-  ?a`1249 is type wildcard (_) at <interactive>:1:9--1:10
-  ?a`1250 is type wildcard (_) at <interactive>:1:14--1:15
+  ?a`1055 is type wildcard (_) at <interactive>:1:9--1:10
+  ?a`1056 is type wildcard (_) at <interactive>:1:14--1:15
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
@@ -218,14 +218,14 @@ recip`{Z _} : {n} (prime n, n >= 1) => Z n -> Z n
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Field (?a`1249, ?a`1250)
+    • Field (?a`1055, ?a`1056)
         arising from
         use of expression recip
         at <interactive>:1:1--1:6
     • Reason: Tuple types do not support field operations.
   where
-  ?a`1249 is type wildcard (_) at <interactive>:1:9--1:10
-  ?a`1250 is type wildcard (_) at <interactive>:1:12--1:13
+  ?a`1055 is type wildcard (_) at <interactive>:1:9--1:10
+  ?a`1056 is type wildcard (_) at <interactive>:1:12--1:13
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
@@ -237,14 +237,14 @@ recip`{Z _} : {n} (prime n, n >= 1) => Z n -> Z n
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Field {x : ?a`1249, y : ?a`1250}
+    • Field {x : ?a`1055, y : ?a`1056}
         arising from
         use of expression recip
         at <interactive>:1:1--1:6
     • Reason: Record types do not support field operations.
   where
-  ?a`1249 is type wildcard (_) at <interactive>:1:13--1:14
-  ?a`1250 is type wildcard (_) at <interactive>:1:20--1:21
+  ?a`1055 is type wildcard (_) at <interactive>:1:13--1:14
+  ?a`1056 is type wildcard (_) at <interactive>:1:20--1:21
 recip`{Float _ _} : {n, m} (ValidFloat n m) =>
                       Float n m -> Float n m
 
@@ -267,35 +267,35 @@ floor`{Rational} : Rational -> Integer
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Round (Z ?n`1253)
+    • Round (Z ?n`1059)
         arising from
         use of expression floor
         at <interactive>:1:1--1:6
     • Reason: Type 'Z' does not support rounding operations.
   where
-  ?n`1253 is type wildcard (_) at <interactive>:1:10--1:11
+  ?n`1059 is type wildcard (_) at <interactive>:1:10--1:11
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Round ([?n`1253]?a`1254)
+    • Round ([?n`1059]?a`1060)
         arising from
         use of expression floor
         at <interactive>:1:1--1:6
     • Reason: Sequence types do not support rounding operations.
   where
-  ?n`1253 is type wildcard (_) at <interactive>:1:9--1:10
-  ?a`1254 is type wildcard (_) at <interactive>:1:11--1:12
+  ?n`1059 is type wildcard (_) at <interactive>:1:9--1:10
+  ?a`1060 is type wildcard (_) at <interactive>:1:11--1:12
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Round (?a`1253 -> ?a`1254)
+    • Round (?a`1059 -> ?a`1060)
         arising from
         use of expression floor
         at <interactive>:1:1--1:6
     • Reason: Function types do not support rounding operations.
   where
-  ?a`1253 is type wildcard (_) at <interactive>:1:9--1:10
-  ?a`1254 is type wildcard (_) at <interactive>:1:14--1:15
+  ?a`1059 is type wildcard (_) at <interactive>:1:9--1:10
+  ?a`1060 is type wildcard (_) at <interactive>:1:14--1:15
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
@@ -307,14 +307,14 @@ floor`{Rational} : Rational -> Integer
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Round (?a`1253, ?a`1254)
+    • Round (?a`1059, ?a`1060)
         arising from
         use of expression floor
         at <interactive>:1:1--1:6
     • Reason: Tuple types do not support rounding operations.
   where
-  ?a`1253 is type wildcard (_) at <interactive>:1:9--1:10
-  ?a`1254 is type wildcard (_) at <interactive>:1:12--1:13
+  ?a`1059 is type wildcard (_) at <interactive>:1:9--1:10
+  ?a`1060 is type wildcard (_) at <interactive>:1:12--1:13
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
@@ -326,14 +326,14 @@ floor`{Rational} : Rational -> Integer
 
 [error] at <interactive>:1:1--1:6:
   Unsolvable constraints:
-    • Round {x : ?a`1253, y : ?a`1254}
+    • Round {x : ?a`1059, y : ?a`1060}
         arising from
         use of expression floor
         at <interactive>:1:1--1:6
     • Reason: Record types do not support rounding operations.
   where
-  ?a`1253 is type wildcard (_) at <interactive>:1:13--1:14
-  ?a`1254 is type wildcard (_) at <interactive>:1:20--1:21
+  ?a`1059 is type wildcard (_) at <interactive>:1:13--1:14
+  ?a`1060 is type wildcard (_) at <interactive>:1:20--1:21
 floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 (==)`{Bit} : Bit -> Bit -> Bit
 (==)`{Integer} : Integer -> Integer -> Bit
@@ -343,14 +343,14 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 
 [error] at <interactive>:1:1--1:5:
   Unsolvable constraints:
-    • Eq (?a`1264 -> ?a`1265)
+    • Eq (?a`1070 -> ?a`1071)
         arising from
         use of expression (==)
         at <interactive>:1:1--1:5
     • Reason: Function types do not support comparisons.
   where
-  ?a`1264 is type wildcard (_) at <interactive>:1:8--1:9
-  ?a`1265 is type wildcard (_) at <interactive>:1:13--1:14
+  ?a`1070 is type wildcard (_) at <interactive>:1:8--1:9
+  ?a`1071 is type wildcard (_) at <interactive>:1:13--1:14
 (==)`{()} : () -> () -> Bit
 (==)`{(_, _)} : {a, b} (Eq b, Eq a) => (a, b) -> (a, b) -> Bit
 (==)`{{}} : {} -> {} -> Bit
@@ -364,25 +364,25 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Cmp (Z ?n`1278)
+    • Cmp (Z ?n`1084)
         arising from
         use of expression (<)
         at <interactive>:1:1--1:4
     • Reason: Type 'Z' does not support order comparisons.
   where
-  ?n`1278 is type wildcard (_) at <interactive>:1:8--1:9
+  ?n`1084 is type wildcard (_) at <interactive>:1:8--1:9
 (<)`{[_]_} : {n, a} (Cmp a, fin n) => [n]a -> [n]a -> Bit
 
 [error] at <interactive>:1:1--1:4:
   Unsolvable constraints:
-    • Cmp (?a`1281 -> ?a`1282)
+    • Cmp (?a`1087 -> ?a`1088)
         arising from
         use of expression (<)
         at <interactive>:1:1--1:4
     • Reason: Function types do not support order comparisons.
   where
-  ?a`1281 is type wildcard (_) at <interactive>:1:7--1:8
-  ?a`1282 is type wildcard (_) at <interactive>:1:12--1:13
+  ?a`1087 is type wildcard (_) at <interactive>:1:7--1:8
+  ?a`1088 is type wildcard (_) at <interactive>:1:12--1:13
 (<)`{()} : () -> () -> Bit
 (<)`{(_, _)} : {a, b} (Cmp b, Cmp a) => (a, b) -> (a, b) -> Bit
 (<)`{{}} : {} -> {} -> Bit
@@ -417,25 +417,25 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 
 [error] at <interactive>:1:1--1:5:
   Unsolvable constraints:
-    • SignedCmp (Z ?n`1292)
+    • SignedCmp (Z ?n`1098)
         arising from
         use of expression (<$)
         at <interactive>:1:1--1:5
     • Reason: Type 'Z' does not support signed comparisons.
   where
-  ?n`1292 is type wildcard (_) at <interactive>:1:9--1:10
+  ?n`1098 is type wildcard (_) at <interactive>:1:9--1:10
 (<$)`{[_]_} : {n, a} (SignedCmp ([n]a)) => [n]a -> [n]a -> Bit
 
 [error] at <interactive>:1:1--1:5:
   Unsolvable constraints:
-    • SignedCmp (?a`1295 -> ?a`1296)
+    • SignedCmp (?a`1101 -> ?a`1102)
         arising from
         use of expression (<$)
         at <interactive>:1:1--1:5
     • Reason: Function types do not support signed comparisons.
   where
-  ?a`1295 is type wildcard (_) at <interactive>:1:8--1:9
-  ?a`1296 is type wildcard (_) at <interactive>:1:13--1:14
+  ?a`1101 is type wildcard (_) at <interactive>:1:8--1:9
+  ?a`1102 is type wildcard (_) at <interactive>:1:13--1:14
 (<$)`{()} : () -> () -> Bit
 (<$)`{(_, _)} : {a, b} (SignedCmp b, SignedCmp a) =>
                   (a, b) -> (a, b) -> Bit
@@ -445,14 +445,14 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 
 [error] at <interactive>:1:1--1:5:
   Unsolvable constraints:
-    • SignedCmp (Float ?n`1303 ?n`1304)
+    • SignedCmp (Float ?n`1109 ?n`1110)
         arising from
         use of expression (<$)
         at <interactive>:1:1--1:5
     • Reason: Type 'Float' does not support signed comparisons.
   where
-  ?n`1303 is type wildcard (_) at <interactive>:1:13--1:14
-  ?n`1304 is type wildcard (_) at <interactive>:1:15--1:16
+  ?n`1109 is type wildcard (_) at <interactive>:1:13--1:14
+  ?n`1110 is type wildcard (_) at <interactive>:1:15--1:16
 number`{rep = Bit} : {n} (1 >= n) => Bit
 
 [error] at <interactive>:1:1--1:7:
@@ -466,60 +466,60 @@ number`{rep = [_]_} : {n, m} (m >= width n, fin m, fin n) => [m]
 
 [error] at <interactive>:1:1--1:7:
   Unsolvable constraints:
-    • Literal ?val`1312 (?a`1313 -> ?a`1314)
+    • Literal ?val`1118 (?a`1119 -> ?a`1120)
         arising from
         use of literal or demoted expression
         at <interactive>:1:1--1:7
-    • Reason: Type '?a`1313 -> ?a`1314' does not support integer literals.
+    • Reason: Type '?a`1119 -> ?a`1120' does not support integer literals.
   where
-  ?val`1312 is type argument 'val' of 'number' at <interactive>:1:1--1:7
-  ?a`1313 is type wildcard (_) at <interactive>:1:15--1:16
-  ?a`1314 is type wildcard (_) at <interactive>:1:20--1:21
+  ?val`1118 is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?a`1119 is type wildcard (_) at <interactive>:1:15--1:16
+  ?a`1120 is type wildcard (_) at <interactive>:1:20--1:21
 
 [error] at <interactive>:1:1--1:7:
   Unsolvable constraints:
-    • Literal ?val`1312 ()
+    • Literal ?val`1118 ()
         arising from
         use of literal or demoted expression
         at <interactive>:1:1--1:7
     • Reason: Type '()' does not support integer literals.
   where
-  ?val`1312 is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?val`1118 is type argument 'val' of 'number' at <interactive>:1:1--1:7
 
 [error] at <interactive>:1:1--1:7:
   Unsolvable constraints:
-    • Literal ?val`1312 (?a`1313, ?a`1314)
+    • Literal ?val`1118 (?a`1119, ?a`1120)
         arising from
         use of literal or demoted expression
         at <interactive>:1:1--1:7
-    • Reason: Type '(?a`1313, ?a`1314)' does not support integer literals.
+    • Reason: Type '(?a`1119, ?a`1120)' does not support integer literals.
   where
-  ?val`1312 is type argument 'val' of 'number' at <interactive>:1:1--1:7
-  ?a`1313 is type wildcard (_) at <interactive>:1:16--1:17
-  ?a`1314 is type wildcard (_) at <interactive>:1:19--1:20
+  ?val`1118 is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?a`1119 is type wildcard (_) at <interactive>:1:16--1:17
+  ?a`1120 is type wildcard (_) at <interactive>:1:19--1:20
 
 [error] at <interactive>:1:1--1:7:
   Unsolvable constraints:
-    • Literal ?val`1312 {}
+    • Literal ?val`1118 {}
         arising from
         use of literal or demoted expression
         at <interactive>:1:1--1:7
     • Reason: Type '{}' does not support integer literals.
   where
-  ?val`1312 is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?val`1118 is type argument 'val' of 'number' at <interactive>:1:1--1:7
 
 [error] at <interactive>:1:1--1:7:
   Unsolvable constraints:
-    • Literal ?val`1312 {x : ?a`1313, y : ?a`1314}
+    • Literal ?val`1118 {x : ?a`1119, y : ?a`1120}
         arising from
         use of literal or demoted expression
         at <interactive>:1:1--1:7
-    • Reason: Type '{x : ?a`1313,
-       y : ?a`1314}' does not support integer literals.
+    • Reason: Type '{x : ?a`1119,
+       y : ?a`1120}' does not support integer literals.
   where
-  ?val`1312 is type argument 'val' of 'number' at <interactive>:1:1--1:7
-  ?a`1313 is type wildcard (_) at <interactive>:1:20--1:21
-  ?a`1314 is type wildcard (_) at <interactive>:1:27--1:28
+  ?val`1118 is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?a`1119 is type wildcard (_) at <interactive>:1:20--1:21
+  ?a`1120 is type wildcard (_) at <interactive>:1:27--1:28
 number`{rep = Float _ _} : {n, m, i} (ValidFloat m i,
                                       Literal n (Float m i)) =>
                              Float m i

--- a/tests/regression/tc-errors.icry.stdout
+++ b/tests/regression/tc-errors.icry.stdout
@@ -16,12 +16,12 @@ Loading module Cryptol
 
 [error] at <interactive>:1:9--1:10:
   Matching would result in an infinite type.
-    The type:  ?arg`965
-    occurs in: ?arg`965 -> ?res
+    The type:  ?arg`771
+    occurs in: ?arg`771 -> ?res
     When checking type of function argument
   where
   ?res is type of function result at <interactive>:1:1--1:10
-  ?arg`965 is type of function argument at <interactive>:1:7--1:10
+  ?arg`771 is type of function argument at <interactive>:1:7--1:10
 
 [error] at <interactive>:1:1--1:5:
   Unsolvable constraints:
@@ -84,19 +84,19 @@ Loading module Main
 
 [error] at tc-errors-5.cry:2:5--2:7:
   Inferred type is not sufficiently polymorphic.
-    Quantified variable: a`961
-    cannot match type: [0]?a`963
+    Quantified variable: a`767
+    cannot match type: [0]?a`769
     When checking the type of 'Main::f'
   where
-  ?a`963 is type of sequence member at tc-errors-5.cry:2:5--2:7
-  a`961 is signature variable 'a' at tc-errors-5.cry:1:6--1:7
+  ?a`769 is type of sequence member at tc-errors-5.cry:2:5--2:7
+  a`767 is signature variable 'a' at tc-errors-5.cry:1:6--1:7
 Loading module Cryptol
 Loading module Main
 
 [error] at tc-errors-6.cry:4:7--4:8:
-  The type ?x`964 is not sufficiently polymorphic.
-    It cannot depend on quantified variables: b`965
+  The type ?x`770 is not sufficiently polymorphic.
+    It cannot depend on quantified variables: b`771
     When checking the type of 'Main::g'
   where
-  ?x`964 is the type of 'x' at tc-errors-6.cry:1:3--1:4
-  b`965 is signature variable 'b' at tc-errors-6.cry:3:8--3:9
+  ?x`770 is the type of 'x' at tc-errors-6.cry:1:3--1:4
+  b`771 is signature variable 'b' at tc-errors-6.cry:3:8--3:9


### PR DESCRIPTION
Add new primitives for `pmult`, `pdiv` and `pmod`.  Currently, these are exposed in the prelude via new symbols named `fast_pmult`, `fast_pdiv` and `fast_pmod`.  The plan is to relocate the current in-Cryptol implementations to a reference implementation module and continue to use these definitions for the symbolic backends, along the lines suggested in #922. 

These still require additional testing, but seem to work correctly on a limited selection of tests.