### PR TITLE
Uninterpreted primitives

### DIFF
--- a/lib/PrimeEC.cry
+++ b/lib/PrimeEC.cry
@@ -68,6 +68,15 @@ ec_is_identity : {p} (prime p, p > 3) => ProjectivePoint p -> Bit
 ec_is_identity S = S.z == 0 /\ ~(S.x == 0 /\ S.y == 0)
 
 /**
+ * Test two projective points for equality, up to the equivalence relation
+ * on projective points.
+ */
+ec_equal : {p} (prime p, p > 3) => ProjectivePoint p -> ProjectivePoint p -> Bit
+ec_equal S T =
+  (S.z == 0 /\ T.z == 0) \/
+  (S.z != 0 /\ T.z != 0 /\ ec_affinify S == ec_affinify T)
+
+/**
  * Compute a projective representative for the given affine point.
  */
 ec_projectify : {p} (prime p, p > 3) => AffinePoint p -> ProjectivePoint p

--- a/src/Cryptol/Backend/What4.hs
+++ b/src/Cryptol/Backend/What4.hs
@@ -204,8 +204,8 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
     | Just False <- W4.asConstantPred cond = evalError err
     | otherwise = addSafety cond
 
-  isReady (What4 sym _) m =
-    case w4Eval m sym of
+  isReady sym m =
+    case w4Eval m (w4 sym) of
       Ready _ -> True
       _ -> False
 
@@ -259,21 +259,21 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
 
   wordLen _ bv = SW.bvWidth bv
 
-  bitLit (What4 sym _) b = W4.backendPred sym b
+  bitLit sym b = W4.backendPred (w4 sym) b
   bitAsLit _ v = W4.asConstantPred v
 
-  wordLit (What4 sym _) intw i
+  wordLit sym intw i
     | Just (Some w) <- someNat intw
     = case isPosNat w of
         Nothing -> pure $ SW.ZBV
-        Just LeqProof -> SW.DBV <$> liftIO (W4.bvLit sym w (BV.mkBV w i))
+        Just LeqProof -> SW.DBV <$> liftIO (W4.bvLit (w4 sym) w (BV.mkBV w i))
     | otherwise = panic "what4: wordLit" ["invalid bit width:", show intw ]
 
   wordAsLit _ v
     | Just x <- SW.bvAsUnsignedInteger v = Just (SW.bvWidth v, x)
     | otherwise = Nothing
 
-  integerLit (What4 sym _) i = liftIO (W4.intLit sym i)
+  integerLit sym i = liftIO (W4.intLit (w4 sym) i)
 
   integerAsLit _ v = W4.asInteger v
 
@@ -293,55 +293,54 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
 
   ppFloat _ _opts _ = text "[?]"
 
+  iteBit sym c x y = liftIO (W4.itePred (w4 sym) c x y)
+  iteWord sym c x y = liftIO (SW.bvIte (w4 sym) c x y)
+  iteInteger sym c x y = liftIO (W4.intIte (w4 sym) c x y)
 
-  iteBit (What4 sym _) c x y = liftIO (W4.itePred sym c x y)
-  iteWord (What4 sym _) c x y = liftIO (SW.bvIte sym c x y)
-  iteInteger (What4 sym _) c x y = liftIO (W4.intIte sym c x y)
+  bitEq  sym x y = liftIO (W4.eqPred (w4 sym) x y)
+  bitAnd sym x y = liftIO (W4.andPred (w4 sym) x y)
+  bitOr  sym x y = liftIO (W4.orPred (w4 sym) x y)
+  bitXor sym x y = liftIO (W4.xorPred (w4 sym) x y)
+  bitComplement sym x = liftIO (W4.notPred (w4 sym) x)
 
