### PR TITLE
Expose `qcExpr` in REPL.Command

### DIFF
--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -36,7 +36,8 @@ module Cryptol.REPL.Command (
   , replCheckExpr
 
     -- Check, SAT, and prove
-  , qcCmd, QCMode(..)
+  , TestReport(..)
+  , qcExpr, qcCmd, QCMode(..)
   , satCmd
   , proveCmd
   , onlineProveSat

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -412,10 +412,10 @@ qcCmd qcMode str pos fnm =
 
 
 data TestReport = TestReport
-  { _reportExpr :: Doc
-  , _reportResult :: TestResult
-  , _reportTestsRun :: Integer
-  , _reportTestsPossible :: Maybe Integer
+  { reportExpr :: Doc
+  , reportResult :: TestResult
+  , reportTestsRun :: Integer
+  , reportTestsPossible :: Maybe Integer
   }
 
 qcExpr ::


### PR DESCRIPTION
This change exposes `qcExpr` and `TestReport` in `REPL.Command` so that clients can easily quickcheck terms.