### PR TITLE
REPL defaulting

### DIFF
--- a/src/Cryptol/TypeCheck/Solve.hs
+++ b/src/Cryptol/TypeCheck/Solve.hs
@@ -159,7 +159,7 @@ defaultReplExpr sol expr sch =
      case mb of
        Nothing -> return Nothing
        Just numBinds -> return $
-         do optss <- mapM tryDefVar otherVs
+         do let optss = map tryDefVar otherVs
             su    <- listToMaybe
                        [ binds | nonSu <- sequence optss
                                , let binds = nonSu ++ numBinds
@@ -185,16 +185,22 @@ defaultReplExpr sol expr sch =
 
   fLitGoals = flitDefaultCandidates gSet
 
-  tryDefVar a =
-    case Map.lookup (TVBound a) fLitGoals of
-      Just m -> m >>= \((_,t),_) -> pure [(a,t)]
-      Nothing ->
-        do let a' = TVBound a
-           gt <- Map.lookup a' (literalGoals gSet)
-           let ok p = not (Set.member a' (fvs p))
-           return [ (a,t) | t <- [ tInteger, tBit, tWord (tWidth (goal gt)) ]
-                          , ok t ]
+  tryDefVar :: TParam -> [(TParam, Type)]
+  tryDefVar a
+    -- REPL defaulting for floating-point literals
+    | Just m <- Map.lookup (TVBound a) fLitGoals
+    = case m of
+        Just ((_,t),_) -> [(a,t)]
+        Nothing        -> []
 
+    -- REPL defaulting for integer literals
+    | Just gt <- Map.lookup (TVBound a) (literalGoals gSet)
+    = let ok p = not (Set.member (TVBound a) (fvs p)) in
+      [ (a,t) | t <- [ tInteger, tWord (tWidth (goal gt)) ]
+              , ok t ]
+
+    -- REPL defaulting for variables unconstrained by a literal constraint
+    | otherwise = [ (a,t) | t <- [tInteger, tRational, tBit] ]
 
   appExpr tys = foldl (\e1 _ -> EProofApp e1)
                       (foldl ETApp expr tys)

--- a/tests/issues/issue877.cry
+++ b/tests/issues/issue877.cry
@@ -1,0 +1,8 @@
+a = []
+
+xs : [_] Integer
+xs = [1,2,3]
+
+b = xs @@ []
+c = xs @@ (map trunc [])
+d = xs @@ (map (\x -> [x]) [])

--- a/tests/issues/issue877.icry
+++ b/tests/issues/issue877.icry
@@ -1,0 +1,21 @@
+[]
+
+let xs = [1,2,3] : [_]Integer
+
+xs @@ []
+xs @@ (map trunc [])
+xs @@ (map (\x -> [x]) [])
+
+:l issue877.cry
+
+:t a
+a
+
+:t b
+b
+
+:t c
+c
+
+:t d
+d

--- a/tests/issues/issue877.icry.stdout
+++ b/tests/issues/issue877.icry.stdout
@@ -1,0 +1,31 @@
+Loading module Cryptol
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for type of sequence member
+[]
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for type of sequence member
+[]
+Showing a specific instance of polymorphic result:
+  * Using 'Rational' for type of sequence member
+[]
+Showing a specific instance of polymorphic result:
+  * Using 'Bit' for type of sequence member
+[]
+Loading module Cryptol
+Loading module Main
+a : {a} [0]a
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for type of sequence member
+[]
+b : {a} (Integral a) => [0]Integer
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for type of sequence member
+[]
+c : {a} (Round a) => [0]Integer
+Showing a specific instance of polymorphic result:
+  * Using 'Rational' for type of sequence member
+[]
+d : {a} (Integral ([1]a)) => [0]Integer
+Showing a specific instance of polymorphic result:
+  * Using 'Bit' for type of sequence member
+[]


### PR DESCRIPTION
Add rules to default types at the command line for type variables not constrained by literal constraints.