### PR TITLE
Update cabal file to include all relevant files in the `lib` directory

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -1,8 +1,9 @@
+Cabal-version:       2.4
 Name:                cryptol
 Version:             2.9.1.99
 Synopsis:            Cryptol: The Language of Cryptography
 Description: Cryptol is a domain-specific language for specifying cryptographic algorithms. A Cryptol implementation of an algorithm resembles its mathematical specification more closely than an implementation in a general purpose language. For more, see <http://www.cryptol.net/>.
-License:             BSD3
+License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              Galois, Inc.
 Maintainer:          cryptol@galois.com
@@ -11,11 +12,10 @@ Bug-reports:         https://github.com/GaloisInc/cryptol/issues
 Copyright:           2013-2020 Galois Inc.
 Category:            Language
 Build-type:          Simple
-Cabal-version:       1.18
 extra-source-files:  bench/data/*.cry
                      CHANGES.md
 
-data-files:          *.cry *.z3
+data-files:          **/*.cry **/*.z3
 data-dir:            lib
 
 source-repository head


### PR DESCRIPTION
Fix for `cabal sdist` and `cabal install` following #923 .  The subdirectories of `lib` were not being included in the source distribution.