-  bitEq  (What4 sym _) x y = liftIO (W4.eqPred sym x y)
-  bitAnd (What4 sym _) x y = liftIO (W4.andPred sym x y)
-  bitOr  (What4 sym _) x y = liftIO (W4.orPred sym x y)
-  bitXor (What4 sym _) x y = liftIO (W4.xorPred sym x y)
-  bitComplement (What4 sym _) x = liftIO (W4.notPred sym x)
-
-  wordBit (What4 sym _) bv idx = liftIO (SW.bvAtBE sym bv idx)
-  wordUpdate (What4 sym _) bv idx b = liftIO (SW.bvSetBE sym bv idx b)
+  wordBit sym bv idx = liftIO (SW.bvAtBE (w4 sym) bv idx)
+  wordUpdate sym bv idx b = liftIO (SW.bvSetBE (w4 sym) bv idx b)
 
   packWord sym bs =
     do z <- wordLit sym (genericLength bs) 0
        let f w (idx,b) = wordUpdate sym w idx b
        foldM f z (zip [0..] bs)
 
-  unpackWord (What4 sym _) bv = liftIO $
-    mapM (SW.bvAtBE sym bv) [0 .. SW.bvWidth bv-1]
+  unpackWord sym bv = liftIO $
+    mapM (SW.bvAtBE (w4 sym) bv) [0 .. SW.bvWidth bv-1]
 
-  joinWord (What4 sym _) x y = liftIO $ SW.bvJoin sym x y
+  joinWord sym x y = liftIO $ SW.bvJoin (w4 sym) x y
 
   splitWord _sym 0 _ bv = pure (SW.ZBV, bv)
   splitWord _sym _ 0 bv = pure (bv, SW.ZBV)
-  splitWord (What4 sym _) lw rw bv = liftIO $
-    do l <- SW.bvSliceBE sym 0 lw bv
-       r <- SW.bvSliceBE sym lw rw bv
+  splitWord sym lw rw bv = liftIO $
+    do l <- SW.bvSliceBE (w4 sym) 0 lw bv
+       r <- SW.bvSliceBE (w4 sym) lw rw bv
        return (l, r)
 
-  extractWord (What4 sym _) bits idx bv =
-    liftIO $ SW.bvSliceLE sym idx bits bv
+  extractWord sym bits idx bv =
+    liftIO $ SW.bvSliceLE (w4 sym) idx bits bv
 
-  wordEq                (What4 sym _) x y = liftIO (SW.bvEq sym x y)
-  wordLessThan          (What4 sym _) x y = liftIO (SW.bvult sym x y)
-  wordGreaterThan       (What4 sym _) x y = liftIO (SW.bvugt sym x y)
-  wordSignedLessThan    (What4 sym _) x y = liftIO (SW.bvslt sym x y)
+  wordEq                sym x y = liftIO (SW.bvEq  (w4 sym) x y)
+  wordLessThan          sym x y = liftIO (SW.bvult (w4 sym) x y)
+  wordGreaterThan       sym x y = liftIO (SW.bvugt (w4 sym) x y)
+  wordSignedLessThan    sym x y = liftIO (SW.bvslt (w4 sym) x y)
 
-  wordOr  (What4 sym _) x y = liftIO (SW.bvOr sym x y)
-  wordAnd (What4 sym _) x y = liftIO (SW.bvAnd sym x y)
-  wordXor (What4 sym _) x y = liftIO (SW.bvXor sym x y)
-  wordComplement (What4 sym _) x = liftIO (SW.bvNot sym x)
+  wordOr  sym x y = liftIO (SW.bvOr  (w4 sym) x y)
+  wordAnd sym x y = liftIO (SW.bvAnd (w4 sym) x y)
+  wordXor sym x y = liftIO (SW.bvXor (w4 sym) x y)
+  wordComplement sym x = liftIO (SW.bvNot (w4 sym) x)
 
-  wordPlus  (What4 sym _) x y = liftIO (SW.bvAdd sym x y)
-  wordMinus (What4 sym _) x y = liftIO (SW.bvSub sym x y)
-  wordMult  (What4 sym _) x y = liftIO (SW.bvMul sym x y)
-  wordNegate (What4 sym _) x  = liftIO (SW.bvNeg sym x)
-  wordLg2 (What4 sym _) x     = sLg2 sym x
+  wordPlus   sym x y = liftIO (SW.bvAdd (w4 sym) x y)
+  wordMinus  sym x y = liftIO (SW.bvSub (w4 sym) x y)
+  wordMult   sym x y = liftIO (SW.bvMul (w4 sym) x y)
+  wordNegate sym x   = liftIO (SW.bvNeg (w4 sym) x)
+  wordLg2    sym x   = sLg2 (w4 sym) x
  
   wordDiv sym x y =
      do assertBVDivisor sym y
