### PR TITLE
Exposes the E monad, which is needed for C code generation work.

### DIFF
--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -13,6 +13,7 @@
 >
 > module Cryptol.Eval.Reference
 >   ( Value(..)
+>   , E(..)
 >   , evaluate
 >   , evalExpr
 >   , evalDeclGroup


### PR DESCRIPTION
The C code generation I'm working on calls the reference evaluator, and relies on the `E` type being exposed so we can handle the error conditions.