### PR TITLE
Property fix

### DIFF
--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -556,12 +556,12 @@ getTypeNames  =
      return (map (show . pp) (Map.keys (M.neTypes fNames)))
 
 -- | Return a list of property names, sorted by position in the file.
-getPropertyNames :: REPL ([M.Name],NameDisp)
+getPropertyNames :: REPL ([(M.Name,M.IfaceDecl)],NameDisp)
 getPropertyNames =
   do fe <- getFocusedEnv
      let xs = M.ifDecls (M.mctxDecls fe)
-         ps = sortBy (comparing (from . M.nameLoc))
-              [ x | (x,d) <- Map.toList xs,
+         ps = sortBy (comparing (from . M.nameLoc . fst))
+              [ (x,d) | (x,d) <- Map.toList xs,
                     T.PragmaProperty `elem` M.ifDeclPragmas d ]
 
      return (ps, M.mctxNameDisp fe)

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -19,7 +19,6 @@ module Cryptol.Testing.Random
 , randomValue
 , dumpableType
 , testableType
-, TestReport(..)
 , TestResult(..)
 , isPass
 , returnTests
@@ -394,13 +393,6 @@ typeValues ty =
 
 --------------------------------------------------------------------------------
 -- Driver function
-
-data TestReport = TestReport {
-    reportResult :: TestResult
-  , reportProp :: String -- ^ The property as entered by the user
-  , reportTestsRun :: Integer
-  , reportTestsPossible :: Maybe Integer
-  }
 
 exhaustiveTests :: MonadIO m =>
   (Integer -> m ()) {- ^ progress callback -} ->

--- a/tests/issues/Issue639_C.cry
+++ b/tests/issues/Issue639_C.cry
@@ -1,0 +1,2 @@
+module Issue639_C where
+  import Issue639_M (f)

--- a/tests/issues/Issue639_M.cry
+++ b/tests/issues/Issue639_M.cry
@@ -1,0 +1,3 @@
+module Issue639_M where
+  f (a:Bit) = True
+  property p a = f a == a

--- a/tests/issues/issue639.icry
+++ b/tests/issues/issue639.icry
@@ -1,0 +1,4 @@
+:m Issue639_C
+:check
+:prove
+:sat

--- a/tests/issues/issue639.icry.stdout
+++ b/tests/issues/issue639.icry.stdout
@@ -1,0 +1,12 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Issue639_M
+Loading module Issue639_C
+property Issue639_M::p Using exhaustive testing.
+Testing... Issue639_M::p False = False
+:prove Issue639_M::p
+	Counterexample
+Issue639_M::p False = False
+:sat Issue639_M::p
+	Satisfiable
+Issue639_M::p True = True


### PR DESCRIPTION
Fixes issues with the bulk testing/proving commands `:prove`, `:check` etc. that occur when properties are loaded in some dependent module, but not currently in scope.