@@ -356,102 +355,102 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
      do assertBVDivisor sym y
         liftIO (SW.bvSRem (w4 sym) x y)
 
-  wordToInt (What4 sym _) x = liftIO (SW.bvToInteger sym x)
-  wordFromInt (What4 sym _) width i = liftIO (SW.integerToBV sym i width)
+  wordToInt sym x = liftIO (SW.bvToInteger (w4 sym) x)
+  wordFromInt sym width i = liftIO (SW.integerToBV (w4 sym) i width)
 
-  intPlus (What4 sym _) x y  = liftIO $ W4.intAdd sym x y
-  intMinus (What4 sym _) x y = liftIO $ W4.intSub sym x y
-  intMult (What4 sym _) x y  = liftIO $ W4.intMul sym x y
-  intNegate (What4 sym _) x  = liftIO $ W4.intNeg sym x
-
-  -- NB: What4's division operation provides SMTLib's euclidean division,
-  -- which doesn't match the round-to-neg-infinity semantics of Cryptol,
-  -- so we have to do some work to get the desired semantics.
-  intDiv sym@(What4 w4sym _) x y =
-    do assertIntDivisor sym y
-       liftIO $ do
-         neg <- liftIO (W4.intLt w4sym y =<< W4.intLit w4sym 0)
-         case W4.asConstantPred neg of
-           Just False -> W4.intDiv w4sym x y
-           Just True  ->
-              do xneg <- W4.intNeg w4sym x
-                 yneg <- W4.intNeg w4sym y
-                 W4.intDiv w4sym xneg yneg
-           Nothing ->
-              do xneg <- W4.intNeg w4sym x
-                 yneg <- W4.intNeg w4sym y
-                 zneg <- W4.intDiv w4sym xneg yneg
-                 z    <- W4.intDiv w4sym x y
-                 W4.intIte w4sym neg zneg z
+  intPlus   sym x y  = liftIO $ W4.intAdd (w4 sym) x y
+  intMinus  sym x y  = liftIO $ W4.intSub (w4 sym) x y
+  intMult   sym x y  = liftIO $ W4.intMul (w4 sym) x y
+  intNegate sym x    = liftIO $ W4.intNeg (w4 sym) x
 
   -- NB: What4's division operation provides SMTLib's euclidean division,
   -- which doesn't match the round-to-neg-infinity semantics of Cryptol,
   -- so we have to do some work to get the desired semantics.
-  intMod sym@(What4 w4sym _) x y =
+  intDiv sym x y =
     do assertIntDivisor sym y
        liftIO $ do
-         neg <- liftIO (W4.intLt w4sym y =<< W4.intLit w4sym 0)
+         neg <- liftIO (W4.intLt (w4 sym) y =<< W4.intLit (w4 sym) 0)
          case W4.asConstantPred neg of
-           Just False -> W4.intMod w4sym x y
+           Just False -> W4.intDiv (w4 sym) x y
            Just True  ->
-              do xneg <- W4.intNeg w4sym x
-                 yneg <- W4.intNeg w4sym y
-                 W4.intNeg w4sym =<< W4.intMod w4sym xneg yneg
+              do xneg <- W4.intNeg (w4 sym) x
+                 yneg <- W4.intNeg (w4 sym) y
+                 W4.intDiv (w4 sym) xneg yneg
            Nothing ->
-              do xneg <- W4.intNeg w4sym x
-                 yneg <- W4.intNeg w4sym y
-                 z    <- W4.intMod w4sym x y
-                 zneg <- W4.intNeg w4sym =<< W4.intMod w4sym xneg yneg
-                 W4.intIte w4sym neg zneg z
+              do xneg <- W4.intNeg (w4 sym) x
+                 yneg <- W4.intNeg (w4 sym) y
+                 zneg <- W4.intDiv (w4 sym) xneg yneg
+                 z    <- W4.intDiv (w4 sym) x y
+                 W4.intIte (w4 sym) neg zneg z
 
