### PR TITLE
Fix parse panic

### DIFF
--- a/src/Cryptol/Parser.y
+++ b/src/Cryptol/Parser.y
@@ -27,6 +27,7 @@ module Cryptol.Parser
 
 import           Control.Applicative as A
 import           Data.Maybe(fromMaybe)
+import           Data.List.NonEmpty ( NonEmpty(..), cons )
 import           Data.Text(Text)
 import qualified Data.Text as T
 import           Control.Monad(liftM2,msum)
@@ -470,7 +471,7 @@ longRHS                        :: { Expr PName }
 
 -- Prefix application expression, ends with an atom.
 simpleApp                      :: { Expr PName }
-  : aexprs                        { mkEApp $1 }
+  : aexprs                        {% mkEApp $1 }
 
 -- Prefix application expression, may end with a long expression
 longApp                        :: { Expr PName }
@@ -478,9 +479,9 @@ longApp                        :: { Expr PName }
   | longExpr                      { $1 }
   | simpleApp                     { $1 }
 
-aexprs                         :: { [Expr PName] }
-  : aexpr                         { [$1] }
-  | aexprs aexpr                  { $2 : $1 }
+aexprs                         :: { NonEmpty (Expr PName) }
+  : aexpr                         { $1 :| [] }
+  | aexprs aexpr                  { cons $2 $1 }
 
 
 -- Expression atom (needs no parens)

--- a/src/Cryptol/Parser/ParserUtils.hs
+++ b/src/Cryptol/Parser/ParserUtils.hs
@@ -299,6 +299,15 @@ mkEApp es@(eLast :| _) =
      [ f, x, `{ a = 2 }, y ]
      becomes
      [ f, x ` { a = 2 }, y ]
+
+     The parser associates field and tuple projectors that follow an
+     explicit type application onto the TTyApp term, so we also
+     have to unwind those projections and reapply them.  For example:
+
+     [ f, x, `{ a = 2 }.f.2, y ]
+     becomes
+     [ f, (x`{ a = 2 }).f.2, y ]
+
   -}
   cvtTypeParams e [] = pure (e :| [])
   cvtTypeParams e (p : ps) =

--- a/src/Cryptol/Parser/Position.hs
+++ b/src/Cryptol/Parser/Position.hs
@@ -57,6 +57,11 @@ rComb r1 r2  = Range { from = rFrom, to = rTo, source = source r1 }
   where rFrom = min (from r1) (from r2)
         rTo   = max (to r1)   (to r2)
 
+rCombMaybe :: Maybe Range -> Maybe Range -> Maybe Range
+rCombMaybe Nothing y = y
+rCombMaybe x Nothing = x
+rCombMaybe (Just x) (Just y) = Just (rComb x y)
+
 rCombs :: [Range] -> Range
 rCombs  = foldl1 rComb
 

--- a/src/Cryptol/TypeCheck/Error.hs
+++ b/src/Cryptol/TypeCheck/Error.hs
@@ -146,7 +146,7 @@ data Error    = KindMismatch (Maybe TypeSource) Kind Kind
 errorImportance :: Error -> Int
 errorImportance err =
   case err of
-    BareTypeApp{}                                    -> 11 -- basically a parse error
+    BareTypeApp                                      -> 11 -- basically a parse error
     KindMismatch {}                                  -> 10
     TyVarWithParams {}                               -> 9
     TypeMismatch {}                                  -> 8
@@ -229,7 +229,7 @@ instance TVars Error where
       RepeatedTypeParameter {} -> err
       AmbiguousSize x t -> AmbiguousSize x !$ (apSubst su t)
 
-      BareTypeApp{} -> err
+      BareTypeApp -> err
 
       UndefinedExistVar {} -> err
       TypeShadowing {}     -> err
@@ -262,7 +262,7 @@ instance FVS Error where
       AmbiguousSize _ t -> fvs t
       BadParameterKind tp _ -> Set.singleton (TVBound tp)
 
-      BareTypeApp{} -> Set.empty
+      BareTypeApp -> Set.empty
 
       UndefinedExistVar {} -> Set.empty
       TypeShadowing {}     -> Set.empty
