### PR TITLE
HTTP transport support in cryptol-remote-api

### DIFF
--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -64,6 +64,8 @@ executable cryptol-remote-api
   import:              deps, warnings
   main-is:             Main.hs
   hs-source-dirs:      cryptol-remote-api
+  ghc-options:
+    -threaded
 
   build-depends:
     cryptol-remote-api,

--- a/cryptol-remote-api/test-scripts/cryptol-api_test.py
+++ b/cryptol-remote-api/test-scripts/cryptol-api_test.py
@@ -8,7 +8,7 @@ from BitVector import *
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-c = cryptol.connect("cabal new-exec --verbose=0 cryptol-remote-api")
+c = cryptol.connect("cabal new-exec --verbose=0 cryptol-remote-api -- socket")
 
 c.change_directory(dir_path)
 

--- a/cryptol-remote-api/test-scripts/cryptol-tests.py
+++ b/cryptol-remote-api/test-scripts/cryptol-tests.py
@@ -164,11 +164,11 @@ def low_level_api_test(c):
 
 c1 = argo.ServerConnection(
        cryptol.CryptolDynamicSocketProcess(
-           "cabal v2-exec cryptol-remote-api  --verbose=0",
+           "cabal v2-exec cryptol-remote-api --verbose=0 -- socket",
            cryptol_path=cryptol_path))
 c2 = argo.ServerConnection(
        cryptol.CryptolStdIOProcess(
-           "cabal v2-exec cryptol-remote-api  --verbose=0 -- --stdio",
+           "cabal v2-exec cryptol-remote-api --verbose=0 -- stdio",
            cryptol_path=cryptol_path))
 
 low_level_api_test(c1)
@@ -178,7 +178,7 @@ env = os.environ.copy()
 env['CRYPTOLPATH'] = cryptol_path
 
 p = subprocess.Popen(
-    ["cabal", "v2-exec", "cryptol-remote-api", "--verbose=0", "--", "--port", "50005"],
+    ["cabal", "v2-exec", "cryptol-remote-api", "--verbose=0", "--", "socket", "--port", "50005"],
     stdout=subprocess.DEVNULL,
     stdin=subprocess.DEVNULL,
     stderr=subprocess.DEVNULL,


### PR DESCRIPTION
 * Integrates Argo's support for HTTP (https://github.com/GaloisInc/argo/pull/101)
 * Updates command-line arguments to use the subcommand style (inherited from the Argo update)
 * Enables threading