-  intEq (What4 sym _) x y = liftIO $ W4.intEq sym x y
-  intLessThan (What4 sym _) x y = liftIO $ W4.intLt sym x y
-  intGreaterThan (What4 sym _) x y = liftIO $ W4.intLt sym y x
+  -- NB: What4's division operation provides SMTLib's euclidean division,
+  -- which doesn't match the round-to-neg-infinity semantics of Cryptol,
+  -- so we have to do some work to get the desired semantics.
+  intMod sym x y =
+    do assertIntDivisor sym y
+       liftIO $ do
+         neg <- liftIO (W4.intLt (w4 sym) y =<< W4.intLit (w4 sym) 0)
+         case W4.asConstantPred neg of
+           Just False -> W4.intMod (w4 sym) x y
+           Just True  ->
+              do xneg <- W4.intNeg (w4 sym) x
+                 yneg <- W4.intNeg (w4 sym) y
+                 W4.intNeg (w4 sym) =<< W4.intMod (w4 sym) xneg yneg
+           Nothing ->
+              do xneg <- W4.intNeg (w4 sym) x
+                 yneg <- W4.intNeg (w4 sym) y
+                 z    <- W4.intMod (w4 sym) x y
+                 zneg <- W4.intNeg (w4 sym) =<< W4.intMod (w4 sym) xneg yneg
+                 W4.intIte (w4 sym) neg zneg z
+
+  intEq sym x y = liftIO $ W4.intEq (w4 sym) x y
+  intLessThan sym x y = liftIO $ W4.intLt (w4 sym) x y
+  intGreaterThan sym x y = liftIO $ W4.intLt (w4 sym) y x
 
   -- NB, we don't do reduction here on symbolic values
-  intToZn (What4 sym _) m x
+  intToZn sym m x
     | Just xi <- W4.asInteger x
-    = liftIO $ W4.intLit sym (xi `mod` m)
+    = liftIO $ W4.intLit (w4 sym) (xi `mod` m)
 
     | otherwise
     = pure x
 
   znToInt _ 0 _ = evalPanic "znToInt" ["0 modulus not allowed"]
-  znToInt (What4 sym _) m x = liftIO (W4.intMod sym x =<< W4.intLit sym m)
+  znToInt sym m x = liftIO (W4.intMod (w4 sym) x =<< W4.intLit (w4 sym) m)
 
   znEq _ 0 _ _ = evalPanic "znEq" ["0 modulus not allowed"]
-  znEq (What4 sym _) m x y = liftIO $
-     do diff <- W4.intSub sym x y
-        W4.intDivisible sym diff (fromInteger m)
+  znEq sym m x y = liftIO $
+     do diff <- W4.intSub (w4 sym) x y
+        W4.intDivisible (w4 sym) diff (fromInteger m)
 
-  znPlus   (What4 sym _) m x y = liftIO $ sModAdd sym m x y
-  znMinus  (What4 sym _) m x y = liftIO $ sModSub sym m x y
-  znMult   (What4 sym _) m x y = liftIO $ sModMult sym m x y
-  znNegate (What4 sym _) m x   = liftIO $ sModNegate sym m x
+  znPlus   sym m x y = liftIO $ sModAdd (w4 sym) m x y
+  znMinus  sym m x y = liftIO $ sModSub (w4 sym) m x y
+  znMult   sym m x y = liftIO $ sModMult (w4 sym) m x y
+  znNegate sym m x   = liftIO $ sModNegate (w4 sym) m x
   znRecip = sModRecip
 
   --------------------------------------------------------------
 
-  fpLit (What4 sym _) e p r = liftIO $ FP.fpFromRationalLit sym e p r
+  fpLit sym e p r = liftIO $ FP.fpFromRationalLit (w4 sym) e p r
 
-  fpExactLit (What4 sym _) BF{ bfExpWidth = e, bfPrecWidth = p, bfValue = bf } =
-    liftIO (FP.fpFromBinary sym e p =<< SW.bvLit sym (e+p) (floatToBits e p bf))
+  fpExactLit sym BF{ bfExpWidth = e, bfPrecWidth = p, bfValue = bf } =
+    liftIO (FP.fpFromBinary (w4 sym) e p =<< SW.bvLit (w4 sym) (e+p) (floatToBits e p bf))
 
