### PR TITLE
chore: submodule bump, test type-level operators

### DIFF
--- a/cryptol-remote-api/test-scripts/Foo.cry
+++ b/cryptol-remote-api/test-scripts/Foo.cry
@@ -15,3 +15,35 @@ foo = {foo = 23, bar = 99}
 getFoo : {foo : [32], bar : [32]}  -> [32]
 getFoo x = x.foo
 
+op1 : {n} (fin n) => [n] -> [n + 1]
+op1 a = 0
+
+op2 : {n} (fin n) => [n] -> [n - n]
+op2 a = 0
+
+op3 : {n} (fin n) => [n] -> [n * 1]
+op3 a = 0
+
+op4 : {n} (fin n) => [n] -> [n / 1]
+op4 a = 0
+
+op5 : {n} (fin n) => [n] -> [n % 1]
+op5 a = 0
+
+op6 : {n} (fin n) => [n] -> [n ^^ 1]
+op6 a = 0
+
+op7 : {n} (fin n) => [n] -> [n /^ 1]
+op7 a = 0
+
+op8 : {n} (fin n) => [n] -> [width n]
+op8 a = 0
+
+op9 : {n} (fin n) => [n] -> [max n 1]
+op9 a = 0
+
+op10 : {n} (fin n) => [n] -> [min 1 n]
+op10 a = 0
+
+op11 : {n} (fin n) => [n] -> [lg2 n]
+op11 a = 0


### PR DESCRIPTION
Requires merge of https://github.com/GaloisInc/argo/pull/112 first and a fixing of submodule.