### PR TITLE
Don't use the `showFreeMin` floating-point printing mode

### DIFF
--- a/tests/regression/float.icry.stdout
+++ b/tests/regression/float.icry.stdout
@@ -26,8 +26,8 @@ Specifies the format to use when showing floating point numbers:
 0b1010.01
 0o12.2
 10.25
-0.4
-0.4
+0.38
+0.38
 0xa.4
 0x0.6
 0x1.234p4


### PR DESCRIPTION
That mode has highly counterintuitive results.  Instad, use the `showFree`
mode, which produces results more accurate to the underlying
bit representation.  The `showFree` mode often produces unfortunate
trailing zeros in decimal representations, so we take some care
to trim those out.

Fixes #1089