-  fpEq          (What4 sym _) x y = liftIO $ FP.fpEqIEEE sym x y
-  fpLessThan    (What4 sym _) x y = liftIO $ FP.fpLtIEEE sym x y
-  fpGreaterThan (What4 sym _) x y = liftIO $ FP.fpGtIEEE sym x y
-  fpLogicalEq   (What4 sym _) x y = liftIO $ FP.fpEq sym x y
+  fpEq          sym x y = liftIO $ FP.fpEqIEEE (w4 sym) x y
+  fpLessThan    sym x y = liftIO $ FP.fpLtIEEE (w4 sym) x y
+  fpGreaterThan sym x y = liftIO $ FP.fpGtIEEE (w4 sym) x y
+  fpLogicalEq   sym x y = liftIO $ FP.fpEq (w4 sym) x y
 
   fpPlus  = fpBinArith FP.fpAdd
   fpMinus = fpBinArith FP.fpSub
   fpMult  = fpBinArith FP.fpMul
   fpDiv   = fpBinArith FP.fpDiv
 
-  fpNeg (What4 sym _) x = liftIO $ FP.fpNeg sym x
+  fpNeg sym x = liftIO $ FP.fpNeg (w4 sym) x
 
-  fpFromInteger sym@(What4 w4sym _) e p r x =
+  fpFromInteger sym e p r x =
     do rm <- fpRoundingMode sym r
-       liftIO $ FP.fpFromInteger w4sym e p rm x
+       liftIO $ FP.fpFromInteger (w4 sym) e p rm x
 
   fpToInteger = fpCvtToInteger
 
@@ -584,43 +583,43 @@ fpBinArith fun = \sym@(What4 s _) r x y ->
 fpCvtToInteger ::
   (W4.IsSymExprBuilder sy, sym ~ What4 sy) =>
   sym -> String -> SWord sym -> SFloat sym -> SEval sym (SInteger sym)
-fpCvtToInteger sym@(What4 sy _) fun r x =
+fpCvtToInteger sym fun r x =
   do grd <- liftIO
-              do bad1 <- FP.fpIsInf sy x
-                 bad2 <- FP.fpIsNaN sy x
-                 W4.notPred sy =<< W4.orPred sy bad1 bad2
+              do bad1 <- FP.fpIsInf (w4 sym) x
+                 bad2 <- FP.fpIsNaN (w4 sym) x
+                 W4.notPred (w4 sym) =<< W4.orPred (w4 sym) bad1 bad2
      assertSideCondition sym grd (BadValue fun)
      rnd  <- fpRoundingMode sym r
      liftIO
-       do y <- FP.fpToReal sy x
+       do y <- FP.fpToReal (w4 sym) x
           case rnd of
-            W4.RNE -> W4.realRoundEven sy y
-            W4.RNA -> W4.realRound sy y
-            W4.RTP -> W4.realCeil sy y
-            W4.RTN -> W4.realFloor sy y
-            W4.RTZ -> W4.realTrunc sy y
+            W4.RNE -> W4.realRoundEven (w4 sym) y
+            W4.RNA -> W4.realRound (w4 sym) y
+            W4.RTP -> W4.realCeil (w4 sym) y
+            W4.RTN -> W4.realFloor (w4 sym) y
+            W4.RTZ -> W4.realTrunc (w4 sym) y
 
 
 fpCvtToRational ::
   (W4.IsSymExprBuilder sy, sym ~ What4 sy) =>
   sym -> SFloat sym -> SEval sym (SRational sym)
-fpCvtToRational sym@(What4 w4sym _) fp =
+fpCvtToRational sym fp =
   do grd <- liftIO
