### PR TITLE
Source position tracking

### DIFF
--- a/cryptol-remote-api/src/CryptolServer/Data/Expression.hs
+++ b/cryptol-remote-api/src/CryptolServer/Data/Expression.hs
@@ -318,6 +318,7 @@ readBack :: PrimMap -> TC.Type -> Value -> Eval Expression
 readBack prims ty val =
   let tbl = primTable theEvalOpts in
   let ?evalPrim = \i -> Right <$> Map.lookup i tbl in
+  let ?range = emptyRange in -- TODO?
   case TC.tNoUser ty of
     TC.TRec tfs ->
       Record . HM.fromList <$>

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -171,6 +171,7 @@ library
                        Cryptol.Eval.Concrete,
                        Cryptol.Eval.Env,
                        Cryptol.Eval.Generic,
+                       Cryptol.Eval.Prims,
                        Cryptol.Eval.Reference,
                        Cryptol.Eval.SBV,
                        Cryptol.Eval.Type,

--- a/src/Cryptol/Backend.hs
+++ b/src/Cryptol/Backend.hs
@@ -35,29 +35,30 @@ import Data.Kind (Type)
 import Data.Ratio ( (%), numerator, denominator )
 
 import Cryptol.Backend.FloatHelpers (BF)
-import Cryptol.Backend.Monad ( PPOpts(..), EvalError(..) )
-import Cryptol.TypeCheck.AST(Name)
+import Cryptol.Backend.Monad ( PPOpts(..), EvalError(..), EvalErrorEx(..) )
+import Cryptol.ModuleSystem.Name(Name,nameLoc)
+import Cryptol.Parser.Position
 import Cryptol.Utils.PP
 
 
-invalidIndex :: Backend sym => sym -> Integer -> SEval sym a
-invalidIndex sym = raiseError sym . InvalidIndex . Just
+invalidIndex :: Backend sym => sym -> Range -> Integer -> SEval sym a
+invalidIndex sym rng = raiseError sym . EvalErrorEx rng . InvalidIndex . Just
 
-cryUserError :: Backend sym => sym -> String -> SEval sym a
-cryUserError sym = raiseError sym . UserError
+cryUserError :: Backend sym => sym -> Range -> String -> SEval sym a
+cryUserError sym rng = raiseError sym . EvalErrorEx rng . UserError
 
 cryNoPrimError :: Backend sym => sym -> Name -> SEval sym a