@@ -423,7 +423,9 @@ instance PP (WithNames Error) where
                  Nothing -> empty
          in addTVarsDescsAfter names err ("Ambiguous numeric type:" <+> pp (tvarDesc x) $$ sizeMsg)
 
-      BareTypeApp -> "Unexpected bare type application"
+      BareTypeApp ->
+        "Unexpected bare type application." $$
+        "Perhaps you meant `( ... ) instead."
 
       UndefinedExistVar x -> "Undefined type" <+> quotes (pp x)
       TypeShadowing this new that ->

--- a/src/Cryptol/TypeCheck/Kind.hs
+++ b/src/Cryptol/TypeCheck/Kind.hs
@@ -387,8 +387,8 @@ doCheckType ty k =
 
     P.TInfix t x _ u-> doCheckType (P.TUser (thing x) [t, u]) k
 
-    P.TTyApp _fs    -> panic "doCheckType"
-                         ["TTyApp found when kind checking, but it should have been eliminated already"]
+    P.TTyApp _fs    -> do kRecordError BareTypeApp
+                          kNewType TypeWildCard KNum
 
   where
   checkF _nm (rng,v) = kInRange rng $ doCheckType v (Just KType)

--- a/tests/issues/issue322.icry.stdout
+++ b/tests/issues/issue322.icry.stdout
@@ -1,4 +1,5 @@
 Loading module Cryptol
 
