### PR TITLE
Fix the binary encoding of floating-point values.

### DIFF
--- a/src/Cryptol/Backend/FloatHelpers.hs
+++ b/src/Cryptol/Backend/FloatHelpers.hs
@@ -234,7 +234,7 @@ floatToBits e p bf =  (isNeg      `shiftL` (e' + p'))
           case num of
             Zero     -> (0,0)
             Num i ev
-              | ex == 0   -> (0, i `shiftL` (p' - m  -1))
+              | ex <= 0   -> (0, i `shiftL` (p' - m -1 + fromInteger ex))
               | otherwise -> (ex, (i `shiftL` (p' - m)) .&. pMask)
               where
               m    = msb 0 i - 1

--- a/tests/issues/issue1049.icry
+++ b/tests/issues/issue1049.icry
@@ -1,0 +1,2 @@
+:m Float
+:exhaust (\x -> (y != y \/ x == fpToBits y  where y = fpFromBits x : Float16))

--- a/tests/issues/issue1049.icry.stdout
+++ b/tests/issues/issue1049.icry.stdout
@@ -1,0 +1,6 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Float
+Using exhaustive testing.
+Testing... Passed 65536 tests.
+Q.E.D.


### PR DESCRIPTION
 Previously, some subnormal values were being incorrectly encoded.

Fixes #1049

Waiting on some local testing to finish before merging, but I'm pretty confident about this fix.