### PR TITLE
Relax the check that all values are consumed

### DIFF
--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -422,7 +422,7 @@ processResults ProverCommand{..} ts results =
     -- to always be the first value in the model assignment list.
     let Right (_, (safetyCV : cvs)) = SBV.getModelAssignment result
         safety = SBV.cvToBool safetyCV
-        (vs, []) = parseValues ts cvs
+        (vs, _) = parseValues ts cvs
         mdl = computeModel prims ts vs
     return (safety, mdl)
 

--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -946,8 +946,10 @@ checkSigB b (Forall as asmps0 t0, validSchema) = case thing (P.bDef b) of
         }
 
 inferDs :: FromDecl d => [d] -> ([DeclGroup] -> InferM a) -> InferM a
-inferDs ds continue = checkTyDecls =<< orderTyDecls (mapMaybe toTyDecl ds)
+inferDs ds continue = either onErr checkTyDecls =<< orderTyDecls (mapMaybe toTyDecl ds)
   where
+  onErr err = recordError err >> continue []
+
   isTopLevel = isTopDecl (head ds)
 
   checkTyDecls (AT t mbD : ts) =

--- a/tests/issues/issue1040.cry
+++ b/tests/issues/issue1040.cry
@@ -1,0 +1,6 @@
+module binarytree where
+
+newtype Tree = { inTree : Tree }
+
+build : Tree
+build = Tree { inTree = undefined }

--- a/tests/issues/issue1040.icry
+++ b/tests/issues/issue1040.icry
@@ -1,0 +1,1 @@
+:l issue1040.cry

--- a/tests/issues/issue1040.icry.stdout
+++ b/tests/issues/issue1040.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module binarytree
+
+[error] at issue1040.cry:1:1--6:36:
+  Recursive type declarations:
+    `binarytree::Tree`

--- a/tests/issues/issue1044.icry
+++ b/tests/issues/issue1044.icry
@@ -1,0 +1,5 @@
+:set prover=sbv-z3
+:safe \(x:Z 7) -> x * (recip x) == 1
+
+:set prover=w4-z3
+:safe \(x:Z 7) -> x * (recip x) == 1

--- a/tests/issues/issue1044.icry.stdout
+++ b/tests/issues/issue1044.icry.stdout
@@ -1,0 +1,17 @@
+Loading module Cryptol
+Counterexample
+(\(x : Z 7) -> x * (recip x) == 1) 0 ~> ERROR
+division by 0
+-- Backtrace --
+Cryptol::recip called at issue1044.icry:2:24--2:29
+(Cryptol::*) called at issue1044.icry:2:19--2:37
+(Cryptol::==) called at issue1044.icry:2:19--2:37
+<interactive>::it called at issue1044.icry:2:7--2:37
+Counterexample
+(\(x : Z 7) -> x * (recip x) == 1) 0 ~> ERROR
+division by 0
+-- Backtrace --
+Cryptol::recip called at issue1044.icry:5:24--5:29
+(Cryptol::*) called at issue1044.icry:5:19--5:37
+(Cryptol::==) called at issue1044.icry:5:19--5:37
+<interactive>::it called at issue1044.icry:5:7--5:37


### PR DESCRIPTION
 when parsing SBV counterexamples.

After parsing all the "input" values, there may be some left over
if we have used constructs (like prime field recip) that are
defined via uniquely specified variables.  We can simply ignore
these extra values.