-            do bad1 <- FP.fpIsInf w4sym fp
-               bad2 <- FP.fpIsNaN w4sym fp
-               W4.notPred w4sym =<< W4.orPred w4sym bad1 bad2
+            do bad1 <- FP.fpIsInf (w4 sym) fp
+               bad2 <- FP.fpIsNaN (w4 sym) fp
+               W4.notPred (w4 sym) =<< W4.orPred (w4 sym) bad1 bad2
      assertSideCondition sym grd (BadValue "fpToRational")
-     (rel,x,y) <- liftIO (FP.fpToRational w4sym fp)
-     addDefEqn sym =<< liftIO (W4.impliesPred w4sym grd rel)
+     (rel,x,y) <- liftIO (FP.fpToRational (w4 sym) fp)
+     addDefEqn sym =<< liftIO (W4.impliesPred (w4 sym) grd rel)
      ratio sym x y
 
 fpCvtFromRational ::
   (W4.IsSymExprBuilder sy, sym ~ What4 sy) =>
   sym -> Integer -> Integer -> SWord sym ->
   SRational sym -> SEval sym (SFloat sym)
-fpCvtFromRational sym@(What4 w4sym _) e p r rat =
+fpCvtFromRational sym e p r rat =
   do rnd <- fpRoundingMode sym r
-     liftIO (FP.fpFromRational w4sym e p rnd (sNum rat) (sDenom rat))
+     liftIO (FP.fpFromRational (w4 sym) e p rnd (sNum rat) (sDenom rat))
 
 -- Create a fresh constant and assert that it is the
 -- multiplicitive inverse of x; return the constant.
@@ -633,7 +632,7 @@ sModRecip ::
   W4.SymInteger sym ->
   W4Eval sym (W4.SymInteger sym)
 sModRecip _sym 0 _ = panic "sModRecip" ["0 modulus not allowed"]
-sModRecip sym@(What4 w4sym _) m x
+sModRecip sym m x
   -- If the input is concrete, evaluate the answer
   | Just xi <- W4.asInteger x
   = let r = Integer.recipModInteger xi m
@@ -644,13 +643,13 @@ sModRecip sym@(What4 w4sym _) m x
   -- Such an inverse will exist under the precondition that
   -- the modulus is prime, and as long as the input is nonzero.
   | otherwise
-  = do divZero <- liftIO (W4.intDivisible w4sym x (fromInteger m))
-       ok <- liftIO (W4.notPred w4sym divZero)
+  = do divZero <- liftIO (W4.intDivisible (w4 sym) x (fromInteger m))
+       ok <- liftIO (W4.notPred (w4 sym) divZero)
        assertSideCondition sym ok DivideByZero
 
-       z <- liftIO (W4.freshBoundedInt w4sym W4.emptySymbol (Just 1) (Just (m-1)))
-       xz <- liftIO (W4.intMul w4sym x z)
-       rel <- znEq sym m xz =<< liftIO (W4.intLit w4sym 1)
-       addDefEqn sym =<< liftIO (W4.orPred w4sym divZero rel)
+       z <- liftIO (W4.freshBoundedInt (w4 sym) W4.emptySymbol (Just 1) (Just (m-1)))
+       xz <- liftIO (W4.intMul (w4 sym) x z)
+       rel <- znEq sym m xz =<< liftIO (W4.intLit (w4 sym) 1)
+       addDefEqn sym =<< liftIO (W4.orPred (w4 sym) divZero rel)
 
        return z

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -524,11 +524,6 @@ processSHA512Block sym st blk =
                   b8  :> b9  :> b10 :> b11 :>
                   b12 :> b13 :> b14 :> b15
      let ret = W4.exprType st
-     liftIO $ putStrLn $ show $ W4.printSymExpr b0
-     liftIO $ putStrLn $ show $ W4.printSymExpr b15
-
-     liftIO $ putStrLn $ unwords $ map show $ toListFC W4.printSymExpr args
-
      fn <- liftIO $ getUninterpFn sym "processSHA512Block" (fmapFC W4.exprType args) ret
      liftIO $ W4.applySymFn (w4 sym) fn args
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -778,7 +778,8 @@ onlineProveSat proverName qtype str mfile = do
        Left sbvCfg -> liftModuleCmd $ SBV.satProve sbvCfg cmd
        Right w4Cfg ->
          do ~(EnvBool hashConsing) <- getUser "hash-consing"