-[error] at issue322.icry:1:5--1:10:
-  Named and positional type applications may not be mixed.
+Parse error at issue322.icry:1:4--1:19
+  Explicit type applications can only be applied to named values.
+  Unexpected: (split`{a = [3]})

--- a/tests/issues/issue845.icry.stdout
+++ b/tests/issues/issue845.icry.stdout
@@ -6,7 +6,7 @@ Loading module Main
 [warning] at issue845.cry:1:9--1:24:
   Assuming  m to have a numeric type
 
-[error] at issue845.cry:2:1--2:18:
+[error] at issue845.cry:2:1--2:37:
   Failed to validate user-specified signature.
     in the definition of 'Main::rfrac', at issue845.cry:2:1--2:6,
     we need to show that

--- a/tests/issues/issue962.icry
+++ b/tests/issues/issue962.icry
@@ -1,4 +1,9 @@
 `{1}
+(((True`{}, zero`{Integer})`{}).1)`{}
+number`{3}`{}`{}`{}`{}`{Integer}
 
 :l issue962a.cry
+:t i
+:t j
+
 :l issue962b.cry

--- a/tests/issues/issue962.icry
+++ b/tests/issues/issue962.icry
@@ -1,0 +1,4 @@
+`{1}
+
+:l issue962a.cry
+:l issue962b.cry

--- a/tests/issues/issue962.icry.stdout
+++ b/tests/issues/issue962.icry.stdout
@@ -1,0 +1,23 @@
+Loading module Cryptol
+
+[error] at issue962.icry:1:2--1:5:
+  Unexpected bare type application.
+  Perhaps you meant `( ... ) instead.
+
+Parse error at issue962.icry:2:3--2:28
+  Explicit type applications can only be applied to named values.
+  Unexpected: (True`{}, zero`{Integer})
+
+Parse error at issue962.icry:3:1--3:11
+  Explicit type applications can only be applied to named values.
+  Unexpected: number`{3}
+Loading module Cryptol
+Loading module Main
+i : {a} (fin a) => [a] -> [a]
+j : {a} (fin a) => [a]{fld : Integer} -> [a]Integer
+Loading module Cryptol
+Loading module Main
+
+[error] at issue962b.cry:32:16--32:25:
+  Unexpected bare type application.
+  Perhaps you meant `( ... ) instead.

--- a/tests/issues/issue962a.cry
+++ b/tests/issues/issue962a.cry
@@ -1,0 +1,10 @@
+f : {a} (fin a) => [a] -> (Bit, [a])
+f x = (True, x)
+
+g : {a} (fin a) => [a] -> [a]
+g x = (f`{a=a} x).1
+
+h = f.1
+
+i : {a} (fin a) => [a] -> [a]
+i = f`{a=a}.1

--- a/tests/issues/issue962a.cry
+++ b/tests/issues/issue962a.cry
@@ -1,10 +1,13 @@
-f : {a} (fin a) => [a] -> (Bit, [a])
+f : {a, b} (fin a) => [a]b -> (Bit, [a]b)
 f x = (True, x)
 
-g : {a} (fin a) => [a] -> [a]
+g : {a,b} (fin a) => [a]b -> [a]b
 g x = (f`{a=a} x).1
 
 h = f.1
 
 i : {a} (fin a) => [a] -> [a]
 i = f`{a=a}.1
+
+j : {a} (fin a) => [a]{ fld : Integer } -> [a]Integer
+j = f`{a=a,b={fld : Integer}}.1.fld

--- a/tests/issues/issue962b.cry
+++ b/tests/issues/issue962b.cry
@@ -28,7 +28,7 @@ build2row : [v1][v1]Fld -> [v1][o1]Fld -> [v1][o2]Fld ->
             [o1][o1]Fld -> [o1][o2]Fld  -> [width nn] -> [nn]Fld
 build2row a11 a12 a13 a22 a23 i =
   if i < `v1 then
-    a11 @ i # a12 @ i # a13
+    a11 @ i # a12 @ i # a13 @ i
   else if i < `{v1 + o1} then
     /*    vzero`{n=v1} # a22 @ (i - `v1) # a23 @ (i - `v1) */
     vzero`{n=v1} # vzero`{n=o1} # vzero`{n=o2}

--- a/tests/issues/issue962b.cry
+++ b/tests/issues/issue962b.cry
@@ -1,0 +1,36 @@
+type Fld = [4]
+
+type v1 = 36
+type o1 = 32
+type o2 = 32
+
+type nn = v1 + o1 + o2
+
+nats : {n} (fin n) => [n][width n]
+nats = take`{n} [0 .. n]
+
+vzero : {n} (fin n, n > 0) => [n]Fld
+vzero = [ zero | _ <- nats`{n=n} ]
+
+build1item : [width nn] -> [width nn] -> Fld
+build1item i j =
+  if i == j then
+    1
+  else        
+    0
+
+build2 : [v1][v1]Fld -> [v1][o1]Fld -> [v1][o2]Fld ->
+         [o1][o1]Fld -> [o1][o2]Fld -> [nn][nn]Fld
+build2 a11 a12 a13 a22 a23 =
+  map (build2row a11 a12 a13 a22 a23) (nats`{n=nn})
+
+build2row : [v1][v1]Fld -> [v1][o1]Fld -> [v1][o2]Fld ->
+            [o1][o1]Fld -> [o1][o2]Fld  -> [width nn] -> [nn]Fld
+build2row a11 a12 a13 a22 a23 i =
+  if i < `v1 then
+    a11 @ i # a12 @ i # a13
+  else if i < `{v1 + o1} then
+    /*    vzero`{n=v1} # a22 @ (i - `v1) # a23 @ (i - `v1) */
+    vzero`{n=v1} # vzero`{n=o1} # vzero`{n=o2}
+  else
+    map (build1item i) (nats`{n=nn})

--- a/tests/regression/tc-errors.icry.stdout
+++ b/tests/regression/tc-errors.icry.stdout
@@ -33,8 +33,9 @@ Loading module Cryptol
 Parse error at tc-errors.icry:6:8,
   unexpected: ,
 
-[error] at tc-errors.icry:7:1--7:5:
-  Named and positional type applications may not be mixed.
+Parse error at tc-errors.icry:7:1--7:10
+  Explicit type applications can only be applied to named values.
+  Unexpected: take`{1}
 
 [error] at tc-errors.icry:8:1--8:5:
   Type mismatch:


### PR DESCRIPTION
Fix parsing/typechecking issues arising from explicit type applications occurring in unexpected places.

This change restricts some programs that were previously accepted, but were rather unusual, I think.  E.g.
```
f`{5}`{Integer}
```
Is a program that used to be accepted with the same meaning as
```
f`{5,Integer}
```

After this patch, the first program with an error indicating that type applications are only allowed on identifiers.