### PR TITLE
Fix the bit-order convention for `extractWord` in the What4 backend

### DIFF
--- a/src/Cryptol/Backend/What4.hs
+++ b/src/Cryptol/Backend/What4.hs
@@ -325,7 +325,7 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
        return (l, r)
 
   extractWord (What4 sym _) bits idx bv =
-    liftIO $ SW.bvSliceBE sym idx bits bv
+    liftIO $ SW.bvSliceLE sym idx bits bv
 
   wordEq                (What4 sym _) x y = liftIO (SW.bvEq sym x y)
   wordLessThan          (What4 sym _) x y = liftIO (SW.bvult sym x y)

--- a/tests/issues/issue958.icry
+++ b/tests/issues/issue958.icry
@@ -1,0 +1,5 @@
+:set prover=sbv-z3
+:prove (\x y -> split (x#y) == [x :[64] ,y])
+
+:set prover=w4-z3
+:prove (\x y -> split (x#y) == [x :[64] ,y])

--- a/tests/issues/issue958.icry.stdout
+++ b/tests/issues/issue958.icry.stdout
@@ -1,0 +1,3 @@
+Loading module Cryptol
+Q.E.D.
+Q.E.D.


### PR DESCRIPTION
Fixes #958