### PR TITLE
Refactor evopts

### DIFF
--- a/cryptol-remote-api/cryptol-eval-server/Main.hs
+++ b/cryptol-remote-api/cryptol-eval-server/Main.hs
@@ -39,7 +39,7 @@ main = customMain initMod initMod initMod description buildApp
       do paths <- getSearchPaths
          initSt <- setSearchPath paths <$> initialState
          let menv = view moduleEnv initSt
-         let minp = ModuleInput False evOpts reader menv
+         let minp = ModuleInput False (pure evOpts) reader menv
          let die =
                \err ->
                  do hPutStrLn stderr $ "Failed to load " ++ either ("file " ++) (("module " ++) . show) file ++ ":\n" ++ show err

--- a/cryptol-remote-api/src/CryptolServer.hs
+++ b/cryptol-remote-api/src/CryptolServer.hs
@@ -10,7 +10,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Reader (ReaderT(ReaderT))
 import qualified Data.Aeson as JSON
 
-import Cryptol.Eval (EvalOpts)
+import Cryptol.Eval (EvalOpts(..))
 import Cryptol.ModuleSystem (ModuleCmd, ModuleEnv, ModuleInput(..))
 import Cryptol.ModuleSystem.Env
   (getLoadedModules, lmFilePath, lmFingerprint, meLoadedModules,

--- a/cryptol-remote-api/src/CryptolServer.hs
+++ b/cryptol-remote-api/src/CryptolServer.hs
@@ -61,7 +61,7 @@ runModuleCmd cmd =
        reader <- CryptolMethod $ const Argo.getFileReader
        let minp = ModuleInput
                   { minpCallStacks = callStacks
-                  , minpEvalOpts   = evOpts
+                  , minpEvalOpts   = pure evOpts
                   , minpByteReader = reader
                   , minpModuleEnv  = view moduleEnv s
                   }

--- a/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
+++ b/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module CryptolServer.EvalExpr (evalExpression, evalExpression', EvalExprParams(..)) where
 
-import Control.Lens hiding ((.=))
 import Control.Monad.IO.Class
 import Data.Aeson as JSON
 
@@ -42,10 +41,8 @@ evalExpression' e =
          do -- TODO: warnDefaults here
             let su = listParamSubst tys
             let theType = apSubst su (sType schema)
-            evOpts <- getEvalOpts
             res <- runModuleCmd (evalExpr checked)
-            prims <- runModuleCmd getPrimMap
-            val <- observe $ readBack evOpts prims theType res
+            val <- observe $ readBack theType res
             return (JSON.object [ "value" .= val
                                 , "type string" .= pretty theType
                                 , "type" .= JSONSchema (Forall [] [] theType)

--- a/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
+++ b/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
@@ -5,7 +5,7 @@ import Control.Monad.IO.Class
 import Data.Aeson as JSON
 
 
-import Cryptol.ModuleSystem (checkExpr, evalExpr, getPrimMap)
+import Cryptol.ModuleSystem (checkExpr, evalExpr)
 import Cryptol.ModuleSystem.Env (meSolverConfig)
 import Cryptol.TypeCheck.Solve (defaultReplExpr)
 import Cryptol.TypeCheck.Subst (apSubst, listParamSubst)

--- a/cryptol-remote-api/src/CryptolServer/Options.hs
+++ b/cryptol-remote-api/src/CryptolServer/Options.hs
@@ -6,9 +6,10 @@ module CryptolServer.Options (Options(..), WithOptions(..)) where
 import Data.Aeson hiding (Options)
 import qualified Data.HashMap.Strict as HM
 
-import Cryptol.Backend.Monad (EvalOpts(..), PPOpts(..), PPFloatFormat(..), PPFloatExp(..))
+import Cryptol.Eval(EvalOpts(..))
 import Cryptol.REPL.Monad (parsePPFloatFormat)
 import Cryptol.Utils.Logger (quietLogger)
+import Cryptol.Utils.PP (PPOpts(..), PPFloatFormat(..), PPFloatExp(..))
 
 data Options = Options { optCallStacks :: Bool, optEvalOpts :: EvalOpts }
 

--- a/cryptol-remote-api/src/CryptolServer/Sat.hs
+++ b/cryptol-remote-api/src/CryptolServer/Sat.hs
@@ -5,7 +5,6 @@
 module CryptolServer.Sat (sat, ProveSatParams(..)) where
 
 import Control.Applicative
-import Control.Lens hiding ((.=))
 import Control.Monad.IO.Class
 import Data.Aeson ((.=), (.:), FromJSON, ToJSON)
 import qualified Data.Aeson as JSON
@@ -15,7 +14,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 
 import Cryptol.Eval.Concrete (Value)
-import Cryptol.ModuleSystem (checkExpr, getPrimMap)
+import Cryptol.ModuleSystem (checkExpr)
 import Cryptol.ModuleSystem.Env (DynamicEnv(..), meDynEnv, meSolverConfig)
 import Cryptol.Symbolic (ProverCommand(..), ProverResult(..), QueryType(..), SatNum(..))
 import Cryptol.Symbolic.SBV (proverNames, satProve, setupProver)
@@ -73,9 +72,7 @@ sat (ProveSatParams (Prover name) jsonExpr num) =
     satResult es = traverse result es
 
     result (t, _, v) =
-      do evalOpts <- getEvalOpts
-         prims <- runModuleCmd getPrimMap
-         e <- observe $ readBack evalOpts prims t v
+      do e <- observe $ readBack t v
          return (JSONType mempty t, e)
 
 data SatResult = Unsatisfiable | Satisfied [[(JSONType, Expression)]]

--- a/src/Cryptol/Backend/Concrete.hs
+++ b/src/Cryptol/Backend/Concrete.hs
@@ -165,15 +165,6 @@ instance Backend Concrete where
   sModifyCallStack _ f m = modifyCallStack f m
   sGetCallStack _ = getCallStack
 
-  ppBit _ b | b         = text "True"
-            | otherwise = text "False"
-
-  ppWord _ = ppBV
-
-  ppInteger _ _opts i = integer i
-
-  ppFloat _ = FP.fpPP
-
   bitLit _ b = b
   bitAsLit _ b = Just b
 
@@ -335,6 +326,7 @@ instance Backend Concrete where
   ------------------------------------------------------------------------
   -- Floating Point
   fpLit _sym e p rat     = pure (FP.fpLit e p rat)
+  fpAsLit _ f            = Just f
   fpExactLit _sym bf     = pure bf
   fpEq _sym x y          = pure (FP.bfValue x == FP.bfValue y)
   fpLogicalEq _sym x y   = pure (FP.bfCompare (FP.bfValue x) (FP.bfValue y) == EQ)
@@ -395,5 +387,3 @@ fpRoundMode sym w =
   case FP.fpRound (bvVal w) of
     Left err -> raiseError sym err
     Right a  -> pure a
-
-

--- a/src/Cryptol/Backend/FloatHelpers.hs
+++ b/src/Cryptol/Backend/FloatHelpers.hs
@@ -9,9 +9,7 @@ import LibBF
 
 import Cryptol.Utils.PP
 import Cryptol.Utils.Panic(panic)
-import Cryptol.Backend.Monad( EvalError(..)
-                         , PPOpts(..), PPFloatFormat(..), PPFloatExp(..)
-                         )
+import Cryptol.Backend.Monad( EvalError(..) )
 
 
 data BF = BF

--- a/src/Cryptol/Backend/Monad.hs
+++ b/src/Cryptol/Backend/Monad.hs
@@ -16,7 +16,6 @@ module Cryptol.Backend.Monad
 ( -- * Evaluation monad
   Eval(..)
 , runEval
-, EvalOpts(..)
 , io
 , delayFill
 , ready
@@ -55,18 +54,11 @@ import qualified Control.Exception as X
 import Cryptol.Parser.Position
 import Cryptol.Utils.Panic
 import Cryptol.Utils.PP
-import Cryptol.Utils.Logger(Logger)
 import Cryptol.TypeCheck.AST(Name)
 
 -- | A computation that returns an already-evaluated value.
 ready :: a -> Eval a
 ready a = Ready a
-
--- | Some options for evaluation
-data EvalOpts = EvalOpts
-  { evalLogger :: Logger    -- ^ Where to print stuff (e.g., for @trace@)
-  , evalPPOpts :: PPOpts    -- ^ How to pretty print things.
-  }
 
 
 -- | The type of dynamic call stacks for the interpreter.

--- a/src/Cryptol/Backend/Monad.hs
+++ b/src/Cryptol/Backend/Monad.hs
@@ -1,6 +1,6 @@
 -- |
--- Module      :  Cryptol.Eval.Monad
--- Copyright   :  (c) 2013-2016 Galois, Inc.
+-- Module      :  Cryptol.Backend.Monad
+-- Copyright   :  (c) 2013-2020 Galois, Inc.
 -- License     :  BSD3
 -- Maintainer  :  cryptol@galois.com
 -- Stability   :  provisional

--- a/src/Cryptol/Backend/Monad.hs
+++ b/src/Cryptol/Backend/Monad.hs
@@ -17,11 +17,6 @@ module Cryptol.Backend.Monad
   Eval(..)
 , runEval
 , EvalOpts(..)
-, PPOpts(..)
-, asciiMode
-, PPFloatFormat(..)
-, PPFloatExp(..)
-, defaultPPOpts
 , io
 , delayFill
 , ready
@@ -66,34 +61,6 @@ import Cryptol.TypeCheck.AST(Name)
 -- | A computation that returns an already-evaluated value.
 ready :: a -> Eval a
 ready a = Ready a
-
--- | How to pretty print things when evaluating
-data PPOpts = PPOpts
-  { useAscii     :: Bool
-  , useBase      :: Int
-  , useInfLength :: Int
-  , useFPBase    :: Int
-  , useFPFormat  :: PPFloatFormat
-  }
-
-asciiMode :: PPOpts -> Integer -> Bool
-asciiMode opts width = useAscii opts && (width == 7 || width == 8)
-
-data PPFloatFormat =
-    FloatFixed Int PPFloatExp -- ^ Use this many significant digits
-  | FloatFrac Int             -- ^ Show this many digits after floating point
-  | FloatFree PPFloatExp      -- ^ Use the correct number of digits
-
-data PPFloatExp = ForceExponent -- ^ Always show an exponent
-                | AutoExponent  -- ^ Only show exponent when needed
-
-
-defaultPPOpts :: PPOpts
-defaultPPOpts = PPOpts { useAscii = False, useBase = 10, useInfLength = 5
-                       , useFPBase = 16
-                       , useFPFormat = FloatFree AutoExponent
-                       }
-
 
 -- | Some options for evaluation
 data EvalOpts = EvalOpts

--- a/src/Cryptol/Backend/SBV.hs
+++ b/src/Cryptol/Backend/SBV.hs
@@ -44,7 +44,7 @@ import Data.SBV.Dynamic as SBV
 import qualified Data.SBV.Internals as SBV
 
 import Cryptol.Backend
-import Cryptol.Backend.Concrete ( integerToChar, ppBV, BV(..) )
+import Cryptol.Backend.Concrete ( integerToChar )
 import Cryptol.Backend.Monad
   ( Eval(..), blackhole, delayFill, evalSpark
   , EvalError(..), EvalErrorEx(..), Unsupported(..)
@@ -52,7 +52,6 @@ import Cryptol.Backend.Monad
   )
 
 import Cryptol.Utils.Panic (panic)
-import Cryptol.Utils.PP
 
 data SBV =
   SBV
@@ -203,16 +202,6 @@ instance Backend SBV where
   wordLen _ v = toInteger (intSizeOf v)
   wordAsChar _ v = integerToChar <$> svAsInteger v
 
-  ppBit _ v
-     | Just b <- svAsBool v = text $! if b then "True" else "False"
-     | otherwise            = text "?"
-  ppWord sym opts v
-     | Just x <- svAsInteger v = ppBV opts (BV (wordLen sym v) x)
-     | otherwise               = text "[?]"
-  ppInteger _ _opts v
-     | Just x <- svAsInteger v = integer x
-     | otherwise               = text "[?]"
-
   iteBit _ b x y = pure $! svSymbolicMerge KBool True b x y
   iteWord _ b x y = pure $! svSymbolicMerge (kindOf x) True b x y
   iteInteger _ b x y = pure $! svSymbolicMerge KUnbounded True b x y
@@ -335,7 +324,7 @@ instance Backend SBV where
   znNegate sym m a  = sModNegate sym m a
   znRecip = sModRecip
 
-  ppFloat _ _ _             = text "[?]"
+  fpAsLit _ _               = Nothing
   fpExactLit _ _            = unsupported "fpExactLit"
   fpLit _ _ _ _             = unsupported "fpLit"
   fpLogicalEq _ _ _         = unsupported "fpLogicalEq"

--- a/src/Cryptol/Backend/What4.hs
+++ b/src/Cryptol/Backend/What4.hs
@@ -36,7 +36,6 @@ import qualified What4.SWord as SW
 import qualified Cryptol.Backend.What4.SFloat as FP
 
 import Cryptol.Backend
-import Cryptol.Backend.Concrete( BV(..), ppBV )
 import Cryptol.Backend.FloatHelpers
 import Cryptol.Backend.Monad
    ( Eval(..), EvalError(..), EvalErrorEx(..)
@@ -44,7 +43,6 @@ import Cryptol.Backend.Monad
    , modifyCallStack, getCallStack
    )
 import Cryptol.Utils.Panic
-import Cryptol.Utils.PP
 
 
 data What4 sym =
@@ -295,22 +293,6 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
 
   integerAsLit _ v = W4.asInteger v
 
-  ppBit _ v
-    | Just b <- W4.asConstantPred v = text $! if b then "True" else "False"
-    | otherwise                     = text "?"
-
-  ppWord _ opts v
-    | Just x <- SW.bvAsUnsignedInteger v
-    = ppBV opts (BV (SW.bvWidth v) x)
-
-    | otherwise = text "[?]"
-
-  ppInteger _ _opts v
-    | Just x <- W4.asInteger v = integer x
-    | otherwise = text "[?]"
-
-  ppFloat _ _opts _ = text "[?]"
-
   iteBit sym c x y = liftIO (W4.itePred (w4 sym) c x y)
   iteWord sym c x y = liftIO (SW.bvIte (w4 sym) c x y)
   iteInteger sym c x y = liftIO (W4.intIte (w4 sym) c x y)
@@ -450,6 +432,7 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
   --------------------------------------------------------------
 
   fpLit sym e p r = liftIO $ FP.fpFromRationalLit (w4 sym) e p r
+  fpAsLit _ _ = Nothing -- TODO
 
   fpExactLit sym BF{ bfExpWidth = e, bfPrecWidth = p, bfValue = bf } =
     liftIO (FP.fpFromBinary (w4 sym) e p =<< SW.bvLit (w4 sym) (e+p) (floatToBits e p bf))

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -577,7 +577,6 @@ evalDecl sym renv env d =
 -- Selectors -------------------------------------------------------------------
 
 {-# SPECIALIZE evalSel ::
-  (?range :: Range, ConcPrims) =>
   Concrete ->
   GenValue Concrete ->
   Selector ->
@@ -588,7 +587,7 @@ evalDecl sym renv env d =
 --   tuple and record selections pointwise down into other value constructs
 --   (e.g., streams and functions).
 evalSel ::
-  (?range :: Range, EvalPrims sym) =>
+  Backend sym =>
   sym ->
   GenValue sym ->
   Selector ->
@@ -626,12 +625,11 @@ evalSel sym val sel = case sel of
                               [ "Unexpected value in list selection"
                               , show vdoc ]
 {-# SPECIALIZE evalSetSel ::
-  (?range :: Range, ConcPrims) =>
   Concrete -> TValue ->
   GenValue Concrete -> Selector -> SEval Concrete (GenValue Concrete) -> SEval Concrete (GenValue Concrete)
   #-}
 evalSetSel :: forall sym.
-  (?range :: Range, EvalPrims sym) =>
+  Backend sym =>
   sym ->
   TValue ->
   GenValue sym -> Selector -> SEval sym (GenValue sym) -> SEval sym (GenValue sym)

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -140,8 +140,8 @@ floatToExpr prims eT pT f =
 
 -- Primitives ------------------------------------------------------------------
 
-primTable :: EvalOpts -> Map PrimIdent (Prim Concrete)
-primTable eOpts = let sym = Concrete in
+primTable :: IO EvalOpts -> Map PrimIdent (Prim Concrete)
+primTable getEOpts = let sym = Concrete in
   Map.union (genericPrimTable sym) $
   Map.union (floatPrims sym) $
   Map.union suiteBPrims $
@@ -183,7 +183,7 @@ primTable eOpts = let sym = Concrete in
                      PFun     \y ->
                      PPrim
                       do msg <- valueToString sym =<< s
-                         let EvalOpts { evalPPOpts, evalLogger } = eOpts
+                         EvalOpts { evalPPOpts, evalLogger } <- io getEOpts
                          doc <- ppValue sym evalPPOpts =<< x
                          io $ logPrint evalLogger
                              $ if null msg then doc else text msg <+> doc

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -55,7 +55,6 @@ import Cryptol.TypeCheck.AST as AST
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.Ident (PrimIdent,prelPrim,floatPrim,suiteBPrim,primeECPrim)
 import Cryptol.Utils.PP
-import Cryptol.Utils.Logger(logPrint)
 import Cryptol.Utils.RecordMap
 
 type Value = GenValue Concrete
@@ -142,7 +141,7 @@ floatToExpr prims eT pT f =
 
 primTable :: IO EvalOpts -> Map PrimIdent (Prim Concrete)
 primTable getEOpts = let sym = Concrete in
-  Map.union (genericPrimTable sym) $
+  Map.union (genericPrimTable sym getEOpts) $
   Map.union (floatPrims sym) $
   Map.union suiteBPrims $
   Map.union primeECPrims $
@@ -173,21 +172,6 @@ primTable getEOpts = let sym = Concrete in
 
   , ("updateEnd"  , {-# SCC "Prelude::updateEnd" #-}
                     updatePrim sym updateBack_word updateBack)
-
-  , ("trace"       , {-# SCC "Prelude::trace" #-}
-                     PNumPoly \_n ->
-                     PTyPoly  \_a ->
-                     PTyPoly  \_b ->
-                     PFun     \s ->
-                     PFun     \x ->
-                     PFun     \y ->
-                     PPrim
-                      do msg <- valueToString sym =<< s
-                         EvalOpts { evalPPOpts, evalLogger } <- io getEOpts
-                         doc <- ppValue sym evalPPOpts =<< x
-                         io $ logPrint evalLogger
-                             $ if null msg then doc else text msg <+> doc
-                         y)
 
    , ("pmult",
         PFinPoly \u ->

--- a/src/Cryptol/Eval/Env.hs
+++ b/src/Cryptol/Eval/Env.hs
@@ -16,8 +16,6 @@ module Cryptol.Eval.Env where
 
 import Cryptol.Backend
 
-import Cryptol.Backend.Monad( PPOpts )
-
 import Cryptol.Eval.Prims
 import Cryptol.Eval.Type
 import Cryptol.Eval.Value
@@ -25,7 +23,6 @@ import Cryptol.ModuleSystem.Name
 import Cryptol.TypeCheck.AST
 import Cryptol.TypeCheck.Solver.InfNat
 import Cryptol.Utils.PP
-
 
 import qualified Data.IntMap.Strict as IntMap
 import Data.Semigroup

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -37,7 +37,7 @@ import Cryptol.TypeCheck.AST
 import Cryptol.TypeCheck.Solver.InfNat (Nat'(..),nMul,widthInteger)
 import Cryptol.Backend
 import Cryptol.Backend.Concrete (Concrete(..))
-import Cryptol.Backend.Monad ( Eval, evalPanic, EvalError(..), Unsupported(..), EvalOpts(..) )
+import Cryptol.Backend.Monad( Eval, evalPanic, EvalError(..), Unsupported(..) )
 import Cryptol.Testing.Random( randomValue )
 
 import Cryptol.Eval.Prims

--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -39,7 +39,7 @@
 > import Cryptol.TypeCheck.AST
 > import Cryptol.Backend.FloatHelpers (BF(..))
 > import qualified Cryptol.Backend.FloatHelpers as FP
-> import Cryptol.Backend.Monad (EvalError(..), PPOpts(..))
+> import Cryptol.Backend.Monad (EvalError(..))
 > import Cryptol.Eval.Type (TValue(..), isTBit, evalValType, evalNumType, TypeEnv)
 > import Cryptol.Eval.Concrete (mkBv, ppBV, lg2)
 > import Cryptol.Utils.Ident (Ident,PrimIdent, prelPrim, floatPrim)

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -30,7 +30,7 @@ import qualified Data.Text as T
 import Data.SBV.Dynamic as SBV
 
 import Cryptol.Backend
-import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..), EvalOpts )
+import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..) )
 import Cryptol.Backend.SBV
 
 import Cryptol.Eval.Type (TValue(..))

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -30,6 +30,8 @@ module Cryptol.Eval.Value
   , forceValue
   , Backend(..)
   , asciiMode
+
+  , EvalOpts(..)
     -- ** Value introduction operations
   , word
   , lam
@@ -108,6 +110,7 @@ import Cryptol.Eval.Type
 
 import Cryptol.TypeCheck.Solver.InfNat(Nat'(..))
 import Cryptol.Utils.Ident (Ident)
+import Cryptol.Utils.Logger(Logger)
 import Cryptol.Utils.Panic(panic)
 import Cryptol.Utils.PP
 import Cryptol.Utils.RecordMap
@@ -115,6 +118,12 @@ import Cryptol.Utils.RecordMap
 import Data.List(genericIndex)
 
 import GHC.Generics (Generic)
+
+-- | Some options for evalutaion
+data EvalOpts = EvalOpts
+  { evalLogger :: Logger    -- ^ Where to print stuff (e.g., for @trace@)
+  , evalPPOpts :: PPOpts    -- ^ How to pretty print things.
+  }
 
 -- Values ----------------------------------------------------------------------
 

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -41,7 +41,7 @@ import qualified What4.SWord as SW
 import qualified What4.Utils.AbstractDomains as W4
 
 import Cryptol.Backend
-import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..), EvalOpts )
+import Cryptol.Backend.Monad ( EvalError(..), Unsupported(..) )
 import Cryptol.Backend.What4
 import qualified Cryptol.Backend.What4.SFloat as W4
 

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -203,7 +203,7 @@ doLoadModule quiet isrc path fp pm0 =
      tcm <- optionalInstantiate =<< checkModule isrc path pm
 
      -- extend the eval env, unless a functor.
-     tbl <- Concrete.primTable <$> getEvalOpts
+     tbl <- Concrete.primTable <$> getEvalOptsAction
      let ?evalPrim = \i -> Right <$> Map.lookup i tbl
      callStacks <- getCallStacks
      let ?callStacks = callStacks
@@ -565,7 +565,7 @@ evalExpr :: T.Expr -> ModuleM Concrete.Value
 evalExpr e = do
   env <- getEvalEnv
   denv <- getDynEnv
-  evopts <- getEvalOpts
+  evopts <- getEvalOptsAction
   let tbl = Concrete.primTable evopts
   let ?evalPrim = \i -> Right <$> Map.lookup i tbl
   let ?range = emptyRange
@@ -577,7 +577,7 @@ evalDecls :: [T.DeclGroup] -> ModuleM ()
 evalDecls dgs = do
   env <- getEvalEnv
   denv <- getDynEnv
-  evOpts <- getEvalOpts
+  evOpts <- getEvalOptsAction
   let env' = env <> deEnv denv
   let tbl = Concrete.primTable evOpts
   let ?evalPrim = \i -> Right <$> Map.lookup i tbl

--- a/src/Cryptol/ModuleSystem/Monad.hs
+++ b/src/Cryptol/ModuleSystem/Monad.hs
@@ -300,7 +300,7 @@ renamerWarnings ws
 
 data RO m =
   RO { roLoading    :: [ImportSource]
-     , roEvalOpts   :: EvalOpts
+     , roEvalOpts   :: m EvalOpts
      , roCallStacks :: Bool
      , roFileReader :: FilePath -> m ByteString
      }
@@ -360,7 +360,7 @@ instance MonadIO m => MonadIO (ModuleT m) where
 data ModuleInput m =
   ModuleInput
   { minpCallStacks :: Bool
-  , minpEvalOpts   :: EvalOpts
+  , minpEvalOpts   :: m EvalOpts
   , minpByteReader :: FilePath -> m ByteString
   , minpModuleEnv  :: ModuleEnv
   }
@@ -515,8 +515,13 @@ modifyEvalEnv f = ModuleT $ do
 getEvalEnv :: ModuleM EvalEnv
 getEvalEnv  = ModuleT (meEvalEnv `fmap` get)
 
+getEvalOptsAction :: ModuleM (IO EvalOpts)
+getEvalOptsAction = ModuleT (roEvalOpts `fmap` ask)
+
 getEvalOpts :: ModuleM EvalOpts
-getEvalOpts = ModuleT (roEvalOpts `fmap` ask)
+getEvalOpts =
+  do act <- getEvalOptsAction
+     liftIO act
 
 getFocusedModule :: ModuleM (Maybe P.ModName)
 getFocusedModule  = ModuleT (meFocusedModule `fmap` get)

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -314,33 +314,6 @@ runCommand lineNum mbBatch c = case c of
     return CommandError
 
 
--- Get the setting we should use for displaying values.
-getPPValOpts :: REPL E.PPOpts
-getPPValOpts =
-  do base      <- getKnownUser "base"
-     ascii     <- getKnownUser "ascii"
-     infLength <- getKnownUser "infLength"
-
-     fpBase    <- getKnownUser "fp-base"
-     fpFmtTxt  <- getKnownUser "fp-format"
-     let fpFmt = case parsePPFloatFormat fpFmtTxt of
-                   Just f  -> f
-                   Nothing -> panic "getPPValOpts"
-                                      [ "Failed to parse fp-format" ]
-
-     return E.PPOpts { E.useBase      = base
-                     , E.useAscii     = ascii
-                     , E.useInfLength = infLength
-                     , E.useFPBase    = fpBase
-                     , E.useFPFormat  = fpFmt
-                     }
-
-getEvalOpts :: REPL E.EvalOpts
-getEvalOpts =
-  do ppOpts <- getPPValOpts
-     l      <- getLogger
-     return E.EvalOpts { E.evalPPOpts = ppOpts, E.evalLogger = l }
-
 evalCmd :: String -> Int -> Maybe FilePath -> REPL ()
 evalCmd str lineNum mbBatch = do
   ri <- replParseInput str lineNum mbBatch
@@ -1617,7 +1590,7 @@ getPrimMap  = liftModuleCmd M.getPrimMap
 
 liftModuleCmd :: M.ModuleCmd a -> REPL a
 liftModuleCmd cmd =
-  do evo <- getEvalOpts
+  do evo <- getEvalOptsAction
      env <- getModuleEnv
      callStacks <- getCallStacks
      let minp = M.ModuleInput

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -79,7 +79,7 @@ module Cryptol.REPL.Monad (
 
 import Cryptol.REPL.Trie
 
-import Cryptol.Eval (EvalErrorEx, Unsupported, WordTooWide)
+import Cryptol.Eval (EvalErrorEx, Unsupported, WordTooWide,EvalOpts(..))
 import qualified Cryptol.ModuleSystem as M
 import qualified Cryptol.ModuleSystem.Env as M
 import qualified Cryptol.ModuleSystem.Name as M
@@ -99,7 +99,6 @@ import qualified Cryptol.Parser.AST as P
 import Cryptol.Symbolic (SatNum(..))
 import Cryptol.Symbolic.SBV (SBVPortfolioException)
 import Cryptol.Symbolic.What4 (W4Exception)
-import Cryptol.Backend.Monad(EvalOpts(..))
 import qualified Cryptol.Symbolic.SBV as SBV (proverNames, setupProver, defaultProver, SBVProverConfig)
 import qualified Cryptol.Symbolic.What4 as W4 (proverNames, setupProver, W4ProverConfig)
 

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -99,7 +99,7 @@ import qualified Cryptol.Parser.AST as P
 import Cryptol.Symbolic (SatNum(..))
 import Cryptol.Symbolic.SBV (SBVPortfolioException)
 import Cryptol.Symbolic.What4 (W4Exception)
-import Cryptol.Backend.Monad(PPFloatFormat(..),PPFloatExp(..),PPOpts(..),EvalOpts(..))
+import Cryptol.Backend.Monad(EvalOpts(..))
 import qualified Cryptol.Symbolic.SBV as SBV (proverNames, setupProver, defaultProver, SBVProverConfig)
 import qualified Cryptol.Symbolic.What4 as W4 (proverNames, setupProver, W4ProverConfig)
 

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -188,12 +188,11 @@ data VarShape sym
   | VarRecord (RecordMap Ident (VarShape sym))
 
 ppVarShape :: Backend sym => sym -> VarShape sym -> Doc
-ppVarShape sym (VarBit b) = ppBit sym b
-ppVarShape sym (VarInteger i) = ppInteger sym defaultPPOpts i
-ppVarShape sym (VarFloat f) = ppFloat sym defaultPPOpts f
-ppVarShape sym (VarRational n d) =
-  text "(ratio" <+> ppInteger sym defaultPPOpts n <+> ppInteger sym defaultPPOpts d <+> text ")"
-ppVarShape sym (VarWord w) = ppWord sym defaultPPOpts w
+ppVarShape _sym (VarBit _b) = text "<bit>"
+ppVarShape _sym (VarInteger _i) = text "<integer>"
+ppVarShape _sym (VarFloat _f) = text "<float>"
+ppVarShape _sym (VarRational _n _d) = text "<rational>"
+ppVarShape sym (VarWord w) = text "<word:" <> integer (wordLen sym w) <> text ">"
 ppVarShape sym (VarFinSeq _ xs) =
   brackets (fsep (punctuate comma (map (ppVarShape sym) xs)))
 ppVarShape sym (VarTuple xs) =

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -431,7 +431,7 @@ satProve :: SBVProverConfig -> ProverCommand -> M.ModuleCmd (Maybe String, Prove
 satProve proverCfg pc =
   protectStack proverError $ \minp ->
   M.runModuleM minp $ do
-  let evo = M.minpEvalOpts minp
+  evo <- liftIO (M.minpEvalOpts minp)
 
   let lPutStrLn = logPutStrLn (Eval.evalLogger evo)
 
@@ -456,7 +456,7 @@ satProveOffline _proverCfg pc@ProverCommand {..} =
               ProveQuery -> False
               SafetyQuery -> False
               SatQuery _ -> True
-        let evo = M.minpEvalOpts minp
+        evo <- liftIO (M.minpEvalOpts minp)
 
         prepareQuery evo pc >>= \case
           Left msg -> return (Left msg)

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -310,6 +310,8 @@ prepareQuery evo ProverCommand{..} =
      callStacks <- M.getCallStacks
      let ?callStacks = callStacks
 
+     getEOpts <- M.getEvalOptsAction
+
      -- The `addAsm` function is used to combine assumptions that
      -- arise from the types of symbolic variables (e.g. Z n values
      -- are assumed to be integers in the range `0 <= x < n`) with
@@ -329,7 +331,7 @@ prepareQuery evo ProverCommand{..} =
                  stateMVar <- liftIO (newMVar sbvState)
                  defRelsVar <- liftIO (newMVar SBV.svTrue)
                  let sym = SBV stateMVar defRelsVar
-                 let tbl = primTable sym
+                 let tbl = primTable sym getEOpts
                  let ?evalPrim = \i -> (Right <$> Map.lookup i tbl) <|>
                                        (Left <$> Map.lookup i ds)
                  let ?range = emptyRange

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -274,7 +274,8 @@ prepareQuery sym ProverCommand { .. } =
                 let ds = Map.fromList [ (prelPrim (identText (M.nameIdent nm)), EWhere (EVar nm) decls) | nm <- nms ]
                 pure ds
 
-       let tbl = primTable sym
+       getEOpts <- M.getEvalOptsAction
+       let tbl = primTable sym getEOpts
        let ?evalPrim = \i -> (Right <$> Map.lookup i tbl) <|>
                              (Left <$> Map.lookup i ds)
        let ?range = emptyRange

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -27,6 +27,38 @@ import qualified Text.PrettyPrint as PJ
 import Prelude ()
 import Prelude.Compat
 
+
+-- | How to pretty print things when evaluating
+data PPOpts = PPOpts
+  { useAscii     :: Bool
+  , useBase      :: Int
+  , useInfLength :: Int
+  , useFPBase    :: Int
+  , useFPFormat  :: PPFloatFormat
+  }
+ deriving Show
+
+asciiMode :: PPOpts -> Integer -> Bool
+asciiMode opts width = useAscii opts && (width == 7 || width == 8)
+
+data PPFloatFormat =
+    FloatFixed Int PPFloatExp -- ^ Use this many significant digis
+  | FloatFrac Int             -- ^ Show this many digits after floating point
+  | FloatFree PPFloatExp      -- ^ Use the correct number of digits
+ deriving Show
+
+data PPFloatExp = ForceExponent -- ^ Always show an exponent
+                | AutoExponent  -- ^ Only show exponent when needed
+ deriving Show
+
+
+defaultPPOpts :: PPOpts
+defaultPPOpts = PPOpts { useAscii = False, useBase = 10, useInfLength = 5
+                       , useFPBase = 16
+                       , useFPFormat = FloatFree AutoExponent
+                       }
+
+
 -- Name Displaying -------------------------------------------------------------
 
 {- | How to display names, inspired by the GHC `Outputable` module.


### PR DESCRIPTION
Builds on PR #985 

This refactors how evaluation options are piped into primitives, and makes them work in a less surprising way.  Currently, this only affects the `trace` and `traceVal` functions. This change makes it pretty straightforward to have the symbolic and concrete evaluators work uniformly with the same implementation for `trace`.