### PR TITLE
Make `freshVar` produce a VWord instead of a VSeq for type `[0]`.

### DIFF
--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -241,7 +241,8 @@ data FreshVarFns sym =
   }
 
 freshVar :: Backend sym => FreshVarFns sym -> FinType -> IO (VarShape sym)
-freshVar fns tp = case tp of
+freshVar fns tp =
+  case tp of
     FTBit         -> VarBit      <$> freshBitVar fns
     FTInteger     -> VarInteger  <$> freshIntegerVar fns Nothing Nothing
     FTRational    -> VarRational
@@ -250,7 +251,7 @@ freshVar fns tp = case tp of
     FTIntMod 0    -> panic "freshVariable" ["0 modulus not allowed"]
     FTIntMod m    -> VarInteger  <$> freshIntegerVar fns (Just 0) (Just (m-1))
     FTFloat e p   -> VarFloat    <$> freshFloatVar fns e p
-    FTSeq n FTBit | n > 0 -> VarWord     <$> freshWordVar fns (toInteger n)
+    FTSeq n FTBit -> VarWord     <$> freshWordVar fns (toInteger n)
     FTSeq n t     -> VarFinSeq (toInteger n) <$> sequence (genericReplicate n (freshVar fns t))
     FTTuple ts    -> VarTuple    <$> mapM (freshVar fns) ts
     FTRecord fs   -> VarRecord   <$> traverse (freshVar fns) fs

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -540,11 +540,16 @@ freshBoundedInt sym lo hi =
        Nothing -> pure ()
      return x
 
+freshBitvector :: SBV -> Integer -> IO SBV.SVal
+freshBitvector sym w
+  | w == 0 = pure (SBV.svInteger (SBV.KBounded False 0) 0)
+  | otherwise = freshBV_ sym (fromInteger w)
+
 sbvFreshFns :: SBV -> FreshVarFns SBV
 sbvFreshFns sym =
   FreshVarFns
   { freshBitVar     = freshSBool_ sym
-  , freshWordVar    = freshBV_ sym . fromInteger
+  , freshWordVar    = freshBitvector sym
   , freshIntegerVar = freshBoundedInt sym
   , freshFloatVar   = \_ _ -> return () -- TODO
   }

--- a/tests/issues/issue1093.icry
+++ b/tests/issues/issue1093.icry
@@ -1,0 +1,4 @@
+:set prover=z3
+:prove \(xs:[12][0]) -> reverse (reverse xs) == xs
+:prove \(xs:[0]) (ys:[0]) -> xs == ys
+:prove \(xs:[0]) (ys:[0]) (zs:[0]) -> (xs # ys) # zs == xs # (ys # zs)

--- a/tests/issues/issue1093.icry
+++ b/tests/issues/issue1093.icry
@@ -2,3 +2,7 @@
 :prove \(xs:[12][0]) -> reverse (reverse xs) == xs
 :prove \(xs:[0]) (ys:[0]) -> xs == ys
 :prove \(xs:[0]) (ys:[0]) (zs:[0]) -> (xs # ys) # zs == xs # (ys # zs)
+:set prover=w4-z3
+:prove \(xs:[12][0]) -> reverse (reverse xs) == xs
+:prove \(xs:[0]) (ys:[0]) -> xs == ys
+:prove \(xs:[0]) (ys:[0]) (zs:[0]) -> (xs # ys) # zs == xs # (ys # zs)

--- a/tests/issues/issue1093.icry.stdout
+++ b/tests/issues/issue1093.icry.stdout
@@ -2,3 +2,6 @@ Loading module Cryptol
 Q.E.D.
 Q.E.D.
 Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.

--- a/tests/issues/issue1093.icry.stdout
+++ b/tests/issues/issue1093.icry.stdout
@@ -1,0 +1,4 @@
+Loading module Cryptol
+Q.E.D.
+Q.E.D.
+Q.E.D.


### PR DESCRIPTION
Fixes #1093. Fixes #1094.