### PR TITLE
Make cryptol-remote-api Dockerfile default to 8080 and EXPOSE it

### DIFF
--- a/.github/Dockerfile-remote-api
+++ b/.github/Dockerfile-remote-api
@@ -74,4 +74,6 @@ COPY --from=solvers /solvers/rootfs /
 USER cryptol
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
-ENTRYPOINT ["/usr/local/bin/cryptol-remote-api", "http", "--host", "0.0.0.0", "/"]
+ENTRYPOINT ["/usr/local/bin/cryptol-remote-api"]
+CMD ["http", "--host", "0.0.0.0", "--port", "8080", "/"]
+EXPOSE 8080


### PR DESCRIPTION
Improve the cryptol-remote-api Dockerfile to bind to port 8080 and EXPOSE it. This makes the container play nicer when used as a service like in GitLab.

With this change you could use this as:
```.gitlab-ci.yml
services:
  - galoisinc/cryptol-remote-api:nightly
```

Example:

```.gitlab-ci.yml
stages:
  - ci
cryptol-example:
  stage: ci
  services:
    - galoisinc/cryptol-remote-api:nightly
  script:
    - >-
      curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -XPOST -d '{"jsonrpc":"2.0","id":1,"method":"load module","params":{"module name":"Cryptol","state":null}}' galoisinc-cryptol-remote-api:8080
```