### PR TITLE
change remote Dockerfile's cwd for server

### DIFF
--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -110,5 +110,6 @@ USER cryptol
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 ENTRYPOINT ["/usr/local/bin/cryptol-remote-api"]
-CMD ["http", "--host", "0.0.0.0", "--port", "8080", "/home/cryptol"]
+WORKDIR /home/cryptol
+CMD ["http", "--host", "0.0.0.0", "--port", "8080", "/"]
 EXPOSE 8080

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -110,5 +110,5 @@ USER cryptol
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 ENTRYPOINT ["/usr/local/bin/cryptol-remote-api"]
-CMD ["http", "--host", "0.0.0.0", "--port", "8080", "/"]
+CMD ["http", "--host", "0.0.0.0", "--port", "8080", "/home/cryptol"]
 EXPOSE 8080


### PR DESCRIPTION
This is probably a better place for the remote cryptol to serve files from by default, right?