### PR TITLE
Init ghcr.io/galoisinc/cryptol-remote-api:nightly-portable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,6 @@ jobs:
           repository: galoisinc/cryptol-remote-api
           push: false
           dockerfile: cryptol-remote-api/test/Dockerfile
-          build_args: GHCVER=8.10.3
       - name: Test cryptol-remote-api helm chart
         run: |
           set -x
@@ -90,6 +89,33 @@ jobs:
           helm install --wait cra-socket ./helm/cryptol-remote-api --set server.connType=socket --set image.tag=nightly
           kubectl run --rm --attach test-http --image=galoisinc/cryptol-remote-api:test --image-pull-policy=Never --restart=Never -- http cra-http-cryptol-remote-api 8080
           kubectl run --rm --attach test-socket --image=galoisinc/cryptol-remote-api:test --image-pull-policy=Never --restart=Never -- socket cra-socket-cryptol-remote-api 8080
+
+  docker-cryptol-remote-api-portable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/galoisinc/cryptol-remote-api
+          tag-custom: nightly-portable
+          tag-custom-only: true
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CR_PAT }}
+      - uses: docker/build-push-action@v2
+        with:
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          push: ${{ github.event_name == 'schedule' }}
+          file: cryptol-remote-api/Dockerfile
+          build-args: PORTABILITY=true
+          cache-from: type=registry,ref=ghcr.io/galoisinc/cryptol-remote-api:nightly-portable-cache
+          cache-to: type=registry,ref=ghcr.io/galoisinc/cryptol-remote-api:nightly-portable-cache,mode=max
 
   build:
     needs: [outputs, docs]

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -1,4 +1,5 @@
 ARG GHCVER="8.10.3"
+ARG GHCVER_BOOTSTRAP="8.10.2"
 FROM debian:buster AS solvers
 
 # Install needed packages for building
