### PR TITLE
Check refactor

### DIFF
--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -50,7 +50,6 @@ import qualified Cryptol.SHA as SHA
 import qualified Cryptol.AES as AES
 import qualified Cryptol.PrimeEC as PrimeEC
 import Cryptol.ModuleSystem.Name
-import Cryptol.Testing.Random (randomV)
 import Cryptol.TypeCheck.AST as AST
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.Ident (PrimIdent,prelPrim,floatPrim,suiteBPrim,primeECPrim)

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -36,7 +36,6 @@ import Cryptol.Backend.SBV
 import Cryptol.Eval.Type (TValue(..), finNat')
 import Cryptol.Eval.Generic
 import Cryptol.Eval.Value
-import Cryptol.Testing.Random( randomV )
 import Cryptol.TypeCheck.Solver.InfNat (Nat'(..), widthInteger)
 import Cryptol.Utils.Ident
 

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -37,7 +37,6 @@ import Cryptol.Eval.Type (finNat', TValue(..))
 import Cryptol.Eval.Value
 
 import Cryptol.TypeCheck.Solver.InfNat( Nat'(..), widthInteger )
-import Cryptol.Testing.Random( randomV )
 import Cryptol.Utils.Ident
 
 

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -19,12 +19,10 @@ module Cryptol.Testing.Random where
 import qualified Control.Exception as X
 import Control.Monad          (join, liftM2)
 import Data.Ratio             ((%))
-import Data.Bits              ( (.&.), shiftR )
 import Data.List              (unfoldr, genericTake, genericIndex, genericReplicate)
 import qualified Data.Sequence as Seq
 
 import System.Random          (RandomGen, split, random, randomR)
-import System.Random.TF.Gen   (seedTFGen)
 
 import Cryptol.Backend        (Backend(..), SRational(..))
 import Cryptol.Backend.Monad  (runEval,Eval,EvalError(..))
@@ -33,7 +31,6 @@ import Cryptol.Backend.Concrete
 import Cryptol.Eval.Type      (TValue(..))
 import Cryptol.Eval.Value     (GenValue(..),SeqMap(..), WordValue(..),
                                ppValue, defaultPPOpts, finiteSeqMap)
-import Cryptol.Eval.Generic   (zeroV)
 import Cryptol.Utils.Ident    (Ident)
 import Cryptol.Utils.Panic    (panic)
 import Cryptol.Utils.RecordMap
@@ -273,26 +270,6 @@ randomFloat sym e p w g =
 
 
 
-
--- Random Values ---------------------------------------------------------------
-
-{-# SPECIALIZE randomV ::
-  Concrete -> TValue -> Integer -> SEval Concrete (GenValue Concrete)
-  #-}
-
--- | Produce a random value with the given seed. If we do not support
--- making values of the given type, return zero of that type.
--- TODO: do better than returning zero
-randomV :: Backend sym => sym -> TValue -> Integer -> SEval sym (GenValue sym)
-randomV sym ty seed =
-  case randomValue sym ty of
-    Nothing -> zeroV sym ty
-    Just gen ->
-      -- unpack the seed into four Word64s
-      let mask64 = 0xFFFFFFFFFFFFFFFF
-          unpack s = fromInteger (s .&. mask64) : unpack (s `shiftR` 64)
-          [a, b, c, d] = take 4 (unpack seed)
-      in fst $ gen 100 $ seedTFGen (a, b, c, d)
 
 
 -- | A test result is either a pass, a failure due to evaluating to


### PR DESCRIPTION
Refactor testing code for `:check` and `:exhaust`.  This simplifies the interface to the testing code, and allows us to finally close #98.  