### PR TITLE
Don't add an extra copy of Programming Cryptol

### DIFF
--- a/docs/ProgrammingCryptol/Makefile
+++ b/docs/ProgrammingCryptol/Makefile
@@ -25,7 +25,6 @@ MAKEINDEX = makeindex
 # TODO: Ensure that TEXINPUTS is set correctly to make \includes and \usepackages more robust?
 
 all: pdf
-	cp ${TMP}/Cryptol.pdf ..
 
 test:
 	cd aes ; make test


### PR DESCRIPTION
Two different Makefiles each copied it and used different file names.

Closes #969.