@@ -43,18 +44,40 @@ RUN latest="$(curl -sSL 'http://cvc4.cs.stanford.edu/downloads/builds/x86_64-lin
 # Set executable and run tests
 RUN chmod +x rootfs/usr/local/bin/*
 
-ARG GHCVER
 FROM debian:buster AS build
-ARG GHCVER
-
+ARG PORTABILITY=false
 RUN apt-get update && apt-get install -y libncurses-dev libz-dev \
-    build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 libnuma-dev
+    build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 libnuma-dev \
+    $(if ${PORTABILITY}; then echo git autoconf python3; fi)
 RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.12/x86_64-linux-ghcup-0.1.12" && chmod +x /usr/local/bin/ghcup
 ENV GHCUP_USE_XDG_DIRS=true \
     XDG_BIN_HOME=/usr/local/bin \
     XDG_DATA_HOME=/usr/local/share
 COPY --from=solvers /solvers/rootfs /
-RUN ghcup install ghc ${GHCVER} && ghcup set ghc ${GHCVER} && ghcup install cabal --set
+RUN ghcup install cabal --set
+ENV PATH /root/.cabal/bin:$PATH
+ADD ./cryptol-remote-api/ghc-portability.patch .
+ARG GHCVER
+ARG GHCVER_BOOTSTRAP
+RUN if ${PORTABILITY}; then \
+        ghcup install ghc ${GHCVER_BOOTSTRAP} && \
+        ghcup set ghc ${GHCVER_BOOTSTRAP} && \
+        cabal v2-update && \
+        cabal v2-install alex happy-1.19.12 && \
+        git clone --recurse-submodules --depth 1 --branch ghc-${GHCVER}-release https://gitlab.haskell.org/ghc/ghc.git && \
+        cd ./ghc && \
+        git apply ../ghc-portability.patch && \
+        ./boot && \
+        ./configure && \
+        make -j && \
+        make install && \
+        cd .. && \
+        rm -rf ./ghc; \
+    else \
+        ghcup install ghc ${GHCVER} && \
+        ghcup set ghc ${GHCVER}; \
+    fi
+
 RUN useradd -m cryptol
 COPY --chown=cryptol:cryptol . /cryptol
 USER cryptol

--- a/cryptol-remote-api/ghc-portability.patch
+++ b/cryptol-remote-api/ghc-portability.patch
@@ -1,0 +1,46 @@
+diff --git a/configure.ac b/configure.ac
+index d1462db837..55053cefe1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -918,7 +918,7 @@ dnl    off_t, because it will affect the result of that test.
+ AC_SYS_LARGEFILE
+ 
+ dnl ** check for specific header (.h) files that we are interested in
+-AC_CHECK_HEADERS([ctype.h dirent.h dlfcn.h errno.h fcntl.h grp.h limits.h locale.h nlist.h pthread.h pwd.h signal.h sys/param.h sys/mman.h sys/resource.h sys/select.h sys/time.h sys/timeb.h sys/timerfd.h sys/timers.h sys/times.h sys/utsname.h sys/wait.h termios.h time.h utime.h windows.h winsock.h sched.h])
++AC_CHECK_HEADERS([ctype.h dirent.h dlfcn.h errno.h fcntl.h grp.h limits.h locale.h nlist.h pthread.h pwd.h signal.h sys/param.h sys/mman.h sys/resource.h sys/select.h sys/time.h sys/timeb.h sys/timers.h sys/times.h sys/utsname.h sys/wait.h termios.h time.h utime.h windows.h winsock.h sched.h])
+ 
+ dnl sys/cpuset.h needs sys/param.h to be included first on FreeBSD 9.1; #7708
+ AC_CHECK_HEADERS([sys/cpuset.h], [], [],
+@@ -1174,10 +1174,6 @@ AC_TRY_LINK(
+     AC_MSG_RESULT(no)
+ )
+ 
+-dnl ** check for eventfd which is needed by the I/O manager
+-AC_CHECK_HEADERS([sys/eventfd.h])
+-AC_CHECK_FUNCS([eventfd])
+-
+ dnl ** Check for __thread support in the compiler
+ AC_MSG_CHECKING(for __thread support)
+ AC_COMPILE_IFELSE(
+diff --git a/libraries/base/configure.ac b/libraries/base/configure.ac
+index d34224acc7..a67bdef684 100644
+--- a/libraries/base/configure.ac
++++ b/libraries/base/configure.ac
+@@ -30,7 +30,7 @@ dnl ** check for full ANSI header (.h) files
+ AC_HEADER_STDC
+ 
+ # check for specific header (.h) files that we are interested in
+-AC_CHECK_HEADERS([ctype.h errno.h fcntl.h inttypes.h limits.h signal.h sys/file.h sys/resource.h sys/select.h sys/stat.h sys/syscall.h sys/time.h sys/timeb.h sys/timers.h sys/times.h sys/types.h sys/utsname.h sys/wait.h termios.h time.h unistd.h utime.h windows.h winsock.h langinfo.h poll.h sys/epoll.h sys/event.h sys/eventfd.h sys/socket.h])
++AC_CHECK_HEADERS([ctype.h errno.h fcntl.h inttypes.h limits.h signal.h sys/file.h sys/resource.h sys/select.h sys/stat.h sys/syscall.h sys/time.h sys/timeb.h sys/timers.h sys/times.h sys/types.h sys/utsname.h sys/wait.h termios.h time.h unistd.h utime.h windows.h winsock.h langinfo.h poll.h sys/epoll.h sys/event.h sys/socket.h])
+ 
+ # Enable large file support. Do this before testing the types ino_t, off_t, and
+ # rlim_t, because it will affect the result of that test.
+@@ -47,7 +47,7 @@ AC_CHECK_FUNCS([clock_gettime])
+ AC_CHECK_FUNCS([getclock getrusage times])
+ AC_CHECK_FUNCS([_chsize ftruncate])
+ 
+-AC_CHECK_FUNCS([epoll_ctl eventfd kevent kevent64 kqueue poll])
++AC_CHECK_FUNCS([epoll_ctl kevent kevent64 kqueue poll])
+ 
+ # event-related fun
+ 


### PR DESCRIPTION
Builds cryptol-remote-api without eventfd and timerfd