-            liftModuleCmd $ W4.satProve w4Cfg hashConsing cmd
+            ~(EnvBool warnUninterp) <- getUser "warnUninterp"
+            liftModuleCmd $ W4.satProve w4Cfg hashConsing warnUninterp cmd
 
   stas <- io (readIORef timing)
   return (firstProver,res,stas)
@@ -832,7 +833,8 @@ offlineProveSat proverName qtype str mfile = do
 
     Right w4Cfg ->
       do ~(EnvBool hashConsing) <- getUser "hash-consing"
-         result <- liftModuleCmd $ W4.satProveOffline w4Cfg hashConsing cmd $ \f ->
+         ~(EnvBool warnUninterp) <- getUser "warnUninterp"
+         result <- liftModuleCmd $ W4.satProveOffline w4Cfg hashConsing warnUninterp cmd $ \f ->
                      do displayMsg
                         case mfile of
                           Just path ->

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -752,6 +752,8 @@ userOptions  = mkOptionMap
     "Choose whether to display warnings when defaulting."
   , simpleOpt "warnShadowing" (EnvBool True) noCheck
     "Choose whether to display warnings when shadowing symbols."
+  , simpleOpt "warnUninterp" (EnvBool True) noCheck
+    "Choose whether to issue a warning when uninterpreted functions are used to implement primitives in the symbolic simulator."
   , simpleOpt "smtfile" (EnvString "-") noCheck
     "The file to use for SMT-Lib scripts (for debugging or offline proving).\nUse \"-\" for stdout."
   , OptionDescr "mono-binds" (EnvBool True) noCheck

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -38,8 +38,13 @@ import qualified Control.Exception as X
 import System.IO (Handle)
 import Data.Time
 import Data.IORef
+import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.List.NonEmpty as NE
 import System.Exit
 
@@ -59,7 +64,7 @@ import qualified Cryptol.Eval.Value as Eval
 import           Cryptol.Eval.What4
 import           Cryptol.Symbolic
 import           Cryptol.TypeCheck.AST
-import           Cryptol.Utils.Logger(logPutStrLn)
+import           Cryptol.Utils.Logger(logPutStrLn,logPutStr,Logger)
 import           Cryptol.Utils.Ident (preludeReferenceName, prelPrim, identText)
 
 import qualified What4.Config as W4
@@ -301,11 +306,13 @@ satProve solverCfg hashConsing ProverCommand {..} =
   do w4sym   <- liftIO makeSym
      defVar  <- liftIO (newMVar (W4.truePred w4sym))
      funVar  <- liftIO (newMVar mempty)
-     let sym = What4 w4sym defVar funVar
+     uninterpWarnVar <- liftIO (newMVar mempty)
+     let sym = What4 w4sym defVar funVar uninterpWarnVar
      logData <- M.withLogger doLog ()
      start   <- liftIO getCurrentTime
      query   <- prepareQuery sym ProverCommand { .. }
      primMap <- M.getPrimMap
+     M.withLogger printUninterpWarn =<< liftIO (readMVar uninterpWarnVar)
      liftIO
        do result <- runProver sym logData primMap query
           end <- getCurrentTime
@@ -344,7 +351,14 @@ satProve solverCfg hashConsing ProverCommand {..} =
             multiSATQuery sym solverCfg primMap logData ts args
                                                             query num
 
-
+printUninterpWarn :: Logger -> Set Text -> IO ()
+printUninterpWarn lg uninterpWarns =
+  case Set.toList uninterpWarns of
+    []  -> pure ()
+    [x] -> logPutStrLn lg ("[Warning] Uninterpreted functions used to represent " ++ Text.unpack x ++ " operations.")
+    xs  -> logPutStr lg $ unlines
+             [ "[Warning] Uninterpreted functions used to represent the following operations:"
+             , "  " ++ intercalate ", " (map Text.unpack xs) ]
 
 satProveOffline ::
   W4ProverConfig ->
@@ -362,8 +376,10 @@ satProveOffline (W4ProverConfig (AnAdapter adpt)) hashConsing ProverCommand {..}
    do w4sym <- liftIO makeSym
       defVar  <- liftIO (newMVar (W4.truePred w4sym))
       funVar  <- liftIO (newMVar mempty)