-cryNoPrimError sym = raiseError sym . NoPrim
+cryNoPrimError sym nm = raiseError sym (EvalErrorEx (nameLoc nm) (NoPrim nm))
 
 
 {-# INLINE sDelay #-}
 -- | Delay the given evaluation computation, returning a thunk
 --   which will run the computation when forced.  Raise a loop
 --   error if the resulting thunk is forced during its own evaluation.
-sDelay :: Backend sym => sym -> Maybe String -> SEval sym a -> SEval sym (SEval sym a)
-sDelay sym msg m =
+sDelay :: Backend sym => sym -> Range -> Maybe String -> SEval sym a -> SEval sym (SEval sym a)
+sDelay sym rng msg m =
   let msg'  = maybe "" ("while evaluating "++) msg
-      retry = raiseError sym (LoopError msg')
+      retry = raiseError sym (EvalErrorEx rng (LoopError msg'))
    in sDelayFill sym m retry
 
 
@@ -72,21 +73,21 @@ data SRational sym =
 intToRational :: Backend sym => sym -> SInteger sym -> SEval sym (SRational sym)
 intToRational sym x = SRational x <$> (integerLit sym 1)
 
-ratio :: Backend sym => sym -> SInteger sym -> SInteger sym -> SEval sym (SRational sym)
-ratio sym n d =
+ratio :: Backend sym => sym -> Range -> SInteger sym -> SInteger sym -> SEval sym (SRational sym)
+ratio sym rng n d =
   do pz  <- bitComplement sym =<< intEq sym d =<< integerLit sym 0
-     assertSideCondition sym pz DivideByZero
+     assertSideCondition sym pz (EvalErrorEx rng DivideByZero)
      pure (SRational n d)
 
-rationalRecip :: Backend sym => sym -> SRational sym -> SEval sym (SRational sym)
-rationalRecip sym (SRational a b) = ratio sym b a
+rationalRecip :: Backend sym => sym -> Range -> SRational sym -> SEval sym (SRational sym)
+rationalRecip sym rng (SRational a b) = ratio sym rng b a
 
-rationalDivide :: Backend sym => sym -> SRational sym -> SRational sym -> SEval sym (SRational sym)
-rationalDivide sym x y = rationalMul sym x =<< rationalRecip sym y
+rationalDivide :: Backend sym => sym -> Range -> SRational sym -> SRational sym -> SEval sym (SRational sym)
+rationalDivide sym rng x y = rationalMul sym x =<< rationalRecip sym rng y
 
 rationalFloor :: Backend sym => sym -> SRational sym -> SEval sym (SInteger sym)
  -- NB, relies on integer division being round-to-negative-inf division
-rationalFloor sym (SRational n d) = intDiv sym n d
+rationalFloor sym (SRational n d) = intDiv sym emptyRange n d
 
 rationalCeiling :: Backend sym => sym -> SRational sym -> SEval sym (SInteger sym)
 rationalCeiling sym r = intNegate sym =<< rationalFloor sym =<< rationalNegate sym r
@@ -120,7 +121,7 @@ rationalRoundToEven sym r =
 
  where
  isEven x =
-   do parity <- intMod sym x =<< integerLit sym 2
+   do parity <- intMod sym emptyRange x =<< integerLit sym 2
       intEq sym parity =<< integerLit sym 0
 
  ite x t e =
@@ -228,7 +229,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   after the fact.  A preallocated thunk is returned, along with an operation to
   --   fill the thunk with the associated computation.
   --   This is used to implement recursive declaration groups.
-  sDeclareHole :: sym -> String -> SEval sym (SEval sym a, SEval sym a -> SEval sym ())
+  sDeclareHole :: sym -> String -> Range -> SEval sym (SEval sym a, SEval sym a -> SEval sym ())
 
   -- | Delay the given evaluation computation, returning a thunk
   --   which will run the computation when forced.  Run the 'retry'
@@ -239,7 +240,7 @@ class MonadIO (SEval sym) => Backend sym where
   -- | Begin evaluating the given computation eagerly in a separate thread
   --   and return a thunk which will await the completion of the given computation
   --   when forced.
-  sSpark :: sym -> SEval sym a -> SEval sym (SEval sym a)
+  sSpark :: sym -> Range -> SEval sym a -> SEval sym (SEval sym a)
 
   -- | Merge the two given computations according to the predicate.
   mergeEval ::
@@ -252,10 +253,10 @@ class MonadIO (SEval sym) => Backend sym where
 
   -- | Assert that a condition must hold, and indicate what sort of
   --   error is indicated if the condition fails.
-  assertSideCondition :: sym -> SBit sym -> EvalError -> SEval sym ()
+  assertSideCondition :: sym -> SBit sym -> EvalErrorEx -> SEval sym ()
 
   -- | Indiciate that an error condition exists
-  raiseError :: sym -> EvalError -> SEval sym a
+  raiseError :: sym -> EvalErrorEx -> SEval sym a
 
 
   -- ==== Pretty printing  ====
@@ -335,6 +336,9 @@ class MonadIO (SEval sym) => Backend sym where
 
 
   -- ==== Word operations ====
+
+  -- TODO, add error handling to wordBit and wordUpdate
+
 
   -- | Extract the numbered bit from the word.
   --
@@ -472,6 +476,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   call with a second argument concretely equal to 0.
   wordDiv ::
     sym ->
+    Range ->
     SWord sym ->
     SWord sym ->
     SEval sym (SWord sym)
@@ -481,6 +486,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   call with a second argument concretely equal to 0.
   wordMod ::
     sym ->
+    Range ->
     SWord sym ->
     SWord sym ->
     SEval sym (SWord sym)
@@ -490,6 +496,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   call with a second argument concretely equal to 0.
   wordSignedDiv ::
     sym ->
+    Range ->
     SWord sym ->
     SWord sym ->
     SEval sym (SWord sym)
@@ -499,6 +506,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   call with a second argument concretely equal to 0.
   wordSignedMod ::
     sym ->
+    Range ->
     SWord sym ->
     SWord sym ->
     SEval sym (SWord sym)
@@ -583,6 +591,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   Same semantics as Haskell's @div@ operation.
   intDiv ::
     sym ->
+    Range ->
     SInteger sym ->
     SInteger sym ->
     SEval sym (SInteger sym)
@@ -592,6 +601,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   Same semantics as Haskell's @mod@ operation.
   intMod ::
     sym ->
+    Range ->
     SInteger sym ->
     SInteger sym ->
     SEval sym (SInteger sym)
@@ -678,6 +688,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   PRECONDITION: the modulus is a prime
   znRecip ::
     sym ->
+    Range ->
     Integer {- ^ modulus -} ->
     SInteger sym ->
     SEval sym (SInteger sym)
@@ -695,11 +706,13 @@ class MonadIO (SEval sym) => Backend sym where
   fpToInteger ::
     sym ->
     String {- ^ Name of the function for error reporting -} ->
+    Range ->
     SWord sym {-^ Rounding mode -} ->
     SFloat sym -> SEval sym (SInteger sym)
 
   fpFromInteger ::
     sym ->
+    Range ->
     Integer         {- exp width -} ->
     Integer         {- prec width -} ->
     SWord sym       {- ^ rounding mode -} ->
@@ -708,6 +721,7 @@ class MonadIO (SEval sym) => Backend sym where
 
 type FPArith2 sym =
   sym ->
+  Range ->
   SWord sym ->
   SFloat sym ->
   SFloat sym ->

--- a/src/Cryptol/Backend.hs
+++ b/src/Cryptol/Backend.hs
@@ -58,9 +58,7 @@ cryNoPrimError sym nm = raiseError sym (EvalErrorEx (nameLoc nm) (NoPrim nm))
 sDelay :: Backend sym => sym -> Range -> Maybe String -> SEval sym a -> SEval sym (SEval sym a)
 sDelay sym rng msg m =
   let msg'  = maybe "" ("while evaluating "++) msg
-      retry = raiseError sym (EvalErrorEx rng (LoopError msg'))
-   in sDelayFill sym m retry
-
+   in sDelayFill sym m Nothing msg' rng
 
 -- | Representation of rational numbers.
 --     Invariant: denominator is not 0
@@ -235,7 +233,7 @@ class MonadIO (SEval sym) => Backend sym where
   --   which will run the computation when forced.  Run the 'retry'
   --   computation instead if the resulting thunk is forced during
   --   its own evaluation.
-  sDelayFill :: sym -> SEval sym a -> SEval sym a -> SEval sym (SEval sym a)
+  sDelayFill :: sym -> SEval sym a -> Maybe (SEval sym a) -> String -> Range -> SEval sym (SEval sym a)
 
   -- | Begin evaluating the given computation eagerly in a separate thread
   --   and return a thunk which will await the completion of the given computation

--- a/src/Cryptol/Backend.hs
+++ b/src/Cryptol/Backend.hs
@@ -55,10 +55,8 @@ cryNoPrimError sym nm = raiseError sym (EvalErrorEx (nameLoc nm) (NoPrim nm))
 -- | Delay the given evaluation computation, returning a thunk
 --   which will run the computation when forced.  Raise a loop
 --   error if the resulting thunk is forced during its own evaluation.
-sDelay :: Backend sym => sym -> Range -> Maybe String -> SEval sym a -> SEval sym (SEval sym a)
-sDelay sym rng msg m =
-  let msg'  = maybe "" ("while evaluating "++) msg
-   in sDelayFill sym m Nothing msg' rng
+sDelay :: Backend sym => sym -> Range -> SEval sym a -> SEval sym (SEval sym a)
+sDelay sym rng m = sDelayFill sym m Nothing "" rng
 
 -- | Representation of rational numbers.
 --     Invariant: denominator is not 0

--- a/src/Cryptol/Backend/Monad.hs
+++ b/src/Cryptol/Backend/Monad.hs
@@ -351,7 +351,7 @@ data EvalError
   | NoPrim Name                   -- ^ Primitive with no implementation
   | BadRoundingMode Integer       -- ^ Invalid rounding mode
   | BadValue String               -- ^ Value outside the domain of a partial function.
-    deriving (Typeable,Show)
+    deriving Typeable
 
 instance PP EvalError where
   ppPrec _ e = case e of
@@ -368,6 +368,9 @@ instance PP EvalError where
     BadRoundingMode r -> "invalid rounding mode" <+> integer r
     BadValue x -> "invalid input for" <+> backticks (text x)
     NoPrim x -> text "unimplemented primitive:" <+> pp x
+
+instance Show EvalError where
+  show = show . pp
 
 instance X.Exception EvalError
 

--- a/src/Cryptol/Backend/Monad.hs
+++ b/src/Cryptol/Backend/Monad.hs
@@ -360,7 +360,6 @@ instance PP EvalError where
   ppPrec _ e = case e of
     InvalidIndex (Just i) -> text "invalid sequence index:" <+> integer i
     InvalidIndex Nothing  -> text "invalid sequence index"
---    TypeCannotBeDemoted t -> text "type cannot be demoted:" <+> pp t
     DivideByZero -> text "division by 0"
     NegativeExponent -> text "negative exponent"
     LogNegative -> text "logarithm of negative"
@@ -396,11 +395,6 @@ instance PP Unsupported where
     UnsupportedSymbolicOp nm -> text "operation can not be supported on symbolic values:" <+> text nm
 
 instance X.Exception Unsupported
-
-
--- | For things like @`(inf)@ or @`(0-1)@.
---typeCannotBeDemoted :: Type -> a
---typeCannotBeDemoted t = X.throw (TypeCannotBeDemoted t)
 
 -- | For when we know that a word is too wide and will exceed gmp's
 -- limits (though words approaching this size will probably cause the

--- a/src/Cryptol/Backend/SBV.hs
+++ b/src/Cryptol/Backend/SBV.hs
@@ -164,8 +164,8 @@ instance Backend SBV where
   isReady _ (SBVEval (Ready _)) = True
   isReady _ _ = False
 
-  sDelayFill _ m retry = SBVEval $
-    do m' <- delayFill (sbvEval m) (sbvEval retry)
+  sDelayFill _ m retry msg rng = SBVEval $
+    do m' <- delayFill (sbvEval m) (sbvEval <$> retry) msg rng
        pure (pure (SBVEval m'))
 
   sSpark _ rng m = SBVEval $

--- a/src/Cryptol/Backend/What4.hs
+++ b/src/Cryptol/Backend/What4.hs
@@ -221,10 +221,10 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
       Ready _ -> True
       _ -> False
 
-  sDelayFill _ m retry =
+  sDelayFill _ m retry msg rng =
     total
     do sym <- getSym
-       doEval (w4Thunk <$> delayFill (w4Eval m sym) (w4Eval retry sym))
+       doEval (w4Thunk <$> delayFill (w4Eval m sym) (w4Eval <$> retry <*> pure sym) msg rng)
 
   sSpark _ rng m =
     total

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -32,6 +32,7 @@ module Cryptol.Eval (
   , EvalError(..)
   , EvalErrorEx(..)
   , Unsupported(..)
+  , WordTooWide(..)
   , forceValue
   ) where
 

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -39,6 +39,7 @@ import Cryptol.Backend.Concrete( Concrete(..) )
 import Cryptol.Backend.Monad
 import Cryptol.Eval.Generic ( iteValue )
 import Cryptol.Eval.Env
+import Cryptol.Eval.Prims
 import Cryptol.Eval.Type
 import Cryptol.Eval.Value
 import Cryptol.ModuleSystem.Name
@@ -63,9 +64,9 @@ import Prelude.Compat
 type EvalEnv = GenEvalEnv Concrete
 
 type EvalPrims sym =
-  ( Backend sym, ?evalPrim :: PrimIdent -> Maybe (Either Expr (GenValue sym)) )
+  ( Backend sym, ?evalPrim :: PrimIdent -> Maybe (Either Expr (Prim sym)) )
 
-type ConcPrims = ?evalPrim :: PrimIdent -> Maybe (Either Expr (GenValue Concrete))
+type ConcPrims = ?evalPrim :: PrimIdent -> Maybe (Either Expr (Prim Concrete))
 
 -- Expression Evaluation -------------------------------------------------------
 
@@ -527,7 +528,7 @@ evalDecl sym renv env d =
   case dDefinition d of
     DPrim ->
       case ?evalPrim =<< asPrim (dName d) of
-        Just (Right v) -> pure (bindVarDirect (dName d) v env)
+        Just (Right p) -> bindVar sym (dName d) (evalPrim sym (dName d) p) env
         Just (Left ex) -> bindVar sym (dName d) (evalExpr sym renv ex) env
         Nothing        -> bindVar sym (dName d) (cryNoPrimError sym (dName d)) env
 

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -106,6 +106,8 @@ evalExpr ::
   SEval sym (GenValue sym)
 evalExpr sym env expr = case expr of
 
+  ELocated _ t -> evalExpr sym env t -- TODO, track source locations
+
   -- Try to detect when the user has directly written a finite sequence of
   -- literal bit values and pack these into a word.
   EList es ty

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -25,7 +25,7 @@ module Cryptol.Eval.Concrete
   , toExpr
   ) where
 
-import Control.Monad (join, guard, zipWithM, foldM)
+import Control.Monad (guard, zipWithM, foldM)
 import Data.Bits (Bits(..))
 import Data.Ratio((%),numerator,denominator)
 import Data.Word(Word32, Word64)
@@ -44,6 +44,7 @@ import Cryptol.Backend.FloatHelpers
 import Cryptol.Backend.Monad
 
 import Cryptol.Eval.Generic hiding (logicShift)
+import Cryptol.Eval.Prims
 import Cryptol.Eval.Type
 import Cryptol.Eval.Value
 import qualified Cryptol.SHA as SHA
@@ -139,152 +140,17 @@ floatToExpr prims eT pT f =
 
 -- Primitives ------------------------------------------------------------------
 
-primTable :: EvalOpts -> Map PrimIdent Value
+primTable :: EvalOpts -> Map PrimIdent (Prim Concrete)
 primTable eOpts = let sym = Concrete in
+  Map.union (genericPrimTable sym) $
   Map.union (floatPrims sym) $
   Map.union suiteBPrims $
   Map.union primeECPrims $
 
   Map.fromList $ map (\(n, v) -> (prelPrim n, v))
 
-  [ -- Literals
-    ("True"       , VBit (bitLit sym True))
-  , ("False"      , VBit (bitLit sym False))
-  , ("number"     , {-# SCC "Prelude::number" #-}
-                    ecNumberV sym)
-  , ("ratio"      , {-# SCC "Prelude::ratio" #-}
-                    ratioV sym)
-  , ("fraction"   , ecFractionV sym)
-
-
-    -- Zero
-  , ("zero"       , {-# SCC "Prelude::zero" #-}
-                    VPoly (zeroV sym))
-
-    -- Logic
-  , ("&&"         , {-# SCC "Prelude::(&&)" #-}
-                    binary (andV sym))
-  , ("||"         , {-# SCC "Prelude::(||)" #-}
-                    binary (orV sym))
-  , ("^"          , {-# SCC "Prelude::(^)" #-}
-                    binary (xorV sym))
-  , ("complement" , {-# SCC "Prelude::complement" #-}
-                    unary  (complementV sym))
-
-    -- Ring
-  , ("fromInteger", {-# SCC "Prelude::fromInteger" #-}
-                    fromIntegerV sym)
-  , ("+"          , {-# SCC "Prelude::(+)" #-}
-                    binary (addV sym))
-  , ("-"          , {-# SCC "Prelude::(-)" #-}
-                    binary (subV sym))
-  , ("*"          , {-# SCC "Prelude::(*)" #-}
-                    binary (mulV sym))
-  , ("negate"     , {-# SCC "Prelude::negate" #-}
-                    unary (negateV sym))
-
-    -- Integral
-  , ("toInteger"  , {-# SCC "Prelude::toInteger" #-}
-                    toIntegerV sym)
-  , ("/"          , {-# SCC "Prelude::(/)" #-}
-                    binary (divV sym))
-  , ("%"          , {-# SCC "Prelude::(%)" #-}
-                    binary (modV sym))
-  , ("^^"         , {-# SCC "Prelude::(^^)" #-}
-                    expV sym)
-  , ("infFrom"    , {-# SCC "Prelude::infFrom" #-}
-                    infFromV sym)
-  , ("infFromThen", {-# SCC "Prelude::infFromThen" #-}
-                    infFromThenV sym)
-
-    -- Field
-  , ("recip"      , {-# SCC "Prelude::recip" #-}
-                    recipV sym)
-  , ("/."         , {-# SCC "Prelude::(/.)" #-}
-                    fieldDivideV sym)
-
-    -- Round
-  , ("floor"      , {-# SCC "Prelude::floor" #-}
-                    unary (floorV sym))
-  , ("ceiling"    , {-# SCC "Prelude::ceiling" #-}
-                    unary (ceilingV sym))
-  , ("trunc"      , {-# SCC "Prelude::trunc" #-}
-                    unary (truncV sym))
-  , ("roundAway"  , {-# SCC "Prelude::roundAway" #-}
-                    unary (roundAwayV sym))
-  , ("roundToEven", {-# SCC "Prelude::roundToEven" #-}
-                    unary (roundToEvenV sym))
-
-    -- Bitvector specific operations
-  , ("/$"         , {-# SCC "Prelude::(/$)" #-}
-                    sdivV sym)
-  , ("%$"         , {-# SCC "Prelude::(%$)" #-}
-                    smodV sym)
-  , ("lg2"        , {-# SCC "Prelude::lg2" #-}
-                    lg2V sym)
-  , (">>$"        , {-# SCC "Prelude::(>>$)" #-}
+  [ (">>$"        , {-# SCC "Prelude::(>>$)" #-}
                     sshrV)
-
-    -- Cmp
-  , ("<"          , {-# SCC "Prelude::(<)" #-}
-                    binary (lessThanV sym))
-  , (">"          , {-# SCC "Prelude::(>)" #-}
-                    binary (greaterThanV sym))
-  , ("<="         , {-# SCC "Prelude::(<=)" #-}
-                    binary (lessThanEqV sym))
-  , (">="         , {-# SCC "Prelude::(>=)" #-}
-                    binary (greaterThanEqV sym))
-  , ("=="         , {-# SCC "Prelude::(==)" #-}
-                    binary (eqV sym))
-  , ("!="         , {-# SCC "Prelude::(!=)" #-}
-                    binary (distinctV sym))
-
-    -- SignedCmp
-  , ("<$"         , {-# SCC "Prelude::(<$)" #-}
-                    binary (signedLessThanV sym))
-
-    -- Finite enumerations
-  , ("fromTo"     , {-# SCC "Prelude::fromTo" #-}
-                    fromToV sym)
-  , ("fromThenTo" , {-# SCC "Prelude::fromThenTo" #-}
-                    fromThenToV sym)
-
-    -- Sequence manipulations
-  , ("#"          , {-# SCC "Prelude::(#)" #-}
-                    nlam $ \ front ->
-                    nlam $ \ back  ->
-                    tlam $ \ elty  ->
-                    lam  $ \ l     -> return $
-                    lam  $ \ r     -> join (ccatV sym front back elty <$> l <*> r))
-
-
-  , ("join"       , {-# SCC "Prelude::join" #-}
-                    nlam $ \ parts ->
-                    nlam $ \ (finNat' -> each)  ->
-                    tlam $ \ a     ->
-                    lam  $ \ x     ->
-                      joinV sym parts each a =<< x)
-
-  , ("split"      , {-# SCC "Prelude::split" #-}
-                    ecSplitV sym)
-
-  , ("splitAt"    , {-# SCC "Prelude::splitAt" #-}
-                    nlam $ \ front ->
-                    nlam $ \ back  ->
-                    tlam $ \ a     ->
-                    lam  $ \ x     ->
-                       splitAtV sym front back a =<< x)
-
-  , ("reverse"    , {-# SCC "Prelude::reverse" #-}
-                    nlam $ \_a ->
-                    tlam $ \_b ->
-                     lam $ \xs -> reverseV sym =<< xs)
-
-  , ("transpose"  , {-# SCC "Prelude::transpose" #-}
-                    nlam $ \a ->
-                    nlam $ \b ->
-                    tlam $ \c ->
-                     lam $ \xs -> transposeV sym a b c =<< xs)
 
     -- Shifts and rotates
   , ("<<"         , {-# SCC "Prelude::(<<)" #-}
@@ -308,44 +174,15 @@ primTable eOpts = let sym = Concrete in
   , ("updateEnd"  , {-# SCC "Prelude::updateEnd" #-}
                     updatePrim sym updateBack_word updateBack)
 
-    -- Misc
-  , ("foldl"      , {-# SCC "Prelude::foldl" #-}
-                    foldlV sym)
-
-  , ("foldl'"     , {-# SCC "Prelude::foldl'" #-}
-                    foldl'V sym)
-
-  , ("deepseq"    , {-# SCC "Prelude::deepseq" #-}
-                    tlam $ \_a ->
-                    tlam $ \_b ->
-                     lam $ \x -> pure $
-                     lam $ \y ->
-                       do _ <- forceValue =<< x
-                          y)
-
-  , ("parmap"     , {-# SCC "Prelude::parmap" #-}
-                    parmapV sym)
-
-  , ("fromZ"      , {-# SCC "Prelude::fromZ" #-}
-                    fromZV sym)
-
-  , ("error"      , {-# SCC "Prelude::error" #-}
-                      tlam $ \a ->
-                      nlam $ \_ ->
-                       lam $ \s -> errorV sym a =<< (valueToString sym =<< s))
-
-  , ("random"      , {-# SCC "Prelude::random" #-}
-                     tlam $ \a ->
-                     wlam sym $ \(bvVal -> x) -> randomV sym a x)
-
   , ("trace"       , {-# SCC "Prelude::trace" #-}
-                     nlam $ \_n ->
-                     tlam $ \_a ->
-                     tlam $ \_b ->
-                      lam $ \s -> return $
-                      lam $ \x -> return $
-                      lam $ \y -> do
-                         msg <- valueToString sym =<< s
+                     PNumPoly \_n ->
+                     PTyPoly  \_a ->
+                     PTyPoly  \_b ->
+                     PFun     \s ->
+                     PFun     \x ->
+                     PFun     \y ->
+                     PPrim
+                      do msg <- valueToString sym =<< s
                          let EvalOpts { evalPPOpts, evalLogger } = eOpts
                          doc <- ppValue sym evalPPOpts =<< x
                          yv <- y
@@ -354,10 +191,11 @@ primTable eOpts = let sym = Concrete in
                          return yv)
 
    , ("pmult",
-        ilam $ \u ->
-        ilam $ \v ->
-          wlam Concrete $ \(BV _ x) -> return $
-          wlam Concrete $ \(BV _ y) ->
+        PFinPoly \u ->
+        PFinPoly \v ->
+        PWordFun \(BV _ x) ->
+        PWordFun \(BV _ y) ->
+        PPrim
             let z = if u <= v then
                       F2.pmult (fromInteger (u+1)) x y
                     else
@@ -365,56 +203,62 @@ primTable eOpts = let sym = Concrete in
              in return . VWord (1+u+v) . pure . WordVal . mkBv (1+u+v) $! z)
 
    , ("pmod",
-        ilam $ \_u ->
-        ilam $ \v ->
-        wlam Concrete $ \(BV w x) -> return $
-        wlam Concrete $ \(BV _ m) ->
+        PFinPoly \_u ->
+        PFinPoly \v ->
+        PWordFun \(BV w x) ->
+        PWordFun \(BV _ m) ->
+        PPrim
           do assertSideCondition sym (m /= 0) DivideByZero
              return . VWord v . pure . WordVal . mkBv v $! F2.pmod (fromInteger w) x m)
 
   , ("pdiv",
-        ilam $ \_u ->
-        ilam $ \_v ->
-        wlam Concrete $ \(BV w x) -> return $
-        wlam Concrete $ \(BV _ m) ->
+        PFinPoly \_u ->
+        PFinPoly \_v ->
+        PWordFun \(BV w x) ->
+        PWordFun \(BV _ m) ->
+        PPrim
           do assertSideCondition sym (m /= 0) DivideByZero
              return . VWord w . pure . WordVal . mkBv w $! F2.pdiv (fromInteger w) x m)
   ]
 
 
-primeECPrims :: Map.Map PrimIdent Value
+primeECPrims :: Map.Map PrimIdent (Prim Concrete)
 primeECPrims = Map.fromList $ map (\(n,v) -> (primeECPrim n, v))
   [ ("ec_double", {-# SCC "PrimeEC::ec_double" #-}
-       ilam $ \p ->
-        lam $ \s ->
+       PFinPoly \p ->
+       PFun     \s ->
+       PPrim
           do s' <- toProjectivePoint =<< s
              let r = PrimeEC.ec_double (PrimeEC.primeModulus p) s'
              fromProjectivePoint $! r)
 
   , ("ec_add_nonzero", {-# SCC "PrimeEC::ec_add_nonzero" #-}
-       ilam $ \p ->
-        lam $ \s -> pure $
-        lam $ \t ->
+       PFinPoly \p ->
+       PFun     \s ->
+       PFun     \t ->
+       PPrim 
           do s' <- toProjectivePoint =<< s
              t' <- toProjectivePoint =<< t
              let r = PrimeEC.ec_add_nonzero (PrimeEC.primeModulus p) s' t'
              fromProjectivePoint $! r)
 
   , ("ec_mult", {-# SCC "PrimeEC::ec_mult" #-}
-       ilam $ \p ->
-        lam $ \d -> pure $
-        lam $ \s ->
+       PFinPoly \p ->
+       PFun     \d ->
+       PFun     \s ->
+       PPrim
           do d' <- fromVInteger <$> d
              s' <- toProjectivePoint =<< s
              let r = PrimeEC.ec_mult (PrimeEC.primeModulus p) d' s'
              fromProjectivePoint $! r)
 
   , ("ec_twin_mult", {-# SCC "PrimeEC::ec_twin_mult" #-}
-       ilam $ \p ->
-        lam $ \d0 -> pure $
-        lam $ \s  -> pure $
-        lam $ \d1 -> pure $
-        lam $ \t  ->
+       PFinPoly \p  ->
+       PFun     \d0 ->
+       PFun     \s  ->
+       PFun     \d1 ->
+       PFun     \t  ->
+       PPrim
           do d0' <- fromVInteger <$> d0
              s'  <- toProjectivePoint =<< s
              d1' <- fromVInteger <$> d1
@@ -436,59 +280,64 @@ fromProjectivePoint (PrimeEC.ProjectivePoint x y z) =
 
 
 
-suiteBPrims :: Map.Map PrimIdent Value
+suiteBPrims :: Map.Map PrimIdent (Prim Concrete)
 suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
   [ ("processSHA2_224", {-# SCC "SuiteB::processSHA2_224" #-}
-                      ilam $ \n ->
-                       lam $ \xs ->
-                         do blks <- enumerateSeqMap n . fromVSeq <$> xs
-                            (SHA.SHA256S w0 w1 w2 w3 w4 w5 w6 _) <-
-                               foldM (\st blk -> seq st (SHA.processSHA256Block st <$> (toSHA256Block =<< blk)))
-                                     SHA.initialSHA224State blks
-                            let f :: Word32 -> Eval Value
-                                f = pure . VWord 32 . pure . WordVal . BV 32 . toInteger
-                                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6])
-                            seq zs (pure (VSeq 7 zs)))
+     PFinPoly \n ->
+     PFun     \xs ->
+     PPrim
+        do blks <- enumerateSeqMap n . fromVSeq <$> xs
+           (SHA.SHA256S w0 w1 w2 w3 w4 w5 w6 _) <-
+              foldM (\st blk -> seq st (SHA.processSHA256Block st <$> (toSHA256Block =<< blk)))
+                    SHA.initialSHA224State blks
+           let f :: Word32 -> Eval Value
+               f = pure . VWord 32 . pure . WordVal . BV 32 . toInteger
+               zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6])
+           seq zs (pure (VSeq 7 zs)))
 
   , ("processSHA2_256", {-# SCC "SuiteB::processSHA2_256" #-}
-                      ilam $ \n ->
-                       lam $ \xs ->
-                         do blks <- enumerateSeqMap n . fromVSeq <$> xs
-                            (SHA.SHA256S w0 w1 w2 w3 w4 w5 w6 w7) <-
-                              foldM (\st blk -> seq st (SHA.processSHA256Block st <$> (toSHA256Block =<< blk)))
-                                    SHA.initialSHA256State blks
-                            let f :: Word32 -> Eval Value
-                                f = pure . VWord 32 . pure . WordVal . BV 32 . toInteger
-                                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6,w7])
-                            seq zs (pure (VSeq 8 zs)))
+     PFinPoly \n ->
+     PFun     \xs ->
+     PPrim
+        do blks <- enumerateSeqMap n . fromVSeq <$> xs
+           (SHA.SHA256S w0 w1 w2 w3 w4 w5 w6 w7) <-
+             foldM (\st blk -> seq st (SHA.processSHA256Block st <$> (toSHA256Block =<< blk)))
+                   SHA.initialSHA256State blks
+           let f :: Word32 -> Eval Value
+               f = pure . VWord 32 . pure . WordVal . BV 32 . toInteger
+               zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6,w7])
+           seq zs (pure (VSeq 8 zs)))
 
   , ("processSHA2_384", {-# SCC "SuiteB::processSHA2_384" #-}
-                      ilam $ \n ->
-                       lam $ \xs ->
-                         do blks <- enumerateSeqMap n . fromVSeq <$> xs
-                            (SHA.SHA512S w0 w1 w2 w3 w4 w5 _ _) <-
-                              foldM (\st blk -> seq st (SHA.processSHA512Block st <$> (toSHA512Block =<< blk)))
-                                    SHA.initialSHA384State blks
-                            let f :: Word64 -> Eval Value
-                                f = pure . VWord 64 . pure . WordVal . BV 64 . toInteger
-                                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5])
-                            seq zs (pure (VSeq 6 zs)))
+     PFinPoly \n ->
+     PFun     \xs ->
+     PPrim
+        do blks <- enumerateSeqMap n . fromVSeq <$> xs
+           (SHA.SHA512S w0 w1 w2 w3 w4 w5 _ _) <-
+             foldM (\st blk -> seq st (SHA.processSHA512Block st <$> (toSHA512Block =<< blk)))
+                   SHA.initialSHA384State blks
+           let f :: Word64 -> Eval Value
+               f = pure . VWord 64 . pure . WordVal . BV 64 . toInteger
+               zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5])
+           seq zs (pure (VSeq 6 zs)))
 
   , ("processSHA2_512", {-# SCC "SuiteB::processSHA2_512" #-}
-                      ilam $ \n ->
-                       lam $ \xs ->
-                         do blks <- enumerateSeqMap n . fromVSeq <$> xs
-                            (SHA.SHA512S w0 w1 w2 w3 w4 w5 w6 w7) <-
-                              foldM (\st blk -> seq st (SHA.processSHA512Block st <$> (toSHA512Block =<< blk)))
-                                    SHA.initialSHA512State blks
-                            let f :: Word64 -> Eval Value
-                                f = pure . VWord 64 . pure . WordVal . BV 64 . toInteger
-                                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6,w7])
-                            seq zs (pure (VSeq 8 zs)))
+     PFinPoly \n ->
+     PFun     \xs ->
+     PPrim
+        do blks <- enumerateSeqMap n . fromVSeq <$> xs
+           (SHA.SHA512S w0 w1 w2 w3 w4 w5 w6 w7) <-
+             foldM (\st blk -> seq st (SHA.processSHA512Block st <$> (toSHA512Block =<< blk)))
+                   SHA.initialSHA512State blks
+           let f :: Word64 -> Eval Value
+               f = pure . VWord 64 . pure . WordVal . BV 64 . toInteger
+               zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6,w7])
+           seq zs (pure (VSeq 8 zs)))
 
   , ("AESKeyExpand", {-# SCC "SuiteB::AESKeyExpand" #-}
-      ilam $ \k ->
-       lam $ \seed ->
+      PFinPoly \k ->
+      PFun     \seed ->
+      PPrim
          do ss <- fromVSeq <$> seed
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESInfKeyExpand" =<< lookupSeqMap ss i)
@@ -500,7 +349,8 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             pure (VSeq len (finiteSeqMap Concrete (map fromWord ws))))
 
   , ("AESInvMixColumns", {-# SCC "SuiteB::AESInvMixColumns" #-}
-      lam $ \st ->
+      PFun \st ->
+      PPrim
          do ss <- fromVSeq <$> st
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESInvMixColumns" =<< lookupSeqMap ss i)
@@ -511,7 +361,8 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
 
   , ("AESEncRound", {-# SCC "SuiteB::AESEncRound" #-}
-      lam $ \st ->
+      PFun \st ->
+      PPrim
          do ss <- fromVSeq <$> st
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESEncRound" =<< lookupSeqMap ss i)
@@ -522,7 +373,8 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
 
   , ("AESEncFinalRound", {-# SCC "SuiteB::AESEncFinalRound" #-}
-      lam $ \st ->
+     PFun \st ->
+     PPrim
          do ss <- fromVSeq <$> st
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESEncFinalRound" =<< lookupSeqMap ss i)
@@ -533,7 +385,8 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
 
   , ("AESDecRound", {-# SCC "SuiteB::AESDecRound" #-}
-      lam $ \st ->
+      PFun \st ->
+      PPrim
          do ss <- fromVSeq <$> st
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESDecRound" =<< lookupSeqMap ss i)
@@ -544,7 +397,8 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
 
   , ("AESDecFinalRound", {-# SCC "SuiteB::AESDecFinalRound" #-}
-      lam $ \st ->
+     PFun \st ->
+     PPrim
          do ss <- fromVSeq <$> st
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESDecFinalRound" =<< lookupSeqMap ss i)
@@ -603,12 +457,13 @@ toSHA512Block blk =
 
 --------------------------------------------------------------------------------
 
-sshrV :: Value
+sshrV :: Prim Concrete
 sshrV =
-  nlam $ \_n ->
-  tlam $ \ix ->
-  wlam Concrete $ \(BV w x) -> return $
-  lam $ \y ->
+  PNumPoly \_n ->
+  PTyPoly  \ix ->
+  PWordFun \(BV w x) ->
+  PFun     \y ->
+  PPrim
    do idx <- y >>= asIndex Concrete ">>$" ix >>= \case
                  Left idx -> pure idx
                  Right wv -> bvVal <$> asWordVal Concrete wv
@@ -618,14 +473,15 @@ logicShift :: (Integer -> Integer -> Integer -> Integer)
               -- ^ The function may assume its arguments are masked.
               -- It is responsible for masking its result if needed.
            -> (Nat' -> TValue -> SeqMap Concrete -> Integer -> SeqMap Concrete)
-           -> Value
-logicShift opW opS
-  = nlam $ \ a ->
-    tlam $ \ _ix ->
-    tlam $ \ c ->
-     lam  $ \ l -> return $
-     lam  $ \ r -> do
-        i <- r >>= \case
+           -> Prim Concrete
+logicShift opW opS =
+  PNumPoly \a ->
+  PTyPoly  \_ix ->
+  PTyPoly  \c ->
+  PFun     \l ->
+  PFun     \r ->
+  PPrim
+     do i <- r >>= \case
           VInteger i -> pure i
           VWord _ wval -> bvVal <$> (asWordVal Concrete =<< wval)
           _ -> evalPanic "logicShift" ["not an index"]
@@ -797,33 +653,33 @@ updateBack_word (Nat n) _eltTy bs (Right w) val = do
   updateWordValue Concrete bs (n - idx - 1) (fromVBit <$> val)
 
 
-floatPrims :: Concrete -> Map PrimIdent Value
+floatPrims :: Concrete -> Map PrimIdent (Prim Concrete)
 floatPrims sym = Map.fromList [ (floatPrim i,v) | (i,v) <- nonInfixTable ]
   where
   (~>) = (,)
   nonInfixTable =
-    [ "fpNaN"       ~> ilam \e -> ilam \p ->
+    [ "fpNaN"       ~> PFinPoly \e -> PFinPoly \p -> PVal $
                         VFloat BF { bfValue = FP.bfNaN
                                   , bfExpWidth = e, bfPrecWidth = p }
 
-    , "fpPosInf"    ~> ilam \e -> ilam \p ->
+    , "fpPosInf"    ~> PFinPoly \e -> PFinPoly \p -> PVal $
                        VFloat BF { bfValue = FP.bfPosInf
                                  , bfExpWidth = e, bfPrecWidth = p }
 
-    , "fpFromBits"  ~> ilam \e -> ilam \p -> wlam sym \bv ->
-                       pure $ VFloat $ floatFromBits e p $ bvVal bv
+    , "fpFromBits"  ~> PFinPoly \e -> PFinPoly \p -> PWordFun \bv -> PVal $
+                       VFloat $ floatFromBits e p $ bvVal bv
 
-    , "fpToBits"    ~> ilam \e -> ilam \p -> flam \x ->
-                       pure $ word sym (e + p)
+    , "fpToBits"    ~> PFinPoly \e -> PFinPoly \p -> PFloatFun \x -> PVal
+                            $ word sym (e + p)
                             $ floatToBits e p
                             $ bfValue x
-    , "=.="         ~> ilam \_ -> ilam \_ -> flam \x -> pure $ flam \y ->
-                       pure $ VBit
+    , "=.="         ~> PFinPoly \_ -> PFinPoly \_ -> PFloatFun \x -> PFloatFun \y -> PVal
+                            $ VBit
                             $ bitLit sym
                             $ FP.bfCompare (bfValue x) (bfValue y) == EQ
 
-    , "fpIsFinite"  ~> ilam \_ -> ilam \_ -> flam \x ->
-                       pure $ VBit $ bitLit sym $ FP.bfIsFinite $ bfValue x
+    , "fpIsFinite"  ~> PFinPoly \_ -> PFinPoly \_ -> PFloatFun \x -> PVal
+                        $ VBit $ bitLit sym $ FP.bfIsFinite $ bfValue x
 
       -- From Backend class
     , "fpAdd"      ~> fpBinArithV sym fpPlus
@@ -832,18 +688,16 @@ floatPrims sym = Map.fromList [ (floatPrim i,v) | (i,v) <- nonInfixTable ]
     , "fpDiv"      ~> fpBinArithV sym fpDiv
 
     , "fpFromRational" ~>
-      ilam \e -> ilam \p -> wlam sym \r -> pure $ lam \x ->
+      PFinPoly \e -> PFinPoly \p -> PWordFun \r -> PFun \x -> PPrim
         do rat <- fromVRational <$> x
            VFloat <$> do mode <- fpRoundMode sym r
                          pure $ floatFromRational e p mode
                               $ sNum rat % sDenom rat
     , "fpToRational" ~>
-      ilam \_e -> ilam \_p -> flam \fp ->
+      PFinPoly \_e -> PFinPoly \_p -> PFloatFun \fp -> PPrim
       case floatToRational "fpToRational" fp of
         Left err -> raiseError sym err
         Right r  -> pure $
                       VRational
                         SRational { sNum = numerator r, sDenom = denominator r }
     ]
-
-

--- a/src/Cryptol/Eval/Env.hs
+++ b/src/Cryptol/Eval/Env.hs
@@ -79,7 +79,7 @@ bindVar ::
   SEval sym (GenEvalEnv sym)
 bindVar sym n val env = do
   let nm = show $ ppLocName n
-  val' <- sDelay sym (nameLoc n) (Just nm) val
+  val' <- sDelayFill sym val Nothing nm (nameLoc n)
   return $ env{ envVars = IntMap.insert (nameUnique n) (Right val') (envVars env) }
 
 -- | Bind a variable to a value in the evaluation environment, without

--- a/src/Cryptol/Eval/Prims.hs
+++ b/src/Cryptol/Eval/Prims.hs
@@ -1,33 +1,37 @@
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 module Cryptol.Eval.Prims where
 
 import Cryptol.Backend
-import Cryptol.TypeCheck.Solver.InfNat(Nat'(..))
 import Cryptol.Eval.Type
 import Cryptol.Eval.Value
 import Cryptol.ModuleSystem.Name
+import Cryptol.Parser.Position
+import Cryptol.TypeCheck.Solver.InfNat(Nat'(..))
 import Cryptol.Utils.Panic
 
 data Prim sym
   = PFun (SEval sym (GenValue sym) -> Prim sym)
-  | PStrictFun (GenValue sym -> Prim sym)
+  | PStrict (GenValue sym -> Prim sym)
   | PWordFun (SWord sym -> Prim sym)
   | PFloatFun (SFloat sym -> Prim sym)
   | PTyPoly (TValue -> Prim sym)
   | PNumPoly (Nat' -> Prim sym)
   | PFinPoly (Integer -> Prim sym)
+  | PRange (Range -> Prim sym)
   | PPrim (SEval sym (GenValue sym))
   | PVal (GenValue sym)
 
-evalPrim :: Backend sym => sym -> Name -> Prim sym -> SEval sym (GenValue sym)
+evalPrim :: (?range :: Range, Backend sym) => sym -> Name -> Prim sym -> SEval sym (GenValue sym)
 evalPrim sym nm p = case p of
-  PFun f       -> pure (lam (evalPrim sym nm . f))
-  PStrictFun f -> pure (lam (\x -> evalPrim sym nm . f =<< x))
-  PWordFun f   -> pure (lam (\x -> evalPrim sym nm . f =<< (fromVWord sym (show nm) =<< x)))
-  PFloatFun f  -> pure (flam (evalPrim sym nm . f))
-  PTyPoly f    -> pure (VPoly (evalPrim sym nm . f))
-  PNumPoly f   -> pure (VNumPoly (evalPrim sym nm . f))
-  PFinPoly f   -> pure (VNumPoly (\case Inf -> panic "PFin" ["Unexpected `inf`", show nm];
+  PFun f      -> pure (lam (evalPrim sym nm . f))
+  PStrict f   -> pure (lam (\x -> evalPrim sym nm . f =<< x))
+  PWordFun f  -> pure (lam (\x -> evalPrim sym nm . f =<< (fromVWord sym (show nm) =<< x)))
+  PFloatFun f -> pure (flam (evalPrim sym nm . f))
+  PTyPoly f   -> pure (VPoly (evalPrim sym nm . f))
+  PNumPoly f  -> pure (VNumPoly (evalPrim sym nm . f))
+  PFinPoly f  -> pure (VNumPoly (\case Inf -> panic "PFin" ["Unexpected `inf`", show nm];
                                         Nat n -> evalPrim sym nm (f n)))
-  PPrim m      -> m
-  PVal v       -> pure v
+  PRange f    -> evalPrim sym nm (f ?range)
+  PPrim m     -> m
+  PVal v      -> pure v

--- a/src/Cryptol/Eval/Prims.hs
+++ b/src/Cryptol/Eval/Prims.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE LambdaCase #-}
+module Cryptol.Eval.Prims where
+
+import Cryptol.Backend
+import Cryptol.TypeCheck.Solver.InfNat(Nat'(..))
+import Cryptol.Eval.Type
+import Cryptol.Eval.Value
+import Cryptol.ModuleSystem.Name
+import Cryptol.Utils.Panic
+
+data Prim sym
+  = PFun (SEval sym (GenValue sym) -> Prim sym)
+  | PStrictFun (GenValue sym -> Prim sym)
+  | PWordFun (SWord sym -> Prim sym)
+  | PFloatFun (SFloat sym -> Prim sym)
+  | PTyPoly (TValue -> Prim sym)
+  | PNumPoly (Nat' -> Prim sym)
+  | PFinPoly (Integer -> Prim sym)
+  | PPrim (SEval sym (GenValue sym))
+  | PVal (GenValue sym)
+
+evalPrim :: Backend sym => sym -> Name -> Prim sym -> SEval sym (GenValue sym)
+evalPrim sym nm p = case p of
+  PFun f       -> pure (lam (evalPrim sym nm . f))
+  PStrictFun f -> pure (lam (\x -> evalPrim sym nm . f =<< x))
+  PWordFun f   -> pure (lam (\x -> evalPrim sym nm . f =<< (fromVWord sym (show nm) =<< x)))
+  PFloatFun f  -> pure (flam (evalPrim sym nm . f))
+  PTyPoly f    -> pure (VPoly (evalPrim sym nm . f))
+  PNumPoly f   -> pure (VNumPoly (evalPrim sym nm . f))
+  PFinPoly f   -> pure (VNumPoly (\case Inf -> panic "PFin" ["Unexpected `inf`", show nm];
+                                        Nat n -> evalPrim sym nm (f n)))
+  PPrim m      -> m
+  PVal v       -> pure v

--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -284,6 +284,8 @@ assigns values to those variables.
 > evalExpr env expr =
 >   case expr of
 >
+>     ELocated _ e -> evalExpr env e
+>
 >     EList es _ty  ->
 >       pure $ VList (Nat (genericLength es)) [ evalExpr env e | e <- es ]
 >

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -30,13 +30,14 @@ import qualified Data.Text as T
 import Data.SBV.Dynamic as SBV
 
 import Cryptol.Backend
-import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..) )
+import Cryptol.Backend.Monad ( EvalError(..), EvalErrorEx(..), Unsupported(..) )
 import Cryptol.Backend.SBV
 
 import Cryptol.Eval.Type (TValue(..))
 import Cryptol.Eval.Generic
 import Cryptol.Eval.Prims
 import Cryptol.Eval.Value
+import Cryptol.Parser.Position
 import Cryptol.TypeCheck.Solver.InfNat (Nat'(..), widthInteger)
 import Cryptol.Utils.Ident
 
@@ -104,13 +105,14 @@ primTable sym =
 
 indexFront ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   SVal ->
   SEval SBV Value
-indexFront sym mblen a xs _ix idx
+indexFront sym rng mblen a xs _ix idx
   | Just i <- SBV.svAsInteger idx
   = lookupSeqMap xs i
 
@@ -128,7 +130,7 @@ indexFront sym mblen a xs _ix idx
 
  where
     k = SBV.kindOf idx
-    def = zeroV sym a
+    def = zeroV sym rng a
     f n y = iteValue sym (SBV.svEqual idx (SBV.svInteger k n)) (lookupSeqMap xs n) y
     folded =
       case k of
@@ -143,31 +145,33 @@ indexFront sym mblen a xs _ix idx
 
 indexBack ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   SWord SBV ->
   SEval SBV Value
-indexBack sym (Nat n) a xs ix idx = indexFront sym (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack"]
+indexBack sym rng (Nat n) a xs ix idx = indexFront sym rng (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack"]
 
 indexFront_bits ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   [SBit SBV] ->
   SEval SBV Value
-indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
+indexFront_bits sym rng mblen _a xs _ix bits0 = go 0 (length bits0) bits0
  where
   go :: Integer -> Int -> [SBit SBV] -> SEval SBV Value
   go i _k []
     -- For indices out of range, fail
     | Nat n <- mblen
     , i >= n
-    = raiseError sym (InvalidIndex (Just i))
+    = raiseError sym (EvalErrorEx rng (InvalidIndex (Just i)))
 
     | otherwise
     = lookupSeqMap xs i
@@ -177,7 +181,7 @@ indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
     -- are out of bounds
     | Nat n <- mblen
     , (i `shiftL` k) >= n
-    = raiseError sym (InvalidIndex Nothing)
+    = raiseError sym (EvalErrorEx rng (InvalidIndex Nothing))
 
     | otherwise
     = iteValue sym b
@@ -187,14 +191,15 @@ indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
 
 indexBack_bits ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   TValue ->
   [SBit SBV] ->
   SEval SBV Value
-indexBack_bits sym (Nat n) a xs ix idx = indexFront_bits sym (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack_bits _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_bits"]
+indexBack_bits sym rng (Nat n) a xs ix idx = indexFront_bits sym rng (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack_bits _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_bits"]
 
 
 -- | Compare a symbolic word value with a concrete integer.
@@ -216,20 +221,21 @@ wordValueEqualsInteger sym wv i
 
 updateFrontSym ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (SeqMap SBV)
-updateFrontSym sym _len _eltTy vs (Left idx) val =
+updateFrontSym sym _rng _len _eltTy vs (Left idx) val =
   case SBV.svAsInteger idx of
     Just i -> return $ updateSeqMap vs i val
     Nothing -> return $ IndexSeqMap $ \i ->
       do b <- intEq sym idx =<< integerLit sym i
          iteValue sym b val (lookupSeqMap vs i)
 
-updateFrontSym sym _len _eltTy vs (Right wv) val =
+updateFrontSym sym _rng _len _eltTy vs (Right wv) val =
   case wv of
     WordVal w | Just j <- SBV.svAsInteger w ->
       return $ updateSeqMap vs j val
@@ -240,26 +246,27 @@ updateFrontSym sym _len _eltTy vs (Right wv) val =
 
 updateFrontSym_word ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   WordValue SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (WordValue SBV)
-updateFrontSym_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateFrontSym_bits"]
+updateFrontSym_word _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateFrontSym_bits"]
 
-updateFrontSym_word sym (Nat _) eltTy (LargeBitsVal n bv) idx val =
-  LargeBitsVal n <$> updateFrontSym sym (Nat n) eltTy bv idx val
+updateFrontSym_word sym rng (Nat _) eltTy (LargeBitsVal n bv) idx val =
+  LargeBitsVal n <$> updateFrontSym sym rng (Nat n) eltTy bv idx val
 
-updateFrontSym_word sym (Nat n) eltTy (WordVal bv) (Left idx) val =
+updateFrontSym_word sym rng (Nat n) eltTy (WordVal bv) (Left idx) val =
   do idx' <- wordFromInt sym n idx
-     updateFrontSym_word sym (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
+     updateFrontSym_word sym rng (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
 
-updateFrontSym_word sym (Nat n) eltTy bv (Right wv) val =
+updateFrontSym_word sym rng (Nat n) eltTy bv (Right wv) val =
   case wv of
     WordVal idx
       | Just j <- SBV.svAsInteger idx ->
-          updateWordValue sym bv j (fromVBit <$> val)
+          updateWordValue sym rng bv j (fromVBit <$> val)
 
       | WordVal bw <- bv ->
         WordVal <$>
@@ -272,27 +279,28 @@ updateFrontSym_word sym (Nat n) eltTy bv (Right wv) val =
              let bw'  = SBV.svAnd bw (SBV.svNot msk)
              return $! SBV.svXOr bw' (SBV.svAnd q msk)
 
-    _ -> LargeBitsVal n <$> updateFrontSym sym (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
+    _ -> LargeBitsVal n <$> updateFrontSym sym rng (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
 
 
 updateBackSym ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (SeqMap SBV)
-updateBackSym _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym"]
+updateBackSym _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym"]
 
-updateBackSym sym (Nat n) _eltTy vs (Left idx) val =
+updateBackSym sym _rng (Nat n) _eltTy vs (Left idx) val =
   case SBV.svAsInteger idx of
     Just i -> return $ updateSeqMap vs (n - 1 - i) val
     Nothing -> return $ IndexSeqMap $ \i ->
       do b <- intEq sym idx =<< integerLit sym (n - 1 - i)
          iteValue sym b val (lookupSeqMap vs i)
 
-updateBackSym sym (Nat n) _eltTy vs (Right wv) val =
+updateBackSym sym _rng (Nat n) _eltTy vs (Right wv) val =
   case wv of
     WordVal w | Just j <- SBV.svAsInteger w ->
       return $ updateSeqMap vs (n - 1 - j) val
@@ -303,26 +311,27 @@ updateBackSym sym (Nat n) _eltTy vs (Right wv) val =
 
 updateBackSym_word ::
   SBV ->
+  Range ->
   Nat' ->
   TValue ->
   WordValue SBV ->
   Either (SInteger SBV) (WordValue SBV) ->
   SEval SBV (GenValue SBV) ->
   SEval SBV (WordValue SBV)
-updateBackSym_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym_bits"]
+updateBackSym_word _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym_bits"]
 
-updateBackSym_word sym (Nat _) eltTy (LargeBitsVal n bv) idx val =
-  LargeBitsVal n <$> updateBackSym sym (Nat n) eltTy bv idx val
+updateBackSym_word sym rng (Nat _) eltTy (LargeBitsVal n bv) idx val =
+  LargeBitsVal n <$> updateBackSym sym rng (Nat n) eltTy bv idx val
 
-updateBackSym_word sym (Nat n) eltTy (WordVal bv) (Left idx) val =
+updateBackSym_word sym rng (Nat n) eltTy (WordVal bv) (Left idx) val =
   do idx' <- wordFromInt sym n idx
-     updateBackSym_word sym (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
+     updateBackSym_word sym rng (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
 
-updateBackSym_word sym (Nat n) eltTy bv (Right wv) val = do
+updateBackSym_word sym rng (Nat n) eltTy bv (Right wv) val = do
   case wv of
     WordVal idx
       | Just j <- SBV.svAsInteger idx ->
-          updateWordValue sym bv (n - 1 - j) (fromVBit <$> val)
+          updateWordValue sym rng bv (n - 1 - j) (fromVBit <$> val)
 
       | WordVal bw <- bv ->
         WordVal <$>
@@ -335,7 +344,7 @@ updateBackSym_word sym (Nat n) eltTy bv (Right wv) val = do
              let bw'  = SBV.svAnd bw (SBV.svNot msk)
              return $! SBV.svXOr bw' (SBV.svAnd q msk)
 
-    _ -> LargeBitsVal n <$> updateBackSym sym (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
+    _ -> LargeBitsVal n <$> updateBackSym sym rng (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
 
 
 asWordList :: [WordValue SBV] -> Maybe [SWord SBV]
@@ -350,7 +359,7 @@ sshrV sym =
   PNumPoly \n ->
   PTyPoly  \ix ->
   PWordFun \x ->
-  PStrictFun \y ->
+  PStrict  \y ->
   PPrim $
    asIndex sym ">>$" ix y >>= \case
      Left idx ->

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -6,6 +6,7 @@
 -- Stability   :  provisional
 -- Portability :  portable
 
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -21,7 +22,6 @@ module Cryptol.Eval.SBV
   ) where
 
 import qualified Control.Exception as X
-import           Control.Monad (join)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Data.Bits (bit, shiftL)
 import qualified Data.Map as Map
@@ -33,8 +33,9 @@ import Cryptol.Backend
 import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..) )
 import Cryptol.Backend.SBV
 
-import Cryptol.Eval.Type (TValue(..), finNat')
+import Cryptol.Eval.Type (TValue(..))
 import Cryptol.Eval.Generic
+import Cryptol.Eval.Prims
 import Cryptol.Eval.Value
 import Cryptol.TypeCheck.Solver.InfNat (Nat'(..), widthInteger)
 import Cryptol.Utils.Ident
@@ -46,106 +47,12 @@ type Value = GenValue SBV
 -- Primitives ------------------------------------------------------------------
 
 -- See also Cryptol.Eval.Concrete.primTable
-primTable :: SBV -> Map.Map PrimIdent Value
-primTable sym =
+primTable :: SBV -> Map.Map PrimIdent (Prim SBV)
+primTable sym = 
+  Map.union (genericPrimTable sym) $
   Map.fromList $ map (\(n, v) -> (prelPrim (T.pack n), v))
 
-  [ -- Literals
-    ("True"        , VBit (bitLit sym True))
-  , ("False"       , VBit (bitLit sym False))
-  , ("number"      , ecNumberV sym) -- Converts a numeric type into its corresponding value.
-                                    -- { val, rep } (Literal val rep) => rep
-  , ("fraction"     , ecFractionV sym)
-  , ("ratio"       , ratioV sym)
-
-    -- Zero
-  , ("zero"        , VPoly (zeroV sym))
-
-    -- Logic
-  , ("&&"          , binary (andV sym))
-  , ("||"          , binary (orV sym))
-  , ("^"           , binary (xorV sym))
-  , ("complement"  , unary  (complementV sym))
-
-    -- Ring
-  , ("fromInteger" , fromIntegerV sym)
-  , ("+"           , binary (addV sym))
-  , ("-"           , binary (subV sym))
-  , ("negate"      , unary (negateV sym))
-  , ("*"           , binary (mulV sym))
-
-    -- Integral
-  , ("toInteger"   , toIntegerV sym)
-  , ("/"           , binary (divV sym))
-  , ("%"           , binary (modV sym))
-  , ("^^"          , expV sym)
-  , ("infFrom"     , infFromV sym)
-  , ("infFromThen" , infFromThenV sym)
-
-    -- Field
-  , ("recip"       , recipV sym)
-  , ("/."          , fieldDivideV sym)
-
-    -- Round
-  , ("floor"       , unary (floorV sym))
-  , ("ceiling"     , unary (ceilingV sym))
-  , ("trunc"       , unary (truncV sym))
-  , ("roundAway"   , unary (roundAwayV sym))
-  , ("roundToEven" , unary (roundToEvenV sym))
-
-    -- Word operations
-  , ("/$"          , sdivV sym)
-  , ("%$"          , smodV sym)
-  , ("lg2"         , lg2V sym)
-  , (">>$"         , sshrV sym)
-
-    -- Cmp
-  , ("<"           , binary (lessThanV sym))
-  , (">"           , binary (greaterThanV sym))
-  , ("<="          , binary (lessThanEqV sym))
-  , (">="          , binary (greaterThanEqV sym))
-  , ("=="          , binary (eqV sym))
-  , ("!="          , binary (distinctV sym))
-
-    -- SignedCmp
-  , ("<$"          , binary (signedLessThanV sym))
-
-    -- Finite enumerations
-  , ("fromTo"      , fromToV sym)
-  , ("fromThenTo"  , fromThenToV sym)
-
-    -- Sequence manipulations
-  , ("#"          , -- {a,b,d} (fin a) => [a] d -> [b] d -> [a + b] d
-     nlam $ \ front ->
-     nlam $ \ back  ->
-     tlam $ \ elty  ->
-     lam  $ \ l     -> return $
-     lam  $ \ r     -> join (ccatV sym front back elty <$> l <*> r))
-
-  , ("join"       ,
-     nlam $ \ parts ->
-     nlam $ \ (finNat' -> each)  ->
-     tlam $ \ a     ->
-     lam  $ \ x     ->
-       joinV sym parts each a =<< x)
-
-  , ("split"       , ecSplitV sym)
-
-  , ("splitAt"    ,
-     nlam $ \ front ->
-     nlam $ \ back  ->
-     tlam $ \ a     ->
-     lam  $ \ x     ->
-       splitAtV sym front back a =<< x)
-
-  , ("reverse"    , nlam $ \_a ->
-                    tlam $ \_b ->
-                     lam $ \xs -> reverseV sym =<< xs)
-
-  , ("transpose"  , nlam $ \a ->
-                    nlam $ \b ->
-                    tlam $ \c ->
-                     lam $ \xs -> transposeV sym a b c =<< xs)
+  [ (">>$"         , sshrV sym)
 
     -- Shifts and rotates
   , ("<<"          , logicShift sym "<<"
@@ -179,51 +86,21 @@ primTable sym =
   , ("update"      , updatePrim sym (updateFrontSym_word sym) (updateFrontSym sym))
   , ("updateEnd"   , updatePrim sym (updateBackSym_word sym) (updateBackSym sym))
 
-    -- Misc
-
-  , ("fromZ"       , fromZV sym)
-
-  , ("foldl"       , foldlV sym)
-  , ("foldl'"      , foldl'V sym)
-
-  , ("deepseq"     ,
-      tlam $ \_a ->
-      tlam $ \_b ->
-       lam $ \x -> pure $
-       lam $ \y ->
-         do _ <- forceValue =<< x
-            y)
-
-  , ("parmap"      , parmapV sym)
-
-    -- {at,len} (fin len) => [len][8] -> at
-  , ("error"       ,
-      tlam $ \a ->
-      nlam $ \_ ->
-      VFun $ \s -> errorV sym a =<< (valueToString sym =<< s))
-
-  , ("random"      ,
-      tlam $ \a ->
-      wlam sym $ \x ->
-         case integerAsLit sym x of
-           Just i  -> randomV sym a i
-           Nothing -> cryUserError sym "cannot evaluate 'random' with symbolic inputs")
-
      -- The trace function simply forces its first two
      -- values before returing the third in the symbolic
      -- evaluator.
   , ("trace",
-      nlam $ \_n ->
-      tlam $ \_a ->
-      tlam $ \_b ->
-       lam $ \s -> return $
-       lam $ \x -> return $
-       lam $ \y -> do
-         _ <- s
-         _ <- x
-         y)
+      PNumPoly \_n ->
+      PTyPoly  \_a ->
+      PTyPoly  \_b ->
+      PFun     \s ->
+      PFun     \x ->
+      PFun     \y ->
+      PPrim
+       do _ <- s
+          _ <- x
+          y)
   ]
-
 
 indexFront ::
   SBV ->
@@ -468,13 +345,14 @@ asWordList = go id
        go f (WordVal x :vs) = go (f . (x:)) vs
        go _f (LargeBitsVal _ _ : _) = Nothing
 
-sshrV :: SBV -> Value
+sshrV :: SBV -> Prim SBV
 sshrV sym =
-  nlam $ \n ->
-  tlam $ \ix ->
-  wlam sym $ \x -> return $
-  lam $ \y ->
-   y >>= asIndex sym ">>$" ix >>= \case
+  PNumPoly \n ->
+  PTyPoly  \ix ->
+  PWordFun \x ->
+  PStrictFun \y ->
+  PPrim $
+   asIndex sym ">>$" ix y >>= \case
      Left idx ->
        do let w = toInteger (SBV.intSizeOf x)
           let pneg = svLessThan idx (svInteger KUnbounded 0)

--- a/src/Cryptol/Eval/Type.hs
+++ b/src/Cryptol/Eval/Type.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Cryptol.Eval.Type where
 
-import Cryptol.Backend.Monad (evalPanic, typeCannotBeDemoted)
+import Cryptol.Backend.Monad (evalPanic)
 import Cryptol.TypeCheck.AST
 import Cryptol.TypeCheck.PP(pp)
 import Cryptol.TypeCheck.Solver.InfNat
@@ -175,5 +175,5 @@ evalTF f vs
   | otherwise  = evalPanic "evalTF"
                         ["Unexpected type function:", show ty]
 
-  where mb = fromMaybe (typeCannotBeDemoted ty)
+  where mb = fromMaybe (evalPanic "evalTF" ["type cannot be demoted", show (pp ty)])
         ty = TCon (TF f) (map tNat' vs)

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -41,7 +41,7 @@ import qualified What4.SWord as SW
 import qualified What4.Utils.AbstractDomains as W4
 
 import Cryptol.Backend
-import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..) )
+import Cryptol.Backend.Monad ( EvalError(..), EvalErrorEx(..), Unsupported(..) )
 import Cryptol.Backend.What4
 import qualified Cryptol.Backend.What4.SFloat as W4
 
@@ -54,6 +54,7 @@ import qualified Cryptol.SHA as SHA
 
 import Cryptol.TypeCheck.Solver.InfNat( Nat'(..), widthInteger )
 
+import Cryptol.Parser.Position(Range)
 import Cryptol.Utils.Ident
 import Cryptol.Utils.Panic
 import Cryptol.Utils.RecordMap
@@ -258,7 +259,7 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
                case intIndex (fromInteger i) (size ret) of
                  Just (Some idx) | Just W4.Refl <- W4.testEquality (ret!idx) (W4.BaseBVRepr (W4.knownNat @32)) ->
                    fromWord32 =<< liftIO (W4.structField (w4 sym) z idx)
-                 _ -> invalidIndex sym i
+                 _ -> evalPanic "AESKeyExpand" ["Index out of range", show k, show i]
 
     -- {n} (fin n) => [n][16][32] -> [7][32]
   , "processSHA2_224" ~>
@@ -275,8 +276,8 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
                 do z <- liftIO $ W4.structField (w4 sym) finalSt idx
                    case W4.testEquality (W4.exprType z) (W4.BaseBVRepr (W4.knownNat @32)) of
                      Just W4.Refl -> fromWord32 z
-                     Nothing -> invalidIndex sym i
-              Nothing -> invalidIndex sym i
+                     Nothing -> evalPanic "processSHA2_224" ["Index out of range", show i]
+              Nothing -> evalPanic "processSHA2_224" ["Index out of range", show i]
 
     -- {n} (fin n) => [n][16][32] -> [8][32]
   , "processSHA2_256" ~>
@@ -293,8 +294,8 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
                 do z <- liftIO $ W4.structField (w4 sym) finalSt idx
                    case W4.testEquality (W4.exprType z) (W4.BaseBVRepr (W4.knownNat @32)) of
                      Just W4.Refl -> fromWord32 z
-                     Nothing -> invalidIndex sym i
-              Nothing -> invalidIndex sym i
+                     Nothing -> evalPanic "processSHA2_256" ["Index out of range", show i]
+              Nothing -> evalPanic "processSHA2_256" ["Index out of range", show i]
 
     -- {n} (fin n) => [n][16][64] -> [6][64]
   , "processSHA2_384" ~>
@@ -311,8 +312,8 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
                 do z <- liftIO $ W4.structField (w4 sym) finalSt idx
                    case W4.testEquality (W4.exprType z) (W4.BaseBVRepr (W4.knownNat @64)) of
                      Just W4.Refl -> fromWord64 z
-                     Nothing -> invalidIndex sym i
-              Nothing -> invalidIndex sym i
+                     Nothing -> evalPanic "processSHA2_384" ["Index out of range", show i]
+              Nothing -> evalPanic "processSHA2_384" ["Index out of range", show i]
 
     -- {n} (fin n) => [n][16][64] -> [8][64]
   , "processSHA2_512" ~>
@@ -329,8 +330,8 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
                 do z <- liftIO $ W4.structField (w4 sym) finalSt idx
                    case W4.testEquality (W4.exprType z) (W4.BaseBVRepr (W4.knownNat @64)) of
                      Just W4.Refl -> fromWord64 z
-                     Nothing -> invalidIndex sym i
-              Nothing -> invalidIndex sym i
+                     Nothing -> evalPanic "processSHA2_512" ["Index out of range", show i]
+              Nothing -> evalPanic "processSHA2_512" ["Index out of range", show i]
   ]
 
 
@@ -520,7 +521,7 @@ applyAESStateFunc sym funNm x =
           | i == 1 -> fromWord32 =<< liftIO (W4.structField (w4 sym) z (natIndex @1))
           | i == 2 -> fromWord32 =<< liftIO (W4.structField (w4 sym) z (natIndex @2))
           | i == 3 -> fromWord32 =<< liftIO (W4.structField (w4 sym) z (natIndex @3))
-          | otherwise -> invalidIndex sym i
+          | otherwise -> evalPanic "applyAESStateFunc" ["Index out of range", show funNm, show i]
 
  where
    nm = Text.unpack funNm
@@ -535,7 +536,7 @@ sshrV sym =
   PFinPoly \n ->
   PTyPoly  \ix ->
   PWordFun \x ->
-  PStrictFun \y ->
+  PStrict  \y ->
   PPrim $
     asIndex sym ">>$" ix y >>= \case
        Left i ->
@@ -555,13 +556,14 @@ sshrV sym =
 indexFront_int ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   TValue ->
   SInteger (What4 sym) ->
   SEval (What4 sym) (Value sym)
-indexFront_int sym mblen _a xs ix idx
+indexFront_int sym rng mblen _a xs ix idx
   | Just i <- W4.asInteger idx
   = lookupSeqMap xs i
 
@@ -574,7 +576,7 @@ indexFront_int sym mblen _a xs ix idx
  where
     w4sym = w4 sym
 
-    def = raiseError sym (InvalidIndex Nothing)
+    def = raiseError sym (EvalErrorEx rng (InvalidIndex Nothing))
 
     f n y =
        do p <- liftIO (W4.intEq w4sym idx =<< W4.intLit w4sym n)
@@ -604,25 +606,27 @@ indexFront_int sym mblen _a xs ix idx
 indexBack_int ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   TValue ->
   SInteger (What4 sym) ->
   SEval (What4 sym) (Value sym)
-indexBack_int sym (Nat n) a xs ix idx = indexFront_int sym (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack_int _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_int"]
+indexBack_int sym rng (Nat n) a xs ix idx = indexFront_int sym rng (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack_int _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_int"]
 
 indexFront_word ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   TValue ->
   SWord (What4 sym) ->
   SEval (What4 sym) (Value sym)
-indexFront_word sym mblen _a xs _ix idx
+indexFront_word sym rng mblen _a xs _ix idx
   | Just i <- SW.bvAsUnsignedInteger idx
   = lookupSeqMap xs i
 
@@ -633,7 +637,7 @@ indexFront_word sym mblen _a xs _ix idx
     w4sym = w4 sym
 
     w = SW.bvWidth idx
-    def = raiseError sym (InvalidIndex Nothing)
+    def = raiseError sym (EvalErrorEx rng (InvalidIndex Nothing))
 
     f n y =
        do p <- liftIO (SW.bvEq w4sym idx =<< SW.bvLit w4sym w n)
@@ -657,32 +661,34 @@ indexFront_word sym mblen _a xs _ix idx
 indexBack_word ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   TValue ->
   SWord (What4 sym) ->
   SEval (What4 sym) (Value sym)
-indexBack_word sym (Nat n) a xs ix idx = indexFront_word sym (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_word"]
+indexBack_word sym rng (Nat n) a xs ix idx = indexFront_word sym rng (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack_word _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_word"]
 
 indexFront_bits :: forall sym.
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   TValue ->
   [SBit (What4 sym)] ->
   SEval (What4 sym) (Value sym)
-indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
+indexFront_bits sym rng mblen _a xs _ix bits0 = go 0 (length bits0) bits0
  where
   go :: Integer -> Int -> [W4.Pred sym] -> W4Eval sym (Value sym)
   go i _k []
     -- For indices out of range, fail
     | Nat n <- mblen
     , i >= n
-    = raiseError sym (InvalidIndex (Just i))
+    = raiseError sym (EvalErrorEx rng (InvalidIndex (Just i)))
 
     | otherwise
     = lookupSeqMap xs i
@@ -692,7 +698,7 @@ indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
     -- are out of bounds
     | Nat n <- mblen
     , (i `shiftL` k) >= n
-    = raiseError sym (InvalidIndex Nothing)
+    = raiseError sym (EvalErrorEx rng (InvalidIndex Nothing))
 
     | otherwise
     = iteValue sym b
@@ -702,14 +708,15 @@ indexFront_bits sym mblen _a xs _ix bits0 = go 0 (length bits0) bits0
 indexBack_bits ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   TValue ->
   [SBit (What4 sym)] ->
   SEval (What4 sym) (Value sym)
-indexBack_bits sym (Nat n) a xs ix idx = indexFront_bits sym (Nat n) a (reverseSeqMap n xs) ix idx
-indexBack_bits _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_bits"]
+indexBack_bits sym rng (Nat n) a xs ix idx = indexFront_bits sym rng (Nat n) a (reverseSeqMap n xs) ix idx
+indexBack_bits _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["indexBack_bits"]
 
 
 -- | Compare a symbolic word value with a concrete integer.
@@ -741,20 +748,21 @@ wordValueEqualsInteger sym wv i
 updateFrontSym ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   Either (SInteger (What4 sym)) (WordValue (What4 sym)) ->
   SEval (What4 sym) (Value sym) ->
   SEval (What4 sym) (SeqMap (What4 sym))
-updateFrontSym sym _len _eltTy vs (Left idx) val =
+updateFrontSym sym _rng _len _eltTy vs (Left idx) val =
   case W4.asInteger idx of
     Just i -> return $ updateSeqMap vs i val
     Nothing -> return $ IndexSeqMap $ \i ->
       do b <- intEq sym idx =<< integerLit sym i
          iteValue sym b val (lookupSeqMap vs i)
 
-updateFrontSym sym _len _eltTy vs (Right wv) val =
+updateFrontSym sym _rng _len _eltTy vs (Right wv) val =
   case wv of
     WordVal w | Just j <- SW.bvAsUnsignedInteger w ->
       return $ updateSeqMap vs j val
@@ -766,22 +774,23 @@ updateFrontSym sym _len _eltTy vs (Right wv) val =
 updateBackSym ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   SeqMap (What4 sym) ->
   Either (SInteger (What4 sym)) (WordValue (What4 sym)) ->
   SEval (What4 sym) (Value sym) ->
   SEval (What4 sym) (SeqMap (What4 sym))
-updateBackSym _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym"]
+updateBackSym _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym"]
 
-updateBackSym sym (Nat n) _eltTy vs (Left idx) val =
+updateBackSym sym _rng (Nat n) _eltTy vs (Left idx) val =
   case W4.asInteger idx of
     Just i -> return $ updateSeqMap vs (n - 1 - i) val
     Nothing -> return $ IndexSeqMap $ \i ->
       do b <- intEq sym idx =<< integerLit sym (n - 1 - i)
          iteValue sym b val (lookupSeqMap vs i)
 
-updateBackSym sym (Nat n) _eltTy vs (Right wv) val =
+updateBackSym sym _rng (Nat n) _eltTy vs (Right wv) val =
   case wv of
     WordVal w | Just j <- SW.bvAsUnsignedInteger w ->
       return $ updateSeqMap vs (n - 1 - j) val
@@ -794,26 +803,27 @@ updateBackSym sym (Nat n) _eltTy vs (Right wv) val =
 updateFrontSym_word ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->
   Nat' ->
   TValue ->
   WordValue (What4 sym) ->
   Either (SInteger (What4 sym)) (WordValue (What4 sym)) ->
   SEval (What4 sym) (GenValue (What4 sym)) ->
   SEval (What4 sym) (WordValue (What4 sym))
-updateFrontSym_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateFrontSym_word"]
+updateFrontSym_word _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateFrontSym_word"]
 
-updateFrontSym_word sym (Nat _) eltTy (LargeBitsVal n bv) idx val =
-  LargeBitsVal n <$> updateFrontSym sym (Nat n) eltTy bv idx val
+updateFrontSym_word sym rng (Nat _) eltTy (LargeBitsVal n bv) idx val =
+  LargeBitsVal n <$> updateFrontSym sym rng (Nat n) eltTy bv idx val
 
-updateFrontSym_word sym (Nat n) eltTy (WordVal bv) (Left idx) val =
+updateFrontSym_word sym rng (Nat n) eltTy (WordVal bv) (Left idx) val =
   do idx' <- wordFromInt sym n idx
-     updateFrontSym_word sym (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
+     updateFrontSym_word sym rng (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
 
-updateFrontSym_word sym (Nat n) eltTy bv (Right wv) val =
+updateFrontSym_word sym rng (Nat n) eltTy bv (Right wv) val =
   case wv of
     WordVal idx
       | Just j <- SW.bvAsUnsignedInteger idx ->
-          updateWordValue sym bv j (fromVBit <$> val)
+          updateWordValue sym rng bv j (fromVBit <$> val)
 
       | WordVal bw <- bv ->
         WordVal <$>
@@ -831,32 +841,33 @@ updateFrontSym_word sym (Nat n) eltTy bv (Right wv) val =
                       SW.bvXor (w4 sym) bw' =<< SW.bvAnd (w4 sym) q msk
 
     _ -> LargeBitsVal (wordValueSize sym wv) <$>
-           updateFrontSym sym (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
+           updateFrontSym sym rng (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
 
 
 updateBackSym_word ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->
+  Range ->  
   Nat' ->
   TValue ->
   WordValue (What4 sym) ->
   Either (SInteger (What4 sym)) (WordValue (What4 sym)) ->
   SEval (What4 sym) (GenValue (What4 sym)) ->
   SEval (What4 sym) (WordValue (What4 sym))
-updateBackSym_word _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym_word"]
+updateBackSym_word _ _ Inf _ _ _ _ = evalPanic "Expected finite sequence" ["updateBackSym_word"]
 
-updateBackSym_word sym (Nat _) eltTy (LargeBitsVal n bv) idx val =
-  LargeBitsVal n <$> updateBackSym sym (Nat n) eltTy bv idx val
+updateBackSym_word sym rng (Nat _) eltTy (LargeBitsVal n bv) idx val =
+  LargeBitsVal n <$> updateBackSym sym rng (Nat n) eltTy bv idx val
 
-updateBackSym_word sym (Nat n) eltTy (WordVal bv) (Left idx) val =
+updateBackSym_word sym rng (Nat n) eltTy (WordVal bv) (Left idx) val =
   do idx' <- wordFromInt sym n idx
-     updateBackSym_word sym (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
+     updateBackSym_word sym rng (Nat n) eltTy (WordVal bv) (Right (WordVal idx')) val
 
-updateBackSym_word sym (Nat n) eltTy bv (Right wv) val =
+updateBackSym_word sym rng (Nat n) eltTy bv (Right wv) val =
   case wv of
     WordVal idx
       | Just j <- SW.bvAsUnsignedInteger idx ->
-          updateWordValue sym bv (n - 1 - j) (fromVBit <$> val)
+          updateWordValue sym rng bv (n - 1 - j) (fromVBit <$> val)
 
       | WordVal bw <- bv ->
         WordVal <$>
@@ -874,7 +885,7 @@ updateBackSym_word sym (Nat n) eltTy bv (Right wv) val =
                       SW.bvXor (w4 sym) bw' =<< SW.bvAnd (w4 sym) q msk
 
     _ -> LargeBitsVal (wordValueSize sym wv) <$>
-           updateBackSym sym (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
+           updateBackSym sym rng (Nat n) eltTy (asBitsMap sym bv) (Right wv) val
 
 
 
@@ -909,13 +920,16 @@ floatPrims sym =
     , "fpDiv"       ~> fpBinArithV sym fpDiv
 
     , "fpFromRational" ~>
-       PFinPoly \e -> PFinPoly \p -> PWordFun \r -> PFun \x -> PPrim
+       PFinPoly \e -> PFinPoly \p -> PWordFun \r -> PFun \x ->
+       PRange \rng ->
+       PPrim
          do rat <- fromVRational <$> x
-            VFloat <$> fpCvtFromRational sym e p r rat
+            VFloat <$> fpCvtFromRational sym rng e p r rat
 
     , "fpToRational" ~>
        PFinPoly \_e -> PFinPoly \_p -> PFloatFun \fp ->
-       PPrim (VRational <$> fpCvtToRational sym fp)
+       PRange \rng ->
+       PPrim (VRational <$> fpCvtToRational sym rng fp)
     ]
 
 -- | A helper for definitng floating point constants.

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -23,7 +23,7 @@ module Cryptol.Eval.What4
 
 import qualified Control.Exception as X
 import           Control.Concurrent.MVar
-import           Control.Monad (join,foldM)
+import           Control.Monad (foldM)
 import           Control.Monad.IO.Class
 import           Data.Bits
 import qualified Data.Map as Map
@@ -32,8 +32,8 @@ import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Parameterized.Context
-import           Data.Parameterized.Some
 import           Data.Parameterized.TraversableFC
+import           Data.Parameterized.Some
 import qualified Data.BitVector.Sized as BV
 
 import qualified What4.Interface as W4
@@ -46,7 +46,8 @@ import Cryptol.Backend.What4
 import qualified Cryptol.Backend.What4.SFloat as W4
 
 import Cryptol.Eval.Generic
-import Cryptol.Eval.Type (finNat', TValue(..))
+import Cryptol.Eval.Prims
+import Cryptol.Eval.Type (TValue(..))
 import Cryptol.Eval.Value
 
 import qualified Cryptol.SHA as SHA
@@ -60,111 +61,17 @@ import Cryptol.Utils.RecordMap
 type Value sym = GenValue (What4 sym)
 
 -- See also Cryptol.Prims.Eval.primTable
-primTable :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Value sym)
+primTable :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Prim (What4 sym))
 primTable sym =
   let w4sym = w4 sym in
   Map.union (floatPrims sym) $
   Map.union (suiteBPrims sym) $
   Map.union (primeECPrims sym) $
+  Map.union (genericPrimTable sym) $
 
   Map.fromList $ map (\(n, v) -> (prelPrim n, v))
 
-  [ -- Literals
-    ("True"        , VBit (bitLit sym True))
-  , ("False"       , VBit (bitLit sym False))
-  , ("number"      , ecNumberV sym) -- Converts a numeric type into its corresponding value.
-                                    -- { val, rep } (Literal val rep) => rep
-  , ("fraction"    , ecFractionV sym)
-  , ("ratio"       , ratioV sym)
-
-    -- Zero
-  , ("zero"        , VPoly (zeroV sym))
-
-    -- Logic
-  , ("&&"          , binary (andV sym))
-  , ("||"          , binary (orV sym))
-  , ("^"           , binary (xorV sym))
-  , ("complement"  , unary  (complementV sym))
-
-    -- Ring
-  , ("fromInteger" , fromIntegerV sym)
-  , ("+"           , binary (addV sym))
-  , ("-"           , binary (subV sym))
-  , ("negate"      , unary (negateV sym))
-  , ("*"           , binary (mulV sym))
-
-    -- Integral
-  , ("toInteger"   , toIntegerV sym)
-  , ("/"           , binary (divV sym))
-  , ("%"           , binary (modV sym))
-  , ("^^"          , expV sym)
-  , ("infFrom"     , infFromV sym)
-  , ("infFromThen" , infFromThenV sym)
-
-    -- Field
-  , ("recip"       , recipV sym)
-  , ("/."          , fieldDivideV sym)
-
-    -- Round
-  , ("floor"       , unary (floorV sym))
-  , ("ceiling"     , unary (ceilingV sym))
-  , ("trunc"       , unary (truncV sym))
-  , ("roundAway"   , unary (roundAwayV sym))
-  , ("roundToEven" , unary (roundToEvenV sym))
-
-    -- Word operations
-  , ("/$"          , sdivV sym)
-  , ("%$"          , smodV sym)
-  , ("lg2"         , lg2V sym)
-  , (">>$"         , sshrV sym)
-
-    -- Cmp
-  , ("<"           , binary (lessThanV sym))
-  , (">"           , binary (greaterThanV sym))
-  , ("<="          , binary (lessThanEqV sym))
-  , (">="          , binary (greaterThanEqV sym))
-  , ("=="          , binary (eqV sym))
-  , ("!="          , binary (distinctV sym))
-
-    -- SignedCmp
-  , ("<$"          , binary (signedLessThanV sym))
-
-    -- Finite enumerations
-  , ("fromTo"      , fromToV sym)
-  , ("fromThenTo"  , fromThenToV sym)
-
-    -- Sequence manipulations
-  , ("#"          , -- {a,b,d} (fin a) => [a] d -> [b] d -> [a + b] d
-     nlam $ \ front ->
-     nlam $ \ back  ->
-     tlam $ \ elty  ->
-     lam  $ \ l     -> return $
-     lam  $ \ r     -> join (ccatV sym front back elty <$> l <*> r))
-
-  , ("join"       ,
-     nlam $ \ parts ->
-     nlam $ \ (finNat' -> each)  ->
-     tlam $ \ a     ->
-     lam  $ \ x     ->
-       joinV sym parts each a =<< x)
-
-  , ("split"       , ecSplitV sym)
-
-  , ("splitAt"    ,
-     nlam $ \ front ->
-     nlam $ \ back  ->
-     tlam $ \ a     ->
-     lam  $ \ x     ->
-       splitAtV sym front back a =<< x)
-
-  , ("reverse"    , nlam $ \_a ->
-                    tlam $ \_b ->
-                     lam $ \xs -> reverseV sym =<< xs)
-
-  , ("transpose"  , nlam $ \a ->
-                    nlam $ \b ->
-                    tlam $ \c ->
-                     lam $ \xs -> transposeV sym a b c =<< xs)
+  [ (">>$"         , sshrV sym)
 
     -- Shifts and rotates
   , ("<<"          , logicShift sym "<<"  shiftShrink
@@ -189,50 +96,23 @@ primTable sym =
 
     -- Misc
 
-  , ("foldl"       , foldlV sym)
-  , ("foldl'"      , foldl'V sym)
-
-  , ("deepseq"     ,
-      tlam $ \_a ->
-      tlam $ \_b ->
-       lam $ \x -> pure $
-       lam $ \y ->
-         do _ <- forceValue =<< x
-            y)
-
-  , ("parmap"      , parmapV sym)
-
-  , ("fromZ"       , fromZV sym)
-
-    -- {at,len} (fin len) => [len][8] -> at
-  , ("error"       ,
-      tlam $ \a ->
-      nlam $ \_ ->
-      VFun $ \s -> errorV sym a =<< (valueToString sym =<< s))
-
-  , ("random"      ,
-      tlam $ \a ->
-      wlam sym $ \x ->
-         case wordAsLit sym x of
-           Just (_,i)  -> randomV sym a i
-           Nothing -> cryUserError sym "cannot evaluate 'random' with symbolic inputs")
-
      -- The trace function simply forces its first two
      -- values before returing the third in the symbolic
      -- evaluator.
   , ("trace",
-      nlam $ \_n ->
-      tlam $ \_a ->
-      tlam $ \_b ->
-       lam $ \s -> return $
-       lam $ \x -> return $
-       lam $ \y -> do
-         _ <- s
-         _ <- x
-         y)
+      PNumPoly \_n ->
+      PTyPoly  \_a ->
+      PTyPoly  \_b ->
+      PFun     \s ->
+      PFun     \x ->
+      PFun     \y ->
+      PPrim
+       do _ <- s
+          _ <- x
+          y)
   ]
 
-primeECPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Value sym)
+primeECPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Prim (What4 sym))
 primeECPrims sym = Map.fromList $ [ (primeECPrim n, v) | (n,v) <- prims ]
  where
  (~>) = (,)
@@ -240,8 +120,9 @@ primeECPrims sym = Map.fromList $ [ (primeECPrim n, v) | (n,v) <- prims ]
  prims =
   [ -- {p} (prime p, p > 3) => ProjectivePoint p -> ProjectivePoint p
     "ec_double" ~>
-      ilam \p ->
-       lam \s ->
+      PFinPoly \p ->
+      PFun     \s ->
+      PPrim
          do p' <- integerLit sym p
             s' <- toProjectivePoint sym =<< s
             addUninterpWarning sym "Prime ECC"
@@ -252,9 +133,10 @@ primeECPrims sym = Map.fromList $ [ (primeECPrim n, v) | (n,v) <- prims ]
 
     -- {p} (prime p, p > 3) => ProjectivePoint p -> ProjectivePoint p -> ProjectivePoint p
   , "ec_add_nonzero" ~>
-      ilam \p ->
-       lam \s -> pure $
-       lam \t ->
+      PFinPoly \p ->
+      PFun     \s ->
+      PFun     \t ->
+      PPrim
          do p' <- integerLit sym p
             s' <- toProjectivePoint sym =<< s
             t' <- toProjectivePoint sym =<< t
@@ -266,9 +148,10 @@ primeECPrims sym = Map.fromList $ [ (primeECPrim n, v) | (n,v) <- prims ]
 
     -- {p} (prime p, p > 3) => Z p -> ProjectivePoint p -> ProjectivePoint p
   , "ec_mult" ~>
-      ilam \p ->
-       lam \k -> pure $
-       lam \s ->
+      PFinPoly \p ->
+      PFun     \k ->
+      PFun     \s ->
+      PPrim
          do p' <- integerLit sym p
             k' <- fromVInteger <$> k
             s' <- toProjectivePoint sym =<< s
@@ -280,11 +163,12 @@ primeECPrims sym = Map.fromList $ [ (primeECPrim n, v) | (n,v) <- prims ]
 
     -- {p} (prime p, p > 3) => Z p -> ProjectivePoint p -> Z p -> ProjectivePoint p -> ProjectivePoint p
   , "ec_twin_mult" ~>
-      ilam \p ->
-       lam \j -> pure $
-       lam \s -> pure $
-       lam \k -> pure $
-       lam \t ->
+      PFinPoly \p ->
+      PFun     \j ->
+      PFun     \s ->
+      PFun     \k ->
+      PFun     \t ->
+      PPrim
          do p' <- integerLit sym p
             j' <- fromVInteger <$> j
             s' <- toProjectivePoint sym =<< s
@@ -298,7 +182,6 @@ primeECPrims sym = Map.fromList $ [ (primeECPrim n, v) | (n,v) <- prims ]
             z  <- liftIO $ W4.applySymFn (w4 sym) fn (Empty :> p' :> j' :> s' :> k' :> t')
             fromProjectivePoint sym z
   ]
-
 
 type ProjectivePoint = W4.BaseStructType (EmptyCtx ::> W4.BaseIntegerType ::> W4.BaseIntegerType ::> W4.BaseIntegerType)
 
@@ -321,37 +204,44 @@ fromProjectivePoint sym p = liftIO $
      z <- VInteger <$> W4.structField (w4 sym) p (natIndex @2)
      pure $ VRecord $ recordFromFields [ (packIdent "x",pure x), (packIdent "y",pure y),(packIdent "z",pure z) ]
 
-suiteBPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Value sym)
+
+suiteBPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map.Map PrimIdent (Prim (What4 sym))
 suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
  where
  (~>) = (,)
 
  prims =
   [ "AESEncRound" ~>
-       lam \st ->
+       PFun \st ->
+       PPrim
          do addUninterpWarning sym "AES encryption"
             applyAESStateFunc sym "AESEncRound" =<< st
   , "AESEncFinalRound" ~>
-       lam \st ->
+       PFun \st ->
+       PPrim
          do addUninterpWarning sym "AES encryption"
             applyAESStateFunc sym "AESEncFinalRound" =<< st
   , "AESDecRound" ~>
-       lam \st ->
+       PFun \st ->
+       PPrim
          do addUninterpWarning sym "AES decryption"
             applyAESStateFunc sym "AESDecRound" =<< st
   , "AESDecFinalRound" ~>
-       lam \st ->
+       PFun \st ->
+       PPrim
          do addUninterpWarning sym "AES decryption"
             applyAESStateFunc sym "AESDecFinalRound" =<< st
   , "AESInvMixColumns" ~>
-       lam \st ->
+       PFun \st ->
+       PPrim
          do addUninterpWarning sym "AES key expansion"
             applyAESStateFunc sym "AESInvMixColumns" =<< st
 
     -- {k} (fin k, k >= 4, 8 >= k) => [k][32] -> [4*(k+7)][32]
   , "AESKeyExpand" ~>
-       ilam \k ->
-        lam \st ->
+       PFinPoly \k ->
+       PFun     \st ->
+       PPrim
           do ss <- fromVSeq <$> st
              -- pack the arguments into a k-tuple of 32-bit values
              Some ws <- generateSomeM (fromInteger k) (\i -> Some <$> toWord32 sym "AESKeyExpand" ss (toInteger i))
@@ -372,8 +262,9 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
 
     -- {n} (fin n) => [n][16][32] -> [7][32]
   , "processSHA2_224" ~>
-    ilam \n ->
-     lam \xs ->
+    PFinPoly \n ->
+    PFun     \xs ->
+    PPrim
        do blks <- enumerateSeqMap n . fromVSeq <$> xs
           addUninterpWarning sym "SHA-224"
           initSt <- liftIO (mkSHA256InitialState sym SHA.initialSHA224State)
@@ -389,8 +280,9 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
 
     -- {n} (fin n) => [n][16][32] -> [8][32]
   , "processSHA2_256" ~>
-    ilam \n ->
-     lam \xs ->
+    PFinPoly \n ->
+    PFun     \xs ->
+    PPrim
        do blks <- enumerateSeqMap n . fromVSeq <$> xs
           addUninterpWarning sym "SHA-256"
           initSt <- liftIO (mkSHA256InitialState sym SHA.initialSHA256State)
@@ -406,8 +298,9 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
 
     -- {n} (fin n) => [n][16][64] -> [6][64]
   , "processSHA2_384" ~>
-    ilam \n ->
-     lam \xs ->
+    PFinPoly \n ->
+    PFun     \xs ->
+    PPrim
        do blks <- enumerateSeqMap n . fromVSeq <$> xs
           addUninterpWarning sym "SHA-384"
           initSt <- liftIO (mkSHA512InitialState sym SHA.initialSHA384State)
@@ -423,8 +316,9 @@ suiteBPrims sym = Map.fromList $ [ (suiteBPrim n, v) | (n,v) <- prims ]
 
     -- {n} (fin n) => [n][16][64] -> [8][64]
   , "processSHA2_512" ~>
-    ilam \n ->
-     lam \xs ->
+    PFinPoly \n ->
+    PFun     \xs ->
+    PPrim
        do blks <- enumerateSeqMap n . fromVSeq <$> xs
           addUninterpWarning sym "SHA-512"
           initSt <- liftIO (mkSHA512InitialState sym SHA.initialSHA512State)
@@ -636,13 +530,14 @@ applyAESStateFunc sym funNm x =
    argCtx = W4.knownRepr
 
 
-sshrV :: W4.IsSymExprBuilder sym => What4 sym -> Value sym
+sshrV :: W4.IsSymExprBuilder sym => What4 sym -> Prim (What4 sym)
 sshrV sym =
-  nlam $ \(Nat n) ->
-  tlam $ \ix ->
-  wlam sym $ \x -> return $
-  lam $ \y ->
-    y >>= asIndex sym ">>$" ix >>= \case
+  PFinPoly \n ->
+  PTyPoly  \ix ->
+  PWordFun \x ->
+  PStrictFun \y ->
+  PPrim $
+    asIndex sym ">>$" ix y >>= \case
        Left i ->
          do pneg <- intLessThan sym i =<< integerLit sym 0
             zneg <- do i' <- shiftShrink sym (Nat n) ix =<< intNegate sym i
@@ -983,9 +878,8 @@ updateBackSym_word sym (Nat n) eltTy bv (Right wv) val =
 
 
 
-
 -- | Table of floating point primitives
-floatPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map PrimIdent (Value sym)
+floatPrims :: W4.IsSymExprBuilder sym => What4 sym -> Map PrimIdent (Prim (What4 sym))
 floatPrims sym =
   Map.fromList [ (floatPrim i,v) | (i,v) <- nonInfixTable ]
   where
@@ -995,18 +889,19 @@ floatPrims sym =
   nonInfixTable =
     [ "fpNaN"       ~> fpConst (W4.fpNaN w4sym)
     , "fpPosInf"    ~> fpConst (W4.fpPosInf w4sym)
-    , "fpFromBits"  ~> ilam \e -> ilam \p -> wlam sym \w ->
-                       VFloat <$> liftIO (W4.fpFromBinary w4sym e p w)
-    , "fpToBits"    ~> ilam \e -> ilam \p -> flam \x ->
-                       pure $ VWord (e+p)
+    , "fpFromBits"  ~> PFinPoly \e -> PFinPoly \p -> PWordFun \w ->
+                       PPrim (VFloat <$> liftIO (W4.fpFromBinary w4sym e p w))
+    , "fpToBits"    ~> PFinPoly \e -> PFinPoly \p -> PFloatFun \x -> PVal
+                            $ VWord (e+p)
                             $ WordVal <$> liftIO (W4.fpToBinary w4sym x)
-    , "=.="         ~> ilam \_ -> ilam \_ -> flam \x -> pure $ flam \y ->
-                       VBit <$> liftIO (W4.fpEq w4sym x y)
-    , "fpIsFinite"  ~> ilam \_ -> ilam \_ -> flam \x ->
-                       VBit <$> liftIO do inf <- W4.fpIsInf w4sym x
-                                          nan <- W4.fpIsNaN w4sym x
-                                          weird <- W4.orPred w4sym inf nan
-                                          W4.notPred w4sym weird
+    , "=.="         ~> PFinPoly \_ -> PFinPoly \_ -> PFloatFun \x -> PFloatFun \y ->
+                       PPrim (VBit <$> liftIO (W4.fpEq w4sym x y))
+    , "fpIsFinite"  ~> PFinPoly \_ -> PFinPoly \_ -> PFloatFun \x ->
+                       PPrim
+                         (VBit <$> liftIO do inf <- W4.fpIsInf w4sym x
+                                             nan <- W4.fpIsNaN w4sym x
+                                             weird <- W4.orPred w4sym inf nan
+                                             W4.notPred w4sym weird)
 
     , "fpAdd"       ~> fpBinArithV sym fpPlus
     , "fpSub"       ~> fpBinArithV sym fpMinus
@@ -1014,23 +909,21 @@ floatPrims sym =
     , "fpDiv"       ~> fpBinArithV sym fpDiv
 
     , "fpFromRational" ~>
-       ilam \e -> ilam \p -> wlam sym \r -> pure $ lam \x ->
-       do rat <- fromVRational <$> x
-          VFloat <$> fpCvtFromRational sym e p r rat
+       PFinPoly \e -> PFinPoly \p -> PWordFun \r -> PFun \x -> PPrim
+         do rat <- fromVRational <$> x
+            VFloat <$> fpCvtFromRational sym e p r rat
 
     , "fpToRational" ~>
-       ilam \_e -> ilam \_p -> flam \fp ->
-       VRational <$> fpCvtToRational sym fp
+       PFinPoly \_e -> PFinPoly \_p -> PFloatFun \fp ->
+       PPrim (VRational <$> fpCvtToRational sym fp)
     ]
-
-
 
 -- | A helper for definitng floating point constants.
 fpConst ::
   W4.IsSymExprBuilder sym =>
   (Integer -> Integer -> IO (W4.SFloat sym)) ->
-  Value sym
+  Prim (What4 sym)
 fpConst mk =
-     ilam \ e ->
- VNumPoly \ ~(Nat p) ->
- VFloat <$> liftIO (mk e p)
+  PFinPoly \e ->
+  PNumPoly \ ~(Nat p) ->
+  PPrim (VFloat <$> liftIO (mk e p))

--- a/src/Cryptol/IR/FreeVars.hs
+++ b/src/Cryptol/IR/FreeVars.hs
@@ -99,6 +99,7 @@ instance FreeVars DeclDef where
 instance FreeVars Expr where
   freeVars expr =
     case expr of
+      ELocated _r t     -> freeVars t
       EList es t        -> freeVars es <> freeVars t
       ETuple es         -> freeVars es
       ERec fs           -> freeVars (recordElements fs)

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -453,7 +453,7 @@ checkSingleModule how isrc path m = do
 
 data TCLinter o = TCLinter
   { lintCheck ::
-      o -> T.InferInput -> Either TcSanity.Error [TcSanity.ProofObligation]
+      o -> T.InferInput -> Either (Range, TcSanity.Error) [TcSanity.ProofObligation]
   , lintModule :: Maybe P.ModName
   }
 
@@ -465,7 +465,9 @@ exprLinter = TCLinter
         Left err     -> Left err
         Right (s1,os)
           | TcSanity.same s s1  -> Right os
-          | otherwise -> Left (TcSanity.TypeMismatch "exprLinter" s s1)
+          | otherwise -> Left ( fromMaybe emptyRange (getLoc e')
+                              , TcSanity.TypeMismatch "exprLinter" s s1
+                              )
   , lintModule = Nothing
   }
 

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -564,6 +564,7 @@ evalExpr e = do
   evopts <- getEvalOpts
   let tbl = Concrete.primTable evopts
   let ?evalPrim = \i -> Right <$> Map.lookup i tbl
+  let ?range = emptyRange
   io $ E.runEval $ (E.evalExpr Concrete (env <> deEnv denv) e)
 
 evalDecls :: [T.DeclGroup] -> ModuleM ()

--- a/src/Cryptol/ModuleSystem/InstantiateModule.hs
+++ b/src/Cryptol/ModuleSystem/InstantiateModule.hs
@@ -183,6 +183,7 @@ instance Inst Expr where
                     Just y -> EVar y
                     _      -> expr
 
+        ELocated r e              -> ELocated r (inst env e)
         EList xs t                -> EList (inst env xs) (inst env t)
         ETuple es                 -> ETuple (inst env es)
         ERec xs                   -> ERec (fmap go xs)

--- a/src/Cryptol/Parser.y
+++ b/src/Cryptol/Parser.y
@@ -424,7 +424,7 @@ expr                          :: { Expr PName }
 
 -- | An expression without a `where` clause
 exprNoWhere                    :: { Expr PName }
-  : simpleExpr qop longRHS        { at ($1,$3) (binOp $1 $2 $3) }
+  : simpleExpr qop longRHS        { binOp $1 $2 $3 }
   | longRHS                       { $1 }
   | typedExpr                     { $1 }
 
@@ -441,7 +441,7 @@ typedExpr                      :: { Expr PName }
 
 -- A possibly infix expression (no where, no long application, no type annot)
 simpleExpr                     :: { Expr PName }
-  : simpleExpr qop simpleRHS      { at ($1,$3) (binOp $1 $2 $3) }
+  : simpleExpr qop simpleRHS      { binOp $1 $2 $3 }
   | simpleRHS                     { $1 }
 
 -- An expression without an obvious end marker

--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -394,7 +394,8 @@ newtype Prop n = CType (Type n)
 
 
 instance AddLoc (Expr n) where
-  addLoc = ELocated
+  addLoc (ELocated x _) r = addLoc x r
+  addLoc x              r = ELocated x r
 
   dropLoc (ELocated e _) = dropLoc e
   dropLoc e              = e

--- a/src/Cryptol/Parser/Lexer.x
+++ b/src/Cryptol/Parser/Lexer.x
@@ -202,7 +202,7 @@ lexer cfg cs = ( case cfgLayout cfg of
 primLexer :: Config -> Text -> ([Located Token], Position)
 primLexer cfg cs = run inp Normal
   where
-  inp = Inp { alexPos           = start
+  inp = Inp { alexPos           = cfgStart cfg
             , alexInputPrevChar = '\n'
             , input             = unLit (cfgPreProc cfg) cs }
 

--- a/src/Cryptol/Parser/LexerUtils.hs
+++ b/src/Cryptol/Parser/LexerUtils.hs
@@ -32,6 +32,7 @@ import Control.DeepSeq
 
 data Config = Config
   { cfgSource      :: !FilePath     -- ^ File that we are working on
+  , cfgStart       :: !Position     -- ^ Starting position for the parser
   , cfgLayout      :: !Layout       -- ^ Settings for layout processing
   , cfgPreProc     :: PreProc       -- ^ Preprocessor settings
   , cfgAutoInclude :: [FilePath]    -- ^ Implicit includes
@@ -43,6 +44,7 @@ data Config = Config
 defaultConfig :: Config
 defaultConfig  = Config
   { cfgSource      = ""
+  , cfgStart       = start
   , cfgLayout      = Layout
   , cfgPreProc     = None
   , cfgAutoInclude = []

--- a/src/Cryptol/Parser/Position.hs
+++ b/src/Cryptol/Parser/Position.hs
@@ -33,6 +33,11 @@ data Range      = Range { from   :: !Position
                         , source :: FilePath }
                   deriving (Eq, Ord, Show, Generic, NFData)
 
+type CallStack = [ (Text, Range) ]
+
+emptyCallStack :: CallStack
+emptyCallStack = []
+
 -- | An empty range.
 --
 -- Caution: using this on the LHS of a use of rComb will cause the empty source

--- a/src/Cryptol/Parser/Position.hs
+++ b/src/Cryptol/Parser/Position.hs
@@ -33,11 +33,6 @@ data Range      = Range { from   :: !Position
                         , source :: FilePath }
                   deriving (Eq, Ord, Show, Generic, NFData)
 
-type CallStack = [ (Text, Range) ]
-
-emptyCallStack :: CallStack
-emptyCallStack = []
-
 -- | An empty range.
 --
 -- Caution: using this on the LHS of a use of rComb will cause the empty source

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -6,6 +6,8 @@
 -- Stability   :  provisional
 -- Portability :  portable
 
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -72,6 +74,7 @@ import qualified Cryptol.Testing.Random  as TestR
 import Cryptol.Parser
     (parseExprWith,parseReplWith,ParseError(),Config(..),defaultConfig
     ,parseModName,parseHelpName)
+import           Cryptol.Parser.Position (Position(..))
 import qualified Cryptol.TypeCheck.AST as T
 import qualified Cryptol.TypeCheck.Error as T
 import qualified Cryptol.TypeCheck.Parseable as T
@@ -135,7 +138,7 @@ import qualified Data.SBV.Internals as SBV (showTDiff)
 
 -- | Commands.
 data Command
-  = Command (REPL ())         -- ^ Successfully parsed command
+  = Command (Int -> Maybe FilePath -> REPL ())         -- ^ Successfully parsed command
   | Ambiguous String [String] -- ^ Ambiguous command, list of conflicting
                               --   commands
   | Unknown String            -- ^ The unknown command
@@ -159,8 +162,8 @@ instance Ord CommandDescr where
   compare = compare `on` cNames
 
 data CommandBody
-  = ExprArg     (String   -> REPL ())
-  | FileExprArg (FilePath -> String -> REPL ())
+  = ExprArg     (String   -> (Int,Int) -> Maybe FilePath -> REPL ())
+  | FileExprArg (FilePath -> String -> (Int,Int) -> Maybe FilePath -> REPL ())
   | DeclsArg    (String   -> REPL ())
   | ExprTypeArg (String   -> REPL ())
   | ModNameArg  (String   -> REPL ())
@@ -214,10 +217,10 @@ nbCommandList  =
   , CommandDescr [ ":s", ":set" ] ["[ OPTION [ = VALUE ] ]"] (OptionArg setOptionCmd)
     "Set an environmental option (:set on its own displays current values)."
     ""
-  , CommandDescr [ ":check" ] ["[ EXPR ]"] (ExprArg (void . qcCmd QCRandom))
+  , CommandDescr [ ":check" ] ["[ EXPR ]"] (ExprArg (qcCmd QCRandom))
     "Use random testing to check that the argument always returns true.\n(If no argument, check all properties.)"
     ""
-  , CommandDescr [ ":exhaust" ] ["[ EXPR ]"] (ExprArg (void . qcCmd QCExhaust))
+  , CommandDescr [ ":exhaust" ] ["[ EXPR ]"] (ExprArg (qcCmd QCExhaust))
     "Use exhaustive testing to prove that the argument always returns\ntrue. (If no argument, check all properties.)"
     ""
   , CommandDescr [ ":prove" ] ["[ EXPR ]"] (ExprArg proveCmd)
@@ -295,10 +298,10 @@ genHelp cs = map cmdHelp cs
 -- Command Evaluation ----------------------------------------------------------
 
 -- | Run a command.
-runCommand :: Command -> REPL CommandExitCode
-runCommand c = case c of
+runCommand :: Int -> Maybe FilePath -> Command -> REPL CommandExitCode
+runCommand lineNum mbBatch c = case c of
 
-  Command cmd -> (cmd >> return CommandOk) `Cryptol.REPL.Monad.catch` handler
+  Command cmd -> (cmd lineNum mbBatch >> return CommandOk) `Cryptol.REPL.Monad.catch` handler
     where
     handler re = rPutStrLn "" >> rPrint (pp re) >> return CommandError
 
@@ -338,9 +341,9 @@ getEvalOpts =
      l      <- getLogger
      return E.EvalOpts { E.evalPPOpts = ppOpts, E.evalLogger = l }
 
-evalCmd :: String -> REPL ()
-evalCmd str = do
-  ri <- replParseInput str
+evalCmd :: String -> Int -> Maybe FilePath -> REPL ()
+evalCmd str lineNum mbBatch = do
+  ri <- replParseInput str lineNum mbBatch
   case ri of
     P.ExprInput expr -> do
       (val,_ty) <- replEvalExpr expr
@@ -381,9 +384,9 @@ printSatisfyingModel pexpr vs =
      rPrint $ hang doc 2 (sep docs) <+> text ("= True")
 
 
-dumpTestsCmd :: FilePath -> String -> REPL ()
-dumpTestsCmd outFile str =
-  do expr <- replParseExpr str
+dumpTestsCmd :: FilePath -> String -> (Int,Int) -> Maybe FilePath -> REPL ()
+dumpTestsCmd outFile str pos fnm =
+  do expr <- replParseExpr str pos fnm
      (val, ty) <- replEvalExpr expr
      ppopts <- getPPValOpts
      testNum <- getKnownUser "tests" :: REPL Int
@@ -412,19 +415,21 @@ data QCMode = QCRandom | QCExhaust deriving (Eq, Show)
 -- | Randomly test a property, or exhaustively check it if the number
 -- of values in the type under test is smaller than the @tests@
 -- environment variable, or we specify exhaustive testing.
-qcCmd :: QCMode -> String -> REPL [TestReport]
-qcCmd qcMode "" =
+qcCmd :: QCMode -> String -> (Int,Int) -> Maybe FilePath -> REPL ()
+qcCmd qcMode "" pos fnm =
   do (xs,disp) <- getPropertyNames
      let nameStr x = show (fixNameDisp disp (pp x))
      if null xs
-        then rPutStrLn "There are no properties in scope." *> return []
-        else concat <$> (forM xs $ \x ->
+        then rPutStrLn "There are no properties in scope."
+        else forM_ xs $ \x ->
+               -- TOOD, this is pretty bogus.  Should find a way to do
+               --  this directly from the 'Name' instead of parsing it again.
                do let str = nameStr x
                   rPutStr $ "property " ++ str ++ " "
-                  qcCmd qcMode str)
+                  qcCmd qcMode str pos fnm
 
-qcCmd qcMode str =
-  do expr <- replParseExpr str
+qcCmd qcMode str pos fnm =
+  do expr <- replParseExpr str pos fnm
      (val,ty) <- replEvalExpr expr
      testNum <- (toInteger :: Int -> Integer) <$> getKnownUser "tests"
      tenv <- E.envTypes . M.deEnv <$> getDynEnv
@@ -448,7 +453,7 @@ qcCmd qcMode str =
             delProgress
             delTesting
             ppReport (map E.tValTy tys) expr True report
-            return [report]
+            --return [report]
 
        Just (sz,tys,_,gens) | qcMode == QCRandom -> do
             rPutStrLn "Using random testing."
@@ -472,7 +477,7 @@ qcCmd qcMode str =
             case sz of
               Just n | isPass res -> rPutStrLn $ coverageString testNum n
               _ -> return ()
-            return [report]
+            --return [report]
        _ -> raise (TypeNotTestable ty)
 
   where
@@ -606,7 +611,7 @@ expectedCoverage testNum sz =
 
    proportion = negate (expm1 (numD * log1p (negate (recip szD))))
 
-satCmd, proveCmd :: String -> REPL ()
+satCmd, proveCmd :: String -> (Int,Int) -> Maybe FilePath -> REPL ()
 satCmd = cmdProveSat True
 proveCmd = cmdProveSat False
 
@@ -628,16 +633,17 @@ rethrowErrorCall m = REPL (\r -> unREPL m r `X.catches` hs)
       ]
 
 -- | Attempts to prove the given term is safe for all inputs
-safeCmd :: String -> REPL ()
-safeCmd str = do
+safeCmd :: String -> (Int,Int) -> Maybe FilePath -> REPL ()
+safeCmd str pos fnm = do
   proverName <- getKnownUser "prover"
   fileName   <- getKnownUser "smtfile"
   let mfile = if fileName == "-" then Nothing else Just fileName
+  pexpr <- replParseExpr str pos fnm
 
   if proverName `elem` ["offline","sbv-offline","w4-offline"] then
-    offlineProveSat proverName SafetyQuery str mfile
+    offlineProveSat proverName SafetyQuery pexpr mfile
   else
-     do (firstProver,result,stats) <- rethrowErrorCall (onlineProveSat proverName SafetyQuery str mfile)
+     do (firstProver,result,stats) <- rethrowErrorCall (onlineProveSat proverName SafetyQuery pexpr mfile)
         case result of
           EmptyResult         ->
             panic "REPL.Command" [ "got EmptyResult for online prover query" ]
@@ -652,7 +658,6 @@ safeCmd str = do
                 vs  = map ( \(_,_,v) -> v)     tevs
 
             (t,e) <- mkSolverResult "counterexample" False (Right tes)
-            pexpr <- replParseExpr str
 
             ~(EnvBool yes) <- getUser "show-examples"
             when yes $ printCounterexample cexType pexpr vs
@@ -670,8 +675,8 @@ safeCmd str = do
 -- console, and binds the @it@ variable to a record whose form depends
 -- on the expression given. See ticket #66 for a discussion of this
 -- design.
-cmdProveSat :: Bool -> String -> REPL ()
-cmdProveSat isSat "" =
+cmdProveSat :: Bool -> String -> (Int,Int) -> Maybe FilePath -> REPL ()
+cmdProveSat isSat "" pos fnm =
   do (xs,disp) <- getPropertyNames
      let nameStr x = show (fixNameDisp disp (pp x))
      if null xs
@@ -681,19 +686,20 @@ cmdProveSat isSat "" =
                   if isSat
                      then rPutStr $ ":sat "   ++ str ++ "\n\t"
                      else rPutStr $ ":prove " ++ str ++ "\n\t"
-                  cmdProveSat isSat str
-cmdProveSat isSat str = do
+                  cmdProveSat isSat str pos fnm
+cmdProveSat isSat str pos fnm = do
   let cexStr | isSat = "satisfying assignment"
              | otherwise = "counterexample"
   qtype <- if isSat then SatQuery <$> getUserSatNum else pure ProveQuery
   proverName <- getKnownUser "prover"
   fileName   <- getKnownUser "smtfile"
   let mfile = if fileName == "-" then Nothing else Just fileName
+  pexpr <- replParseExpr str pos fnm
 
   if proverName `elem` ["offline","sbv-offline","w4-offline"] then
-     offlineProveSat proverName qtype str mfile
+     offlineProveSat proverName qtype pexpr mfile
   else
-     do (firstProver,result,stats) <- rethrowErrorCall (onlineProveSat proverName qtype str mfile)
+     do (firstProver,result,stats) <- rethrowErrorCall (onlineProveSat proverName qtype pexpr mfile)
         case result of
           EmptyResult         ->
             panic "REPL.Command" [ "got EmptyResult for online prover query" ]
@@ -711,7 +717,6 @@ cmdProveSat isSat str = do
                 vs  = map ( \(_,_,v) -> v)     tevs
 
             (t,e) <- mkSolverResult cexStr isSat (Right tes)
-            pexpr <- replParseExpr str
 
             ~(EnvBool yes) <- getUser "show-examples"
             when yes $ printCounterexample cexType pexpr vs
@@ -736,7 +741,6 @@ cmdProveSat isSat str = do
                             [ "no satisfying assignments after mkSolverResult" ]
                     [(t, e)] -> (t, [e])
                     _        -> collectTes resultRecs
-            pexpr <- replParseExpr str
 
             ~(EnvBool yes) <- getUser "show-examples"
             when yes $ forM_ vss (printSatisfyingModel pexpr)
@@ -750,12 +754,12 @@ cmdProveSat isSat str = do
 
 onlineProveSat :: String
                -> QueryType
-               -> String -> Maybe FilePath
+               -> P.Expr P.PName
+               -> Maybe FilePath
                -> REPL (Maybe String,ProverResult,ProverStats)
-onlineProveSat proverName qtype str mfile = do
+onlineProveSat proverName qtype parseExpr mfile = do
   verbose <- getKnownUser "debug"
   modelValidate <- getUserProverValidate
-  parseExpr <- replParseExpr str
   (_, expr, schema) <- replCheckExpr parseExpr
   validEvalContext expr
   validEvalContext schema
@@ -784,11 +788,10 @@ onlineProveSat proverName qtype str mfile = do
   stas <- io (readIORef timing)
   return (firstProver,res,stas)
 
-offlineProveSat :: String -> QueryType -> String -> Maybe FilePath -> REPL ()
-offlineProveSat proverName qtype str mfile = do
+offlineProveSat :: String -> QueryType -> P.Expr P.PName -> Maybe FilePath -> REPL ()
+offlineProveSat proverName qtype parseExpr mfile = do
   verbose <- getKnownUser "debug"
   modelValidate <- getUserProverValidate
-  parseExpr <- replParseExpr str
   (_, expr, schema) <- replCheckExpr parseExpr
   decls <- fmap M.deDecls getDynEnv
   timing <- io (newIORef 0)
@@ -882,9 +885,9 @@ mkSolverResult thing result earg =
       let argName = M.packIdent ("arg" ++ show n)
        in ((argName,t),(argName,e))
 
-specializeCmd :: String -> REPL ()
-specializeCmd str = do
-  parseExpr <- replParseExpr str
+specializeCmd :: String -> (Int,Int) -> Maybe FilePath -> REPL ()
+specializeCmd str pos fnm = do
+  parseExpr <- replParseExpr str pos fnm
   (_, expr, schema) <- replCheckExpr parseExpr
   spexpr <- replSpecExpr expr
   rPutStrLn  "Expression type:"
@@ -894,9 +897,9 @@ specializeCmd str = do
   rPutStrLn  "Specialized expression:"
   rPutStrLn $ dump spexpr
 
-refEvalCmd :: String -> REPL ()
-refEvalCmd str = do
-  parseExpr <- replParseExpr str
+refEvalCmd :: String -> (Int,Int) -> Maybe FilePath -> REPL ()
+refEvalCmd str pos fnm = do
+  parseExpr <- replParseExpr str pos fnm
   (_, expr, schema) <- replCheckExpr parseExpr
   validEvalContext expr
   validEvalContext schema
@@ -904,9 +907,9 @@ refEvalCmd str = do
   opts <- getPPValOpts
   rPrint $ R.ppEValue opts val
 
-astOfCmd :: String -> REPL ()
-astOfCmd str = do
- expr <- replParseExpr str
+astOfCmd :: String -> (Int,Int) -> Maybe FilePath -> REPL ()
+astOfCmd str pos fnm = do
+ expr <- replParseExpr str pos fnm
  (re,_,_) <- replCheckExpr (P.noPos expr)
  rPrint (fmap M.nameUnique re)
 
@@ -915,10 +918,10 @@ allTerms = do
   me <- getModuleEnv
   rPrint $ T.showParseable $ concatMap T.mDecls $ M.loadedModules me
 
-typeOfCmd :: String -> REPL ()
-typeOfCmd str = do
+typeOfCmd :: String -> (Int,Int) -> Maybe FilePath -> REPL ()
+typeOfCmd str pos fnm = do
 
-  expr         <- replParseExpr str
+  expr         <- replParseExpr str pos fnm
   (_re,def,sig) <- replCheckExpr expr
 
   -- XXX need more warnings from the module system
@@ -963,9 +966,9 @@ byteStringToInteger bs
     x1 = byteStringToInteger bs1
     x2 = byteStringToInteger bs2
 
-writeFileCmd :: FilePath -> String -> REPL ()
-writeFileCmd file str = do
-  expr         <- replParseExpr str
+writeFileCmd :: FilePath -> String -> (Int,Int) -> Maybe FilePath -> REPL ()
+writeFileCmd file str pos fnm = do
+  expr         <- replParseExpr str pos fnm
   (val,ty)     <- replEvalExpr expr
   if not (tIsByteSeq ty)
    then rPrint $  "Cannot write expression of types other than [n][8]."
@@ -1348,9 +1351,9 @@ helpCmd cmd
   | null cmd  = mapM_ rPutStrLn (genHelp commandList)
   | cmd0 : args <- words cmd, ":" `isPrefixOf` cmd0 =
     case findCommandExact cmd0 of
-      []  -> void $ runCommand (Unknown cmd0)
+      []  -> void $ runCommand 1 Nothing (Unknown cmd0)
       [c] -> showCmdHelp c args
-      cs  -> void $ runCommand (Ambiguous cmd0 (concatMap cNames cs))
+      cs  -> void $ runCommand 1 Nothing (Ambiguous cmd0 (concatMap cNames cs))
   | otherwise =
     case parseHelpName cmd of
       Just qname ->
@@ -1557,11 +1560,25 @@ replParse parse str = case parse str of
   Right a -> return a
   Left e  -> raise (ParseError e)
 
-replParseInput :: String -> REPL (P.ReplInput P.PName)
-replParseInput = replParse (parseReplWith interactiveConfig . T.pack)
+replParseInput :: String -> Int -> Maybe FilePath -> REPL (P.ReplInput P.PName)
+replParseInput str lineNum fnm = replParse (parseReplWith cfg . T.pack) str
+  where
+  cfg = case fnm of
+          Nothing -> interactiveConfig{ cfgStart = Position lineNum 1 }
+          Just f  -> defaultConfig
+                     { cfgSource = f
+                     , cfgStart  = Position lineNum 1
+                     }
 
-replParseExpr :: String -> REPL (P.Expr P.PName)
-replParseExpr = replParse (parseExprWith interactiveConfig . T.pack)
+replParseExpr :: String -> (Int,Int) -> Maybe FilePath -> REPL (P.Expr P.PName)
+replParseExpr str (l,c) fnm = replParse (parseExprWith cfg. T.pack) str
+  where
+  cfg = case fnm of
+          Nothing -> interactiveConfig{ cfgStart = Position l c }
+          Just f  -> defaultConfig
+                     { cfgSource = f
+                     , cfgStart  = Position l c
+                     }
 
 interactiveConfig :: Config
 interactiveConfig = defaultConfig { cfgSource = "<interactive>" }
@@ -1770,19 +1787,26 @@ trim :: String -> String
 trim = sanitizeEnd . sanitize
 
 -- | Split at the first word boundary.
-splitCommand :: String -> Maybe (String,String)
-splitCommand txt =
-  case sanitize txt of
-    ':' : more
+splitCommand :: String -> Maybe (Int,String,String)
+splitCommand = go 0
+  where
+   go !len (c  : more)
+      | isSpace c = go (len+1) more
+
+   go !len (':': more)
       | (as,bs) <- span (\x -> isPunctuation x || isSymbol x) more
-      , not (null as) -> Just (':' : as, sanitize bs)
+      , (ws,cs) <- span isSpace bs
+      , not (null as) = Just (len+1+length as+length ws, ':' : as, cs)
 
       | (as,bs) <- break isSpace more
-      , not (null as) -> Just (':' : as, sanitize bs)
+      , (ws,cs) <- span isSpace bs
+      , not (null as) = Just (len+1+length as+length ws, ':' : as, cs)
 
-      | otherwise -> Nothing
+      | otherwise = Nothing
 
-    expr -> guard (not (null expr)) >> return (expr,[])
+   go !len expr
+      | null expr = Nothing
+      | otherwise = Just (len+length expr, expr, [])
 
 -- | Uncons a list.
 uncons :: [a] -> Maybe (a,[a])
@@ -1807,23 +1831,24 @@ findNbCommand False str = lookupTrie      str nbCommands
 -- | Parse a line as a command.
 parseCommand :: (String -> [CommandDescr]) -> String -> Maybe Command
 parseCommand findCmd line = do
-  (cmd,args) <- splitCommand line
+  (cmdLen,cmd,args) <- splitCommand line
   let args' = sanitizeEnd args
   case findCmd cmd of
     [c] -> case cBody c of
-      ExprArg     body -> Just (Command (body args'))
-      DeclsArg    body -> Just (Command (body args'))
-      ExprTypeArg body -> Just (Command (body args'))
-      ModNameArg  body -> Just (Command (body args'))
-      FilenameArg body -> Just (Command (body =<< expandHome args'))
-      OptionArg   body -> Just (Command (body args'))
-      ShellArg    body -> Just (Command (body args'))
-      HelpArg     body -> Just (Command (body args'))
-      NoArg       body -> Just (Command  body)
+      ExprArg     body -> Just (Command \l fp -> (body args' (l,cmdLen+1) fp))
+      DeclsArg    body -> Just (Command \_ _ -> (body args'))
+      ExprTypeArg body -> Just (Command \_ _ -> (body args'))
+      ModNameArg  body -> Just (Command \_ _ -> (body args'))
+      FilenameArg body -> Just (Command \_ _ -> (body =<< expandHome args'))
+      OptionArg   body -> Just (Command \_ _ -> (body args'))
+      ShellArg    body -> Just (Command \_ _ -> (body args'))
+      HelpArg     body -> Just (Command \_ _ -> (body args'))
+      NoArg       body -> Just (Command \_ _ -> body)
       FileExprArg body ->
-        case extractFilePath args' of
-           Just (fp,expr) -> Just (Command (expandHome fp >>= flip body expr))
-           Nothing        -> Nothing
+           do (fpLen,fp,expr) <- extractFilePath args'
+              Just (Command \l fp' -> do let col = cmdLen + fpLen + 1
+                                         hm <- expandHome fp
+                                         body hm expr (l,col) fp')
     [] -> case uncons cmd of
       Just (':',_) -> Just (Unknown cmd)
       Just _       -> Just (Command (evalCmd line))
@@ -1839,9 +1864,10 @@ parseCommand findCmd line = do
       _ -> return path
 
   extractFilePath ipt =
-    let quoted q = (\(a,b) -> (a, drop 1 b)) . break (== q)
+    let quoted q = (\(a,b) -> (length a + 2, a, drop 1 b)) . break (== q)
     in case ipt of
         ""        -> Nothing
         '\'':rest -> Just $ quoted '\'' rest
         '"':rest  -> Just $ quoted '"' rest
-        _         -> Just $ break isSpace ipt
+        _         -> let (a,b) = break isSpace ipt in
+                     if null a then Nothing else Just (length a, a, b)

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -76,7 +76,7 @@ module Cryptol.REPL.Monad (
 
 import Cryptol.REPL.Trie
 
-import Cryptol.Eval (EvalError, Unsupported)
+import Cryptol.Eval (EvalErrorEx, Unsupported)
 import qualified Cryptol.ModuleSystem as M
 import qualified Cryptol.ModuleSystem.Env as M
 import qualified Cryptol.ModuleSystem.Name as M
@@ -289,7 +289,7 @@ data REPLException
   | DirectoryNotFound FilePath
   | NoPatError [Error]
   | NoIncludeError [IncludeError]
-  | EvalError EvalError
+  | EvalError EvalErrorEx
   | Unsupported Unsupported
   | ModuleSystemError NameDisp M.ModuleError
   | EvalPolyError T.Schema
@@ -350,7 +350,7 @@ rethrowEvalError m = run `X.catch` rethrow `X.catch` rethrowUnsupported
     a <- m
     return $! a
 
-  rethrow :: EvalError -> IO a
+  rethrow :: EvalErrorEx -> IO a
   rethrow exn = X.throwIO (EvalError exn)
 
   rethrowUnsupported :: Unsupported -> IO a

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -212,7 +212,7 @@ varShapeToValue sym var =
     VarRational n d -> VRational (SRational n d)
     VarWord w    -> VWord (wordLen sym w) (return (WordVal w))
     VarFloat f   -> VFloat f
-    VarFinSeq n vs -> VSeq n (finiteSeqMap sym (map (pure . varShapeToValue sym) vs))
+    VarFinSeq n vs -> VSeq n (finiteSeqMap (map (pure . varShapeToValue sym) vs))
     VarTuple vs  -> VTuple (map (pure . varShapeToValue sym) vs)
     VarRecord fs -> VRecord (fmap (pure . varShapeToValue sym) fs)
 

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -58,6 +58,7 @@ import qualified Cryptol.Eval as Eval
 import qualified Cryptol.Eval.Concrete as Concrete
 import qualified Cryptol.Eval.Value as Eval
 import           Cryptol.Eval.SBV
+import           Cryptol.Parser.Position (emptyRange)
 import           Cryptol.Symbolic
 import           Cryptol.TypeCheck.AST
 import           Cryptol.Utils.Ident (preludeReferenceName, prelPrim, identText)
@@ -328,6 +329,8 @@ prepareQuery evo ProverCommand{..} =
                  let tbl = primTable sym
                  let ?evalPrim = \i -> (Right <$> Map.lookup i tbl) <|>
                                        (Left <$> Map.lookup i ds)
+                 let ?range = emptyRange
+
                  -- Compute the symbolic inputs, and any domain constraints needed
                  -- according to their types.
                  args <- map (pure . varShapeToValue sym) <$>

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -62,6 +62,7 @@ import qualified Cryptol.Eval as Eval
 import qualified Cryptol.Eval.Concrete as Concrete
 import qualified Cryptol.Eval.Value as Eval
 import           Cryptol.Eval.What4
+import           Cryptol.Parser.Position (emptyRange)
 import           Cryptol.Symbolic
 import           Cryptol.TypeCheck.AST
 import           Cryptol.Utils.Logger(logPutStrLn,logPutStr,Logger)
@@ -276,6 +277,7 @@ prepareQuery sym ProverCommand { .. } =
        let tbl = primTable sym
        let ?evalPrim = \i -> (Right <$> Map.lookup i tbl) <|>
                              (Left <$> Map.lookup i ds)
+       let ?range = emptyRange
 
        modEnv <- M.getModuleEnv
        let extDgs = M.allDeclGroups modEnv ++ pcExtraDecls

--- a/src/Cryptol/Transform/AddModParams.hs
+++ b/src/Cryptol/Transform/AddModParams.hs
@@ -230,6 +230,7 @@ instance Inst Expr where
         in ESel (EVar paramModRecParam) (RecordSel (nameIdent x) (Just sh))
       | otherwise -> EVar x
 
+     ELocated r t -> ELocated r (inst ps t)
      EList es t -> EList (inst ps es) (inst ps t)
      ETuple es -> ETuple (inst ps es)
      ERec fs   -> ERec (fmap (inst ps) fs)

--- a/src/Cryptol/Transform/MonoValues.hs
+++ b/src/Cryptol/Transform/MonoValues.hs
@@ -179,6 +179,7 @@ rewE rews = go
                           Nothing  -> EProofApp <$> go e
                           Just yes -> return yes
 
+      ELocated r t    -> ELocated r <$> go t
       EList es t      -> EList   <$> mapM go es <*> return t
       ETuple es       -> ETuple  <$> mapM go es
       ERec fs         -> ERec    <$> traverse go fs

--- a/src/Cryptol/Transform/Specialize.hs
+++ b/src/Cryptol/Transform/Specialize.hs
@@ -70,6 +70,7 @@ specialize expr (ev, byteReader, modEnv) = run $ do
 specializeExpr :: Expr -> SpecM Expr
 specializeExpr expr =
   case expr of
+    ELocated r e  -> ELocated r <$> specializeExpr e
     EList es t    -> EList <$> traverse specializeExpr es <*> pure t
     ETuple es     -> ETuple <$> traverse specializeExpr es
     ERec fs       -> ERec <$> traverse specializeExpr fs

--- a/src/Cryptol/TypeCheck.hs
+++ b/src/Cryptol/TypeCheck.hs
@@ -78,7 +78,9 @@ tcExpr e0 inp = runInferM inp
   where
   go loc expr =
     case expr of
-      P.ELocated e loc' -> go loc' e
+      P.ELocated e loc' ->
+        do (te, sch) <- go loc' e
+           pure (ELocated loc' te, sch)
       P.EVar x  ->
         do res <- lookupVar x
            case res of

--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -169,7 +169,7 @@ appTys expr ts tGoal =
          -- XXX: Is there a scoping issue here?  I think not, but check.
 
     P.ELocated e r ->
-      inRange r (appTys e ts tGoal)
+      inRange r (ELocated r <$> appTys e ts tGoal)
 
     P.ENeg        {} -> mono
     P.EComplement {} -> mono
@@ -368,7 +368,7 @@ checkE expr tGoal =
 
     P.EFun ps e -> checkFun Nothing ps e tGoal
 
-    P.ELocated e r  -> inRange r (checkE e tGoal)
+    P.ELocated e r  -> inRange r (ELocated r <$> checkE e tGoal)
 
     P.ESplit e ->
       do prim <- mkPrim "splitAt"

--- a/src/Cryptol/TypeCheck/Parseable.hs
+++ b/src/Cryptol/TypeCheck/Parseable.hs
@@ -31,6 +31,7 @@ class ShowParseable t where
   showParseable :: t -> Doc
 
 instance ShowParseable Expr where
+  showParseable (ELocated _ e) = showParseable e -- TODO? emit range information
   showParseable (EList es _) = parens (text "EList" <+> showParseable es)
   showParseable (ETuple es) = parens (text "ETuple" <+> showParseable es)
   showParseable (ERec ides) = parens (text "ERec" <+> showParseable (canonicalFields ides))

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -348,6 +348,7 @@ instance TVars Expr where
     where
     go expr =
       case expr of
+        ELocated r e  -> ELocated r !$ (go e)
         EApp e1 e2    -> EApp !$ (go e1) !$ (go e2)
         EAbs x t e1   -> EAbs x !$ (apSubst su t) !$ (go e1)
         ETAbs a e     -> ETAbs a !$ (go e)

--- a/src/Cryptol/TypeCheck/TypeOf.hs
+++ b/src/Cryptol/TypeCheck/TypeOf.hs
@@ -30,6 +30,7 @@ fastTypeOf :: Map Name Schema -> Expr -> Type
 fastTypeOf tyenv expr =
   case expr of
     -- Monomorphic fragment
+    ELocated _ t  -> fastTypeOf tyenv t
     EList es t    -> tSeq (tNum (length es)) t
     ETuple es     -> tTuple (map (fastTypeOf tyenv) es)
     ERec fields   -> tRec (fmap (fastTypeOf tyenv) fields)
@@ -59,6 +60,8 @@ fastTypeOf tyenv expr =
 fastSchemaOf :: Map Name Schema -> Expr -> Schema
 fastSchemaOf tyenv expr =
   case expr of
+    ELocated _ e -> fastSchemaOf tyenv e
+
     -- Polymorphic fragment
     EVar x         -> case Map.lookup x tyenv of
                          Just ty -> ty

--- a/tests/issues/T820.icry.stdout
+++ b/tests/issues/T820.icry.stdout
@@ -3,14 +3,14 @@ Showing a specific instance of polymorphic result:
   * Using 'Rational' for type argument 'a' of 'Cryptol::fraction'
 (ratio 1 2)
 
-[error] at <interactive>:1:1--1:8:
+[error] at T820.icry:2:1--2:8:
   • `?a` is not an integral type.
       arising from
       use of expression (/)
-      at <interactive>:1:1--1:8
+      at T820.icry:2:1--2:8
   • `1/1` is not a valid literal of type `?a`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:8
+      at T820.icry:2:1--2:8
   where
-  ?a is type argument 'a' of 'fraction' at <interactive>:1:1--1:8
+  ?a is type argument 'a' of 'fraction' at T820.icry:2:1--2:8

--- a/tests/issues/issue084.icry.stdout
+++ b/tests/issues/issue084.icry.stdout
@@ -3,7 +3,7 @@ Showing a specific instance of polymorphic result:
   * Using '5' for type argument 'n' of 'Cryptol::lg2'
 0x03
 
-[error] at <interactive>:1:1--1:4:
+[error] at issue084.icry:2:1--2:4:
   Type mismatch:
     Expected type: Integer
     Inferred type: [5]

--- a/tests/issues/issue101.icry.stdout
+++ b/tests/issues/issue101.icry.stdout
@@ -1,8 +1,8 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:1--1:11:
+[error] at issue101.icry:1:1--1:11:
   • Unsolvable constraint:
       0 >= 1
         arising from
         use of partial type function (-)
-        at <interactive>:1:1--1:11
+        at issue101.icry:1:1--1:11

--- a/tests/issues/issue103.icry.stdout
+++ b/tests/issues/issue103.icry.stdout
@@ -1,7 +1,9 @@
 Loading module Cryptol
 
 Run-time error: undefined
+at Cryptol:951:13--951:18
 Using exhaustive testing.
 Testing... ERROR for the following inputs:
 ()
 invalid sequence index: 1
+at issue103.icry:2:11--2:21

--- a/tests/issues/issue211.icry.stdout
+++ b/tests/issues/issue211.icry.stdout
@@ -4,3 +4,4 @@ Loading module Cryptol
 0x0
 
 Run-time error: boom
+at issue211.icry:4:28--4:33

--- a/tests/issues/issue322.icry.stdout
+++ b/tests/issues/issue322.icry.stdout
@@ -1,4 +1,4 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:2--1:7:
+[error] at issue322.icry:1:5--1:10:
   Named and positional type applications may not be mixed.

--- a/tests/issues/issue364.icry.stdout
+++ b/tests/issues/issue364.icry.stdout
@@ -25,4 +25,4 @@ Q.E.D.
 	Q.E.D.
 :prove moderately_bogus_property
 	
-Run-time error: cannot evaluate 'random' with symbolic inputs
+operation can not be supported on symbolic values: random

--- a/tests/issues/issue382.icry.stdout
+++ b/tests/issues/issue382.icry.stdout
@@ -1,67 +1,67 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:1--1:5:
+[error] at issue382.icry:1:1--1:5:
   Type mismatch:
     Expected type: Bit
     Inferred type: [2]
     When checking user annotation
 
-[error] at <interactive>:1:1--1:20:
+[error] at issue382.icry:2:1--2:20:
   Type mismatch:
     Expected type: (Bit, Bit)
     Inferred type: (Bit, Bit, Bit)
     When checking user annotation
 
-[error] at <interactive>:1:1--1:8:
+[error] at issue382.icry:3:1--3:8:
   Type mismatch:
     Expected type: 4
     Inferred type: 5
     When checking user annotation
 
-[error] at <interactive>:1:1--1:14:
+[error] at issue382.icry:4:1--4:14:
   Type mismatch:
     Expected type: Bit
     Inferred type: (Bit, Bit)
     When checking user annotation
 
-[error] at <interactive>:1:1--1:11:
+[error] at issue382.icry:5:1--5:11:
   Type mismatch:
     Expected type: {a : Bit, b : Bit}
     Inferred type: {a : Bit}
     Missing field b
     When checking user annotation
 
-[error] at <interactive>:1:1--1:5:
+[error] at issue382.icry:6:1--6:5:
   Type mismatch:
     Expected type: [2]
     Inferred type: Bit
     When checking user annotation
 
-[error] at <interactive>:1:1--1:3:
+[error] at issue382.icry:7:1--7:3:
   Type mismatch:
     Expected type: inf
     Inferred type: 0
     When checking length of sequence
 
-[error] at <interactive>:1:9--1:11:
+[error] at issue382.icry:8:9--8:11:
   Type mismatch:
     Expected type: [3]
     Inferred type: {}
     When checking type of function argument
 
-[error] at <interactive>:1:9--1:22:
+[error] at issue382.icry:9:9--9:22:
   Type mismatch:
     Expected type: [3]
     Inferred type: (Bit, Bit)
     When checking type of function argument
 
-[error] at <interactive>:1:2--1:15:
+[error] at issue382.icry:10:2--10:15:
   Type mismatch:
     Expected type: [2]
     Inferred type: Bit -> Bit
     When checking user annotation
 
-[error] at <interactive>:1:1--1:5:
+[error] at issue382.icry:11:1--11:5:
   Type mismatch:
     Expected type: Bit -> Bit
     Inferred type: Bit

--- a/tests/issues/issue413.icry.stdout
+++ b/tests/issues/issue413.icry.stdout
@@ -1,7 +1,10 @@
 Loading module Cryptol
 
 division by 0
+at issue413.icry:1:1--1:10
 
 division by 0
+at issue413.icry:2:1--2:5
 
 division by 0
+at issue413.icry:3:1--3:5

--- a/tests/issues/issue582.icry.stdout
+++ b/tests/issues/issue582.icry.stdout
@@ -1,46 +1,46 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:1--1:18:
+[error] at issue582.icry:1:1--1:18:
   • Unsolvable constraint:
       fin inf
         arising from
         use of partial type function (/^)
-        at <interactive>:1:1--1:18
+        at issue582.icry:1:1--1:18
 
-[error] at <interactive>:1:1--1:18:
+[error] at issue582.icry:2:1--2:18:
   • Unsolvable constraint:
       fin inf
         arising from
         use of partial type function (/^)
-        at <interactive>:1:1--1:18
+        at issue582.icry:2:1--2:18
 
-[error] at <interactive>:1:1--1:16:
+[error] at issue582.icry:3:1--3:16:
   • Unsolvable constraint:
       0 >= 1
         arising from
         use of partial type function (/^)
-        at <interactive>:1:1--1:16
+        at issue582.icry:3:1--3:16
 
-[error] at <interactive>:1:1--1:18:
+[error] at issue582.icry:4:1--4:18:
   • Unsolvable constraint:
       fin inf
         arising from
         use of partial type function (%^)
-        at <interactive>:1:1--1:18
+        at issue582.icry:4:1--4:18
 
-[error] at <interactive>:1:1--1:18:
+[error] at issue582.icry:5:1--5:18:
   • Unsolvable constraint:
       fin inf
         arising from
         use of partial type function (%^)
-        at <interactive>:1:1--1:18
+        at issue582.icry:5:1--5:18
 
-[error] at <interactive>:1:1--1:16:
+[error] at issue582.icry:6:1--6:16:
   • Unsolvable constraint:
       0 >= 1
         arising from
         use of partial type function (%^)
-        at <interactive>:1:1--1:16
+        at issue582.icry:6:1--6:16
 Loading module Cryptol
 Loading module Main
 

--- a/tests/issues/issue712.icry.stdout
+++ b/tests/issues/issue712.icry.stdout
@@ -1,4 +1,4 @@
 Loading module Cryptol
 
-Parse error at <interactive>:1:1--1:28
+Parse error at issue712.icry:1:4--1:31
   Polynomial literal too large: 18446744073709551617

--- a/tests/issues/issue713.icry.stdout
+++ b/tests/issues/issue713.icry.stdout
@@ -1,4 +1,4 @@
 Loading module Cryptol
 
-Parse error at <interactive>:1:13--1:17
+Parse error at issue713.icry:1:13--1:17
   malformed selector: .0x1

--- a/tests/issues/issue746.icry.stdout
+++ b/tests/issues/issue746.icry.stdout
@@ -1,6 +1,6 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:11--1:16:
+[error] at issue746.icry:1:11--1:16:
   Type mismatch:
     Expected type: 3
     Inferred type: 2

--- a/tests/issues/issue818.icry.stdout
+++ b/tests/issues/issue818.icry.stdout
@@ -1,10 +1,10 @@
 Loading module Cryptol
 
-Parse error at <interactive>:1:5--1:10
+Parse error at issue818.icry:1:5--1:10
   malformed literal: 0b012
 
-Parse error at <interactive>:1:5--1:7
+Parse error at issue818.icry:2:5--2:7
   malformed literal: 2z
 
-Parse error at <interactive>:1:5--1:7
+Parse error at issue818.icry:3:5--3:7
   malformed literal: 2z

--- a/tests/issues/issue835.icry.stdout
+++ b/tests/issues/issue835.icry.stdout
@@ -2,8 +2,8 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module Float
 
-[error] at <interactive>:1:1--1:28:
+[error] at issue835.icry:2:4--2:31:
   • Type `Float 5 11` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:28
+      at issue835.icry:2:4--2:31

--- a/tests/issues/issue845.icry.stdout
+++ b/tests/issues/issue845.icry.stdout
@@ -26,36 +26,36 @@ Loading module Main
             at issue845.cry:2:9--2:17
 (ratio 1 2)
 
-[error] at <interactive>:1:1--1:9:
+[error] at issue845.icry:3:1--3:9:
   • `1/0` is not a valid literal of type `Rational`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:9
+      at issue845.icry:3:1--3:9
 
-[error] at <interactive>:1:1--1:9:
+[error] at issue845.icry:4:1--4:9:
   • `inf/2` is not a valid literal of type `Rational`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:9
+      at issue845.icry:4:1--4:9
 Loading module Cryptol
 Loading module Float
 0x0.8
 
-[error] at <interactive>:1:1--1:9:
+[error] at issue845.icry:7:1--7:9:
   • `1/0` is not a valid literal of type `Float64`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:9
+      at issue845.icry:7:1--7:9
 
-[error] at <interactive>:1:1--1:9:
+[error] at issue845.icry:8:1--8:9:
   • `inf/2` is not a valid literal of type `Float64`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:9
+      at issue845.icry:8:1--8:9
 0x0.2
 
-[error] at <interactive>:1:1--1:9:
+[error] at issue845.icry:10:1--10:9:
   • `1/10` is not a valid literal of type `Float 3 2`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:9
+      at issue845.icry:10:1--10:9

--- a/tests/issues/issue861.icry.stdout
+++ b/tests/issues/issue861.icry.stdout
@@ -4,26 +4,34 @@ Loading module Cryptol
 2
 
 invalid sequence index: 3
+at issue861.icry:7:1--7:5
 
 invalid sequence index: -1
+at issue861.icry:8:1--8:8
 2
 1
 0
 
 invalid sequence index: 3
+at issue861.icry:13:1--13:5
 
 invalid sequence index: -1
+at issue861.icry:14:1--14:8
 [5, 1, 2]
 [0, 5, 2]
 [0, 1, 5]
 
 invalid sequence index: 3
+at issue861.icry:19:1--19:7
 
 invalid sequence index: -1
+at issue861.icry:20:1--20:7
 [0, 1, 5]
 [0, 5, 2]
 [5, 1, 2]
 
 invalid sequence index: 3
+at issue861.icry:25:1--25:10
 
 invalid sequence index: -1
+at issue861.icry:26:1--26:10

--- a/tests/issues/issue910.icry.stdout
+++ b/tests/issues/issue910.icry.stdout
@@ -1,25 +1,25 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:1--1:21:
+[error] at issue910.icry:1:1--1:21:
   • `?a` is not an integral type.
       arising from
       use of expression (@)
-      at <interactive>:1:8--1:21
+      at issue910.icry:1:8--1:21
   • Type `?a` does not support field operations.
       arising from
       use of expression (/.)
-      at <interactive>:1:14--1:20
+      at issue910.icry:1:14--1:20
   where
-  ?a is type argument 'a' of '(/.)' at <interactive>:1:14--1:20
+  ?a is type argument 'a' of '(/.)' at issue910.icry:1:14--1:20
 
-[error] at <interactive>:1:1--1:16:
+[error] at issue910.icry:2:1--2:16:
   • `?a` is not an integral type.
       arising from
       use of expression (@)
-      at <interactive>:1:8--1:16
+      at issue910.icry:2:8--2:16
   • `6/5` is not a valid literal of type `?a`
       arising from
       use of fractional literal
-      at <interactive>:1:13--1:16
+      at issue910.icry:2:13--2:16
   where
-  ?a is type argument 'a' of 'fraction' at <interactive>:1:13--1:16
+  ?a is type argument 'a' of 'fraction' at issue910.icry:2:13--2:16

--- a/tests/issues/issue913.icry.stdout
+++ b/tests/issues/issue913.icry.stdout
@@ -4,9 +4,9 @@ False
 0x5b
 number`{rep = Bit} : {n} (1 >= n) => Bit
 
-[error] at <interactive>:1:1--1:2:
+[error] at issue913.icry:5:1--5:2:
   • Unsolvable constraint:
       1 >= 2
         arising from
         use of literal or demoted expression
-        at <interactive>:1:1--1:2
+        at issue913.icry:5:1--5:2

--- a/tests/regression/float.icry.stdout
+++ b/tests/regression/float.icry.stdout
@@ -44,19 +44,19 @@ Specifies the format to use when showing floating point numbers:
 IEEE-754 floating point numbers.
 
 
-[error] at <interactive>:1:1--1:17:
+[error] at float.icry:36:1--36:17:
   Unsolved constraints:
     • ValidFloat 0 0
         arising from
         use of partial type function Float
-        at <interactive>:1:1--1:17
+        at float.icry:36:1--36:17
 
-[error] at <interactive>:1:1--1:21:
+[error] at float.icry:37:1--37:21:
   Unsolved constraints:
     • ValidFloat 80 1000
         arising from
         use of partial type function Float
-        at <interactive>:1:1--1:21
+        at float.icry:37:1--37:21
 0x0.0p0
 0x0.0p0
 0x0.0p0
@@ -70,21 +70,21 @@ IEEE-754 floating point numbers.
 0x1.0p8
 0x4.0p0
 
-[error] at <interactive>:1:1--1:20:
+[error] at float.icry:53:1--53:20:
   • `5/1` is not a valid literal of type `Small`
       arising from
       use of fractional literal
-      at <interactive>:1:1--1:6
+      at float.icry:53:1--53:6
 0x1.3p0
 0x2.0p-4
 0x2.0p-4
 0x8.0p0
 
-[error] at <interactive>:1:1--1:2:
+[error] at float.icry:59:1--59:2:
   • `7` is not a valid literal of type `Small`
       arising from
       use of literal or demoted expression
-      at <interactive>:1:1--1:2
+      at float.icry:59:1--59:2
 "-- NaN------------------------------------------------------------------------"
 
     fpNaN : {e, p} (ValidFloat e p) => Float e p

--- a/tests/regression/instance.icry.stdout
+++ b/tests/regression/instance.icry.stdout
@@ -15,25 +15,25 @@ zero`{{x : _, y : _}} : {a, b} (Zero b, Zero a) => {x : a, y : b}
 zero`{Float _ _} : {n, m} (ValidFloat n m) => Float n m
 complement`{Bit} : Bit -> Bit
 
-[error] at <interactive>:1:1--1:11:
+[error] at instance.icry:16:4--16:14:
   • Type `Integer` does not support logical operations.
       arising from
       use of expression complement
-      at <interactive>:1:1--1:11
+      at instance.icry:16:4--16:14
 
-[error] at <interactive>:1:1--1:11:
+[error] at instance.icry:17:4--17:14:
   • Type `Rational` does not support logical operations.
       arising from
       use of expression complement
-      at <interactive>:1:1--1:11
+      at instance.icry:17:4--17:14
 
-[error] at <interactive>:1:1--1:11:
+[error] at instance.icry:18:4--18:14:
   • Type `Z ?m` does not support logical operations.
       arising from
       use of expression complement
-      at <interactive>:1:1--1:11
+      at instance.icry:18:4--18:14
   where
-  ?m is type wildcard (_) at <interactive>:1:15--1:16
+  ?m is type wildcard (_) at instance.icry:18:18--18:19
 complement`{[_]_} : {n, a} (Logic a) => [n]a -> [n]a
 complement`{(_ -> _)} : {a, b} (Logic b) => (a -> b) -> a -> b
 complement`{()} : () -> ()
@@ -42,20 +42,20 @@ complement`{{}} : {} -> {}
 complement`{{x : _, y : _}} : {a, b} (Logic b, Logic a) =>
                                 {x : a, y : b} -> {x : a, y : b}
 
-[error] at <interactive>:1:1--1:11:
+[error] at instance.icry:25:4--25:14:
   • Type `Float ?m ?n` does not support logical operations.
       arising from
       use of expression complement
-      at <interactive>:1:1--1:11
+      at instance.icry:25:4--25:14
   where
-  ?m is type wildcard (_) at <interactive>:1:19--1:20
-  ?n is type wildcard (_) at <interactive>:1:21--1:22
+  ?m is type wildcard (_) at instance.icry:25:22--25:23
+  ?n is type wildcard (_) at instance.icry:25:24--25:25
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:27:4--27:10:
   • Type `Bit` does not support ring operations.
       arising from
       use of expression negate
-      at <interactive>:1:1--1:7
+      at instance.icry:27:4--27:10
 negate`{Integer} : Integer -> Integer
 negate`{Rational} : Rational -> Rational
 negate`{Z _} : {n} (n >= 1, fin n) => Z n -> Z n
@@ -70,208 +70,208 @@ negate`{{x : _, y : _}} : {a, b} (Ring b, Ring a) =>
 negate`{Float _ _} : {n, m} (ValidFloat n m) =>
                        Float n m -> Float n m
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:40:4--40:7:
   • `Bit` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:40:4--40:7
 (%)`{Integer} : Integer -> Integer -> Integer
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:42:4--42:7:
   • `Rational` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:42:4--42:7
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:43:4--43:7:
   • `Z ?m` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:43:4--43:7
   where
-  ?m is type wildcard (_) at <interactive>:1:8--1:9
+  ?m is type wildcard (_) at instance.icry:43:11--43:12
 (%)`{[_]_} : {n, a} (Integral ([n]a)) => [n]a -> [n]a -> [n]a
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:45:4--45:7:
   • `?a -> ?b` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:45:4--45:7
   where
-  ?a is type wildcard (_) at <interactive>:1:7--1:8
-  ?b is type wildcard (_) at <interactive>:1:12--1:13
+  ?a is type wildcard (_) at instance.icry:45:10--45:11
+  ?b is type wildcard (_) at instance.icry:45:15--45:16
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:46:4--46:7:
   • `()` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:46:4--46:7
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:47:4--47:7:
   • `(?a, ?b)` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:47:4--47:7
   where
-  ?a is type wildcard (_) at <interactive>:1:7--1:8
-  ?b is type wildcard (_) at <interactive>:1:10--1:11
+  ?a is type wildcard (_) at instance.icry:47:10--47:11
+  ?b is type wildcard (_) at instance.icry:47:13--47:14
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:48:4--48:7:
   • `{}` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:48:4--48:7
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:49:4--49:7:
   • `{x : ?a, y : ?b}` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:49:4--49:7
   where
-  ?a is type wildcard (_) at <interactive>:1:11--1:12
-  ?b is type wildcard (_) at <interactive>:1:18--1:19
+  ?a is type wildcard (_) at instance.icry:49:14--49:15
+  ?b is type wildcard (_) at instance.icry:49:21--49:22
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:50:4--50:7:
   • `Float ?m ?n` is not an integral type.
       arising from
       use of expression (%)
-      at <interactive>:1:1--1:4
+      at instance.icry:50:4--50:7
   where
-  ?m is type wildcard (_) at <interactive>:1:12--1:13
-  ?n is type wildcard (_) at <interactive>:1:14--1:15
+  ?m is type wildcard (_) at instance.icry:50:15--50:16
+  ?n is type wildcard (_) at instance.icry:50:17--50:18
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:52:4--52:9:
   • Type `Bit` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:52:4--52:9
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:53:4--53:9:
   • Type `Integer` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:53:4--53:9
 recip`{Rational} : Rational -> Rational
 recip`{Z _} : {n} (prime n, n >= 1) => Z n -> Z n
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:56:4--56:9:
   • Type `[?m]?a` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:56:4--56:9
   where
-  ?m is type wildcard (_) at <interactive>:1:9--1:10
-  ?a is type wildcard (_) at <interactive>:1:11--1:12
+  ?m is type wildcard (_) at instance.icry:56:12--56:13
+  ?a is type wildcard (_) at instance.icry:56:14--56:15
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:57:4--57:9:
   • Type `?a -> ?b` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:57:4--57:9
   where
-  ?a is type wildcard (_) at <interactive>:1:9--1:10
-  ?b is type wildcard (_) at <interactive>:1:14--1:15
+  ?a is type wildcard (_) at instance.icry:57:12--57:13
+  ?b is type wildcard (_) at instance.icry:57:17--57:18
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:58:4--58:9:
   • Type `()` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:58:4--58:9
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:59:4--59:9:
   • Type `(?a, ?b)` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:59:4--59:9
   where
-  ?a is type wildcard (_) at <interactive>:1:9--1:10
-  ?b is type wildcard (_) at <interactive>:1:12--1:13
+  ?a is type wildcard (_) at instance.icry:59:12--59:13
+  ?b is type wildcard (_) at instance.icry:59:15--59:16
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:60:4--60:9:
   • Type `{}` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:60:4--60:9
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:61:4--61:9:
   • Type `{x : ?a, y : ?b}` does not support field operations.
       arising from
       use of expression recip
-      at <interactive>:1:1--1:6
+      at instance.icry:61:4--61:9
   where
-  ?a is type wildcard (_) at <interactive>:1:13--1:14
-  ?b is type wildcard (_) at <interactive>:1:20--1:21
+  ?a is type wildcard (_) at instance.icry:61:16--61:17
+  ?b is type wildcard (_) at instance.icry:61:23--61:24
 recip`{Float _ _} : {n, m} (ValidFloat n m) =>
                       Float n m -> Float n m
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:64:4--64:9:
   • Type `Bit` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:64:4--64:9
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:65:4--65:9:
   • Type `Integer` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:65:4--65:9
 floor`{Rational} : Rational -> Integer
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:67:4--67:9:
   • Type `Z ?m` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:67:4--67:9
   where
-  ?m is type wildcard (_) at <interactive>:1:10--1:11
+  ?m is type wildcard (_) at instance.icry:67:13--67:14
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:68:4--68:9:
   • Type `[?m]?a` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:68:4--68:9
   where
-  ?m is type wildcard (_) at <interactive>:1:9--1:10
-  ?a is type wildcard (_) at <interactive>:1:11--1:12
+  ?m is type wildcard (_) at instance.icry:68:12--68:13
+  ?a is type wildcard (_) at instance.icry:68:14--68:15
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:69:4--69:9:
   • Type `?a -> ?b` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:69:4--69:9
   where
-  ?a is type wildcard (_) at <interactive>:1:9--1:10
-  ?b is type wildcard (_) at <interactive>:1:14--1:15
+  ?a is type wildcard (_) at instance.icry:69:12--69:13
+  ?b is type wildcard (_) at instance.icry:69:17--69:18
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:70:4--70:9:
   • Type `()` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:70:4--70:9
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:71:4--71:9:
   • Type `(?a, ?b)` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:71:4--71:9
   where
-  ?a is type wildcard (_) at <interactive>:1:9--1:10
-  ?b is type wildcard (_) at <interactive>:1:12--1:13
+  ?a is type wildcard (_) at instance.icry:71:12--71:13
+  ?b is type wildcard (_) at instance.icry:71:15--71:16
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:72:4--72:9:
   • Type `{}` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:72:4--72:9
 
-[error] at <interactive>:1:1--1:6:
+[error] at instance.icry:73:4--73:9:
   • Type `{x : ?a, y : ?b}` does not support rounding operations.
       arising from
       use of expression floor
-      at <interactive>:1:1--1:6
+      at instance.icry:73:4--73:9
   where
-  ?a is type wildcard (_) at <interactive>:1:13--1:14
-  ?b is type wildcard (_) at <interactive>:1:20--1:21
+  ?a is type wildcard (_) at instance.icry:73:16--73:17
+  ?b is type wildcard (_) at instance.icry:73:23--73:24
 floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 (==)`{Bit} : Bit -> Bit -> Bit
 (==)`{Integer} : Integer -> Integer -> Bit
@@ -279,14 +279,14 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 (==)`{Z _} : {n} (n >= 1, fin n) => Z n -> Z n -> Bit
 (==)`{[_]_} : {n, a} (Eq a, fin n) => [n]a -> [n]a -> Bit
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:81:4--81:8:
   • Type `?a -> ?b` does not support equality.
       arising from
       use of expression (==)
-      at <interactive>:1:1--1:5
+      at instance.icry:81:4--81:8
   where
-  ?a is type wildcard (_) at <interactive>:1:8--1:9
-  ?b is type wildcard (_) at <interactive>:1:13--1:14
+  ?a is type wildcard (_) at instance.icry:81:11--81:12
+  ?b is type wildcard (_) at instance.icry:81:16--81:17
 (==)`{()} : () -> () -> Bit
 (==)`{(_, _)} : {a, b} (Eq b, Eq a) => (a, b) -> (a, b) -> Bit
 (==)`{{}} : {} -> {} -> Bit
@@ -298,23 +298,23 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 (<)`{Integer} : Integer -> Integer -> Bit
 (<)`{Rational} : Rational -> Rational -> Bit
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:91:4--91:7:
   • Type `Z ?m` does not support comparisons.
       arising from
       use of expression (<)
-      at <interactive>:1:1--1:4
+      at instance.icry:91:4--91:7
   where
-  ?m is type wildcard (_) at <interactive>:1:8--1:9
+  ?m is type wildcard (_) at instance.icry:91:11--91:12
 (<)`{[_]_} : {n, a} (Cmp a, fin n) => [n]a -> [n]a -> Bit
 
-[error] at <interactive>:1:1--1:4:
+[error] at instance.icry:93:4--93:7:
   • Type `?a -> ?b` does not support comparisons.
       arising from
       use of expression (<)
-      at <interactive>:1:1--1:4
+      at instance.icry:93:4--93:7
   where
-  ?a is type wildcard (_) at <interactive>:1:7--1:8
-  ?b is type wildcard (_) at <interactive>:1:12--1:13
+  ?a is type wildcard (_) at instance.icry:93:10--93:11
+  ?b is type wildcard (_) at instance.icry:93:15--93:16
 (<)`{()} : () -> () -> Bit
 (<)`{(_, _)} : {a, b} (Cmp b, Cmp a) => (a, b) -> (a, b) -> Bit
 (<)`{{}} : {} -> {} -> Bit
@@ -323,41 +323,41 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 (<)`{Float _ _} : {n, m} (ValidFloat n m) =>
                     Float n m -> Float n m -> Bit
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:100:4--100:8:
   • Type `Bit` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:5
+      at instance.icry:100:4--100:8
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:101:4--101:8:
   • Type `Integer` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:5
+      at instance.icry:101:4--101:8
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:102:4--102:8:
   • Type `Rational` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:5
+      at instance.icry:102:4--102:8
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:103:4--103:8:
   • Type `Z ?m` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:5
+      at instance.icry:103:4--103:8
   where
-  ?m is type wildcard (_) at <interactive>:1:9--1:10
+  ?m is type wildcard (_) at instance.icry:103:12--103:13
 (<$)`{[_]_} : {n, a} (SignedCmp ([n]a)) => [n]a -> [n]a -> Bit
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:105:4--105:8:
   • Type `?a -> ?b` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:5
+      at instance.icry:105:4--105:8
   where
-  ?a is type wildcard (_) at <interactive>:1:8--1:9
-  ?b is type wildcard (_) at <interactive>:1:13--1:14
+  ?a is type wildcard (_) at instance.icry:105:11--105:12
+  ?b is type wildcard (_) at instance.icry:105:16--105:17
 (<$)`{()} : () -> () -> Bit
 (<$)`{(_, _)} : {a, b} (SignedCmp b, SignedCmp a) =>
                   (a, b) -> (a, b) -> Bit
@@ -365,70 +365,70 @@ floor`{Float _ _} : {n, m} (ValidFloat n m) => Float n m -> Integer
 (<$)`{{x : _, y : _}} : {a, b} (SignedCmp b, SignedCmp a) =>
                           {x : a, y : b} -> {x : a, y : b} -> Bit
 
-[error] at <interactive>:1:1--1:5:
+[error] at instance.icry:110:4--110:8:
   • Type `Float ?m ?n` does not support signed comparisons.
       arising from
       use of expression (<$)
-      at <interactive>:1:1--1:5
+      at instance.icry:110:4--110:8
   where
-  ?m is type wildcard (_) at <interactive>:1:13--1:14
-  ?n is type wildcard (_) at <interactive>:1:15--1:16
+  ?m is type wildcard (_) at instance.icry:110:16--110:17
+  ?n is type wildcard (_) at instance.icry:110:18--110:19
 number`{rep = Bit} : {n} (1 >= n) => Bit
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:113:4--113:10:
   Ambiguous numeric type: type argument 'val' of 'number'
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:114:4--114:10:
   Ambiguous numeric type: type argument 'val' of 'number'
 number`{rep = Z _} : {n, m} (m >= 1 + n, m >= 1, fin m, fin n) =>
                        Z m
 number`{rep = [_]_} : {n, m} (m >= width n, fin m, fin n) => [m]
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:117:4--117:10:
   • `?m` is not a valid literal of type `?a -> ?b`
       arising from
       use of literal or demoted expression
-      at <interactive>:1:1--1:7
+      at instance.icry:117:4--117:10
   where
-  ?m is type argument 'val' of 'number' at <interactive>:1:1--1:7
-  ?a is type wildcard (_) at <interactive>:1:15--1:16
-  ?b is type wildcard (_) at <interactive>:1:20--1:21
+  ?m is type argument 'val' of 'number' at instance.icry:117:4--117:10
+  ?a is type wildcard (_) at instance.icry:117:18--117:19
+  ?b is type wildcard (_) at instance.icry:117:23--117:24
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:118:4--118:10:
   • `?m` is not a valid literal of type `()`
       arising from
       use of literal or demoted expression
-      at <interactive>:1:1--1:7
+      at instance.icry:118:4--118:10
   where
-  ?m is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?m is type argument 'val' of 'number' at instance.icry:118:4--118:10
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:119:4--119:10:
   • `?m` is not a valid literal of type `(?a, ?b)`
       arising from
       use of literal or demoted expression
-      at <interactive>:1:1--1:7
+      at instance.icry:119:4--119:10
   where
-  ?m is type argument 'val' of 'number' at <interactive>:1:1--1:7
-  ?a is type wildcard (_) at <interactive>:1:16--1:17
-  ?b is type wildcard (_) at <interactive>:1:19--1:20
+  ?m is type argument 'val' of 'number' at instance.icry:119:4--119:10
+  ?a is type wildcard (_) at instance.icry:119:19--119:20
+  ?b is type wildcard (_) at instance.icry:119:22--119:23
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:120:4--120:10:
   • `?m` is not a valid literal of type `{}`
       arising from
       use of literal or demoted expression
-      at <interactive>:1:1--1:7
+      at instance.icry:120:4--120:10
   where
-  ?m is type argument 'val' of 'number' at <interactive>:1:1--1:7
+  ?m is type argument 'val' of 'number' at instance.icry:120:4--120:10
 
-[error] at <interactive>:1:1--1:7:
+[error] at instance.icry:121:4--121:10:
   • `?m` is not a valid literal of type `{x : ?a, y : ?b}`
       arising from
       use of literal or demoted expression
-      at <interactive>:1:1--1:7
+      at instance.icry:121:4--121:10
   where
-  ?m is type argument 'val' of 'number' at <interactive>:1:1--1:7
-  ?a is type wildcard (_) at <interactive>:1:20--1:21
-  ?b is type wildcard (_) at <interactive>:1:27--1:28
+  ?m is type argument 'val' of 'number' at instance.icry:121:4--121:10
+  ?a is type wildcard (_) at instance.icry:121:23--121:24
+  ?b is type wildcard (_) at instance.icry:121:30--121:31
 number`{rep = Float _ _} : {n, m, i} (ValidFloat m i,
                                       Literal n (Float m i)) =>
                              Float m i

--- a/tests/regression/primes.icry.stdout
+++ b/tests/regression/primes.icry.stdout
@@ -48,19 +48,19 @@ Expected test coverage: 0.00% (100 of 2^^1042 values)
 1
 1
 
-[error] at <interactive>:1:1--1:8:
+[error] at primes.icry:9:1--9:8:
   • Unsolvable constraint:
       prime 8
         arising from
         use of expression z1prime
-        at <interactive>:1:1--1:8
+        at primes.icry:9:1--9:8
 
-[error] at <interactive>:1:1--1:8:
+[error] at primes.icry:10:1--10:8:
   • Unsolvable constraint:
       prime 43091033305484275771318189120554014028061750499173210735564075069516863836988716943216254409932734872431737796205873180054667648466751626159946491190398490019830895369540999907009814461968819338016648922197947056129
         arising from
         use of expression z1prime
-        at <interactive>:1:1--1:8
+        at primes.icry:10:1--10:8
 Q.E.D.
 Q.E.D.
 Q.E.D.

--- a/tests/regression/repeatFields.icry.stdout
+++ b/tests/regression/repeatFields.icry.stdout
@@ -1,10 +1,10 @@
 Loading module Cryptol
 
-Parse error at <interactive>:1:22--1:23
+Parse error at repeatFields.icry:1:22--1:23
   Record has repeated field: a
 
-Parse error at <interactive>:1:22--1:23
+Parse error at repeatFields.icry:3:22--3:23
   Record has repeated field: b
 
-Parse error at <interactive>:1:16--1:17
+Parse error at repeatFields.icry:5:16--5:17
   Record has repeated field: c

--- a/tests/regression/safety.icry.stdout
+++ b/tests/regression/safety.icry.stdout
@@ -1,10 +1,16 @@
 Loading module Cryptol
 Counterexample
 (\x -> assert x "asdf" "asdf") False ~> ERROR
+Run-time error: asdf
+at Cryptol:959:41--959:46
 Counterexample
 (\(x : [4]) -> [0 .. 14] @ x == x) 0xf ~> ERROR
+invalid sequence index: 15
+at safety.icry:4:20--4:34
 Counterexample
 (\y -> (10 : Integer) / y) 0 ~> ERROR
+division by 0
+at safety.icry:5:14--5:30
 Safe
 Safe
 Safe

--- a/tests/regression/tc-errors.icry.stdout
+++ b/tests/regression/tc-errors.icry.stdout
@@ -1,42 +1,42 @@
 Loading module Cryptol
 
-[error] at <interactive>:1:8--1:15:
+[error] at tc-errors.icry:1:8--1:15:
   Incorrect type form.
     Expected: a numeric type
     Inferred: a value type
 
-[error] at <interactive>:1:12--1:17:
+[error] at tc-errors.icry:2:12--2:17:
   Malformed type.
     Kind '*' is not a function,
     but it was applied to 1 parameter.
 
-[error] at <interactive>:1:3--1:6:
+[error] at tc-errors.icry:3:3--3:6:
   Ambiguous numeric type: type argument 'n' of '(@)'
   Must be at least: 1
 
-[error] at <interactive>:1:9--1:10:
+[error] at tc-errors.icry:4:9--4:10:
   Matching would result in an infinite type.
     The type:  ?b
     occurs in: ?b -> ?a
     When checking type of function argument
   where
-  ?a is type of function result at <interactive>:1:1--1:10
-  ?b is type of function argument at <interactive>:1:7--1:10
+  ?a is type of function result at tc-errors.icry:4:1--4:10
+  ?b is type of function argument at tc-errors.icry:4:7--4:10
 
-[error] at <interactive>:1:1--1:5:
+[error] at tc-errors.icry:5:1--5:5:
   • Unsolvable constraint:
       fin inf
         arising from
         use of expression take
-        at <interactive>:1:1--1:5
+        at tc-errors.icry:5:1--5:5
 
-Parse error at <interactive>:1:8,
+Parse error at tc-errors.icry:6:8,
   unexpected: ,
 
-[error] at <interactive>:1:1--1:5:
+[error] at tc-errors.icry:7:1--7:5:
   Named and positional type applications may not be mixed.
 
-[error] at <interactive>:1:1--1:5:
+[error] at tc-errors.icry:8:1--8:5:
   Type mismatch:
     Expected type: Integer
     Inferred type: Bit


### PR DESCRIPTION
Retain source position information into the typechecked AST (for expressions) and use this information to print location information for runtime errors.