### PR TITLE
cryptol-remote-api: Upgrade to mypy-0.812

### DIFF
--- a/cryptol-remote-api/python/cryptol/bitvector.py
+++ b/cryptol-remote-api/python/cryptol/bitvector.py
@@ -99,7 +99,7 @@ class BV:
         Args:
             n (int): How many bits wider the returned ``BV`` should be than ``self`` (must be nonnegative).
         """
-        if not isinstance(n, int) or n < 0: #type: ignore
+        if not isinstance(n, int) or n < 0:
             raise ValueError(f'``widen`` expects a nonnegative integer, but got {n!r}')
         else:
             return BV(self.__size + n, self.__value)
@@ -193,7 +193,7 @@ class BV:
         
         :param size: Size of segments to partition ``self`` into (must evently divide ``self.size()``).
         """
-        if not isinstance(size, int) or size <= 0: #type: ignore
+        if not isinstance(size, int) or size <= 0:
             raise ValueError(f'`size` argument to splits must be a positive integer, got {size!r}')
         if not self.size() % size == 0:
             raise ValueError(f'{self!r} is not divisible into equal parts of size {size!r}')
@@ -246,7 +246,7 @@ class BV:
     def with_bits(self, low : int, bits : 'BV') -> 'BV':
         """Return a ``BV`` identical to ``self`` but with the bits from ``low`` to
         ``low + bits.size() - 1`` replaced by the bits from ``bits``."""
-        if not isinstance(low, int) or low < 0 or low >= self.__size: # type: ignore
+        if not isinstance(low, int) or low < 0 or low >= self.__size:
             raise ValueError(f'{low!r} is not a valid low bit index for {self!r}')
         elif not isinstance(bits, BV):
             raise ValueError(f'Expected a BV but got {bits!r}')

--- a/cryptol-remote-api/python/poetry.lock
+++ b/cryptol-remote-api/python/poetry.lock
@@ -44,7 +44,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "mypy"
-version = "0.790"
+version = "0.812"
 description = "Optional static typing for Python"
 category = "main"
 optional = false
@@ -116,7 +116,7 @@ brotli = ["brotlipy (>=0.6.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5cf8c3c9b5b0da0060f9522b96bbadda2e776852257c2e3465144be9e9a20743"
+content-hash = "3a5d27a6af34508eb18ba18ece3a04240e86bba677b152d4a679010a33173935"
 
 [metadata.files]
 argo-client = [
@@ -139,20 +139,28 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 mypy = [
-    {file = "mypy-0.790-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:bd03b3cf666bff8d710d633d1c56ab7facbdc204d567715cb3b9f85c6e94f669"},
-    {file = "mypy-0.790-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:2170492030f6faa537647d29945786d297e4862765f0b4ac5930ff62e300d802"},
-    {file = "mypy-0.790-cp35-cp35m-win_amd64.whl", hash = "sha256:e86bdace26c5fe9cf8cb735e7cedfe7850ad92b327ac5d797c656717d2ca66de"},
-    {file = "mypy-0.790-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e97e9c13d67fbe524be17e4d8025d51a7dca38f90de2e462243ab8ed8a9178d1"},
-    {file = "mypy-0.790-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0d34d6b122597d48a36d6c59e35341f410d4abfa771d96d04ae2c468dd201abc"},
-    {file = "mypy-0.790-cp36-cp36m-win_amd64.whl", hash = "sha256:72060bf64f290fb629bd4a67c707a66fd88ca26e413a91384b18db3876e57ed7"},
-    {file = "mypy-0.790-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:eea260feb1830a627fb526d22fbb426b750d9f5a47b624e8d5e7e004359b219c"},
-    {file = "mypy-0.790-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c614194e01c85bb2e551c421397e49afb2872c88b5830e3554f0519f9fb1c178"},
-    {file = "mypy-0.790-cp37-cp37m-win_amd64.whl", hash = "sha256:0a0d102247c16ce93c97066443d11e2d36e6cc2a32d8ccc1f705268970479324"},
-    {file = "mypy-0.790-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf4e7bf7f1214826cf7333627cb2547c0db7e3078723227820d0a2490f117a01"},
-    {file = "mypy-0.790-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:af4e9ff1834e565f1baa74ccf7ae2564ae38c8df2a85b057af1dbbc958eb6666"},
-    {file = "mypy-0.790-cp38-cp38-win_amd64.whl", hash = "sha256:da56dedcd7cd502ccd3c5dddc656cb36113dd793ad466e894574125945653cea"},
-    {file = "mypy-0.790-py3-none-any.whl", hash = "sha256:2842d4fbd1b12ab422346376aad03ff5d0805b706102e475e962370f874a5122"},
-    {file = "mypy-0.790.tar.gz", hash = "sha256:2b21ba45ad9ef2e2eb88ce4aeadd0112d0f5026418324176fd494a6824b74975"},
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -11,7 +11,7 @@ BitVector = "^3.4.9"
 argo-client = "0.0.4"
 
 [tool.poetry.dev-dependencies]
-mypy = "^0.790"
+mypy = "^0.812"
 
 [build-system]
 requires = ["poetry>=1.1.4", "setuptools>=40.8.0"]

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -14,4 +14,4 @@ argo-client = "0.0.4"
 mypy = "^0.790"
 
 [build-system]
-requires = ["poetry>=1.1.4"]
+requires = ["poetry>=1.1.4", "setuptools>=40.8.0"]

--- a/cryptol-remote-api/python/requirements.txt
+++ b/cryptol-remote-api/python/requirements.txt
@@ -9,7 +9,7 @@ idna==2.10
 imagesize==1.2.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-mypy==0.790
+mypy==0.812
 mypy-extensions==0.4.3
 packaging==20.4
 Pygments==2.7.1

--- a/cryptol-remote-api/python/setup.py
+++ b/cryptol-remote-api/python/setup.py
@@ -29,7 +29,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "BitVector==3.4.9",
-        "mypy==0.790",
+        "mypy==0.812",
         "mypy-extensions==0.4.3",
         "argo-client==0.0.4"
     ],


### PR DESCRIPTION
This upgrades `mypy` to version `0.812`. This is primarily motivated by a need to work around python-poetry/poetry#3094, which currently happens if you try to include the SAW Python bindings in a `poetry` project as a `develop` dependency. For the most part, this is a matter of adjusting version bounds. In a handful of cases, we are able to remove `type: ignore` comments due to `mypy-0.8` being smarter than `mypy-0.7`.