-      let sym = What4 w4sym defVar funVar
+      uninterpWarnVar <- liftIO (newMVar mempty)
+      let sym = What4 w4sym defVar funVar uninterpWarnVar
       ok  <- prepareQuery sym ProverCommand { .. }
+      M.withLogger printUninterpWarn =<< liftIO (readMVar uninterpWarnVar)
       liftIO
         case ok of
           Left msg -> return (Just msg)

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -300,7 +300,8 @@ satProve solverCfg hashConsing ProverCommand {..} =
   M.runModuleM (evo, byteReader, modEnv)
   do w4sym   <- liftIO makeSym
      defVar  <- liftIO (newMVar (W4.truePred w4sym))
-     let sym = What4 w4sym defVar
+     funVar  <- liftIO (newMVar mempty)
+     let sym = What4 w4sym defVar funVar
      logData <- M.withLogger doLog ()
      start   <- liftIO getCurrentTime
      query   <- prepareQuery sym ProverCommand { .. }
@@ -360,7 +361,8 @@ satProveOffline (W4ProverConfig (AnAdapter adpt)) hashConsing ProverCommand {..}
   M.runModuleM (evo,byteReader,modEnv)
    do w4sym <- liftIO makeSym
       defVar  <- liftIO (newMVar (W4.truePred w4sym))
-      let sym = What4 w4sym defVar
+      funVar  <- liftIO (newMVar mempty)
+      let sym = What4 w4sym defVar funVar
       ok  <- prepareQuery sym ProverCommand { .. }
       liftIO
         case ok of

--- a/tests/regression/twinmult.cry
+++ b/tests/regression/twinmult.cry
@@ -1,0 +1,19 @@
+import PrimeEC
+
+zro : ProjectivePoint 7
+zro = { x = 1, y = 1, z = 0 }
+
+property twin_mult_zro j k =
+  ec_equal`{7} (ec_twin_mult j zro k zro) zro
+
+property twin_mult_zro1 j k S =
+  ec_equal`{7} (ec_twin_mult j zro k S) (ec_mult k S)
+
+property twin_mult_zro2 j k S =
+  ec_equal`{7} (ec_twin_mult j S k zro) (ec_mult j S)
+
+property twin_mult_same j k S =
+  ec_equal`{7} (ec_twin_mult j S k S) (ec_add (ec_mult j S) (ec_mult k S))
+
+property twin_mult_neg j k S =
+  ec_equal`{7} (ec_twin_mult j S k (ec_negate S)) (ec_sub (ec_mult j S) (ec_mult k S))

--- a/tests/regression/twinmult.icry
+++ b/tests/regression/twinmult.icry
@@ -1,0 +1,3 @@
+:l twinmult.cry
+
+:exhaust

--- a/tests/regression/twinmult.icry.stdout
+++ b/tests/regression/twinmult.icry.stdout
@@ -1,0 +1,19 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module PrimeEC
+Loading module Main
+property twin_mult_zro Using exhaustive testing.
+Testing... Passed 49 tests.
+Q.E.D.
+property twin_mult_zro1 Using exhaustive testing.
+Testing... Passed 16807 tests.
+Q.E.D.
+property twin_mult_zro2 Using exhaustive testing.
+Testing... Passed 16807 tests.
+Q.E.D.
+property twin_mult_same Using exhaustive testing.
+Testing... Passed 16807 tests.
+Q.E.D.
+property twin_mult_neg Using exhaustive testing.
+Testing... Passed 16807 tests.
+Q.E.D.


### PR DESCRIPTION
Add support to the What4 provers for treating the SuiteB AES primitives
as uninterpreted functions.  This allows basic use of `:safe`, and
also allows one to prove basic facts using `:prove`, provided they
don't rely on any interesting properties of the AES primitives.
Proof counterexamples and `:sat` results, however, are very likely
to be spurious.

The SHA-2 and PrimeEC primitives are next to get the same treatment.

Eventually, we should probably make the symbolic behavior of these primitives configurable.