### PR TITLE
Persist solver, part 2

### DIFF
--- a/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
+++ b/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
@@ -12,13 +12,12 @@ import Data.Aeson as JSON
 
 
 import Cryptol.ModuleSystem (checkExpr, evalExpr)
-import Cryptol.ModuleSystem.Env (meSolverConfig,deEnv,meDynEnv)
+import Cryptol.ModuleSystem.Env (deEnv,meDynEnv)
 import Cryptol.TypeCheck.Solve (defaultReplExpr)
 import Cryptol.TypeCheck.Subst (apSubst, listParamSubst)
 import Cryptol.TypeCheck.Type (Schema(..))
 import qualified Cryptol.Parser.AST as P
 import Cryptol.Parser.Name (PName)
-import qualified Cryptol.TypeCheck.Solver.SMT as SMT
 import Cryptol.Utils.PP (pretty)
 import qualified Cryptol.Eval.Env as E
 import qualified Cryptol.Eval.Type as E
@@ -43,9 +42,8 @@ evalExpression' e =
      -- TODO: see Cryptol REPL for how to check whether we
      -- can actually evaluate things, which we can't do in
      -- a parameterized module
-     me <- getModuleEnv
-     let cfg = meSolverConfig me
-     perhapsDef <- liftIO $ SMT.withSolver cfg (\s -> defaultReplExpr s ty schema)
+     s <- getTCSolver
+     perhapsDef <- liftIO (defaultReplExpr s ty schema)
      case perhapsDef of
        Nothing ->
          raise (evalPolyErr schema)

--- a/cryptol-remote-api/src/CryptolServer/Sat.hs
+++ b/cryptol-remote-api/src/CryptolServer/Sat.hs
@@ -23,13 +23,12 @@ import qualified Data.Text as T
 import Cryptol.Eval.Concrete (Value)
 import Cryptol.Eval.Type (TValue, tValTy)
 import Cryptol.ModuleSystem (checkExpr)
-import Cryptol.ModuleSystem.Env (DynamicEnv(..), meDynEnv, meSolverConfig)
+import Cryptol.ModuleSystem.Env (DynamicEnv(..), meDynEnv)
 import Cryptol.Symbolic ( ProverCommand(..), ProverResult(..), QueryType(..)
                         , SatNum(..), CounterExampleType(..))
 import Cryptol.Symbolic.SBV (proverNames, satProve, setupProver)
 import Cryptol.TypeCheck.AST (Expr)
 import Cryptol.TypeCheck.Solve (defaultReplExpr)
-import qualified Cryptol.TypeCheck.Solver.SMT as SMT
 
 import CryptolServer
 import CryptolServer.Exceptions (evalPolyErr, proverError)
@@ -49,8 +48,9 @@ proveSat (ProveSatParams queryType (Prover name) jsonExpr) =
      -- TODO validEvalContext expr, ty, schema
      me <- getModuleEnv
      let decls = deDecls (meDynEnv me)
-     let cfg = meSolverConfig me
-     perhapsDef <- liftIO $ SMT.withSolver cfg (\s -> defaultReplExpr s ty schema)
+     s <- getTCSolver
+
+     perhapsDef <- liftIO (defaultReplExpr s ty schema)
      case perhapsDef of
        Nothing ->
          raise (evalPolyErr schema)

--- a/cryptol-remote-api/src/CryptolServer/TypeCheck.hs
+++ b/cryptol-remote-api/src/CryptolServer/TypeCheck.hs
@@ -11,7 +11,6 @@ import qualified Argo.Doc as Doc
 import Data.Aeson as JSON
 
 import Cryptol.ModuleSystem (checkExpr)
-import Cryptol.ModuleSystem.Env (meSolverConfig)
 
 import CryptolServer
 import CryptolServer.Exceptions
@@ -26,8 +25,6 @@ checkType :: TypeCheckParams -> CryptolCommand JSON.Value
 checkType (TypeCheckParams e) =
   do e' <- getExpr e
      (_expr, _ty, schema) <- runModuleCmd (checkExpr e')
-     -- FIXME: why are we running this command if the result isn't used?
-     _cfg <- meSolverConfig <$> getModuleEnv
      return (JSON.object [ "type schema" .= JSONSchema schema ])
   where
     -- FIXME: Why is this check not being used?

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -532,7 +532,6 @@ genInferInput :: Range -> PrimMap -> IfaceParams -> IfaceDecls -> ModuleM T.Infe
 genInferInput r prims params env = do
   seeds <- getNameSeeds
   monoBinds <- getMonoBinds
-  cfg <- getSolverConfig
   solver <- getTCSolver
   supply <- getSupply
   searchPath <- getSearchPath
@@ -548,7 +547,6 @@ genInferInput r prims params env = do
     , T.inpNameSeeds = seeds
     , T.inpMonoBinds = monoBinds
     , T.inpCallStacks = callStacks
-    , T.inpSolverConfig = cfg
     , T.inpSearchPath = searchPath
     , T.inpSupply    = supply
     , T.inpPrimNames = prims

--- a/src/Cryptol/ModuleSystem/Env.hs
+++ b/src/Cryptol/ModuleSystem/Env.hs
@@ -60,9 +60,6 @@ data ModuleEnv = ModuleEnv
   , meNameSeeds     :: T.NameSeeds
     -- ^ A source of new names for the type checker.
 
-  , meSolverConfig  :: T.SolverConfig
-    -- ^ Configuration settings for the SMT solver used for type-checking.
-
   , meEvalEnv       :: EvalEnv
     -- ^ The evaluation environment.  Contains the values for all loaded
     -- modules, both public and private.
@@ -150,12 +147,6 @@ initialModuleEnv = do
     , meSearchPath    = searchPath
     , meDynEnv        = mempty
     , meMonoBinds     = True
-    , meSolverConfig  = T.SolverConfig
-                          { T.solverPath = "z3"
-                          , T.solverArgs = [ "-smt2", "-in" ]
-                          , T.solverVerbose = 0
-                          , T.solverPreludePath = searchPath
-                          }
     , meCoreLint      = NoCoreLint
     , meSupply        = emptySupply
     }

--- a/src/Cryptol/ModuleSystem/Monad.hs
+++ b/src/Cryptol/ModuleSystem/Monad.hs
@@ -570,16 +570,6 @@ setDynEnv denv = ModuleT $ do
   me <- get
   set $! me { meDynEnv = denv }
 
-setSolver :: T.SolverConfig -> ModuleM ()
-setSolver cfg = ModuleT $ do
-  me <- get
-  set $! me { meSolverConfig = cfg }
-
-getSolverConfig :: ModuleM T.SolverConfig
-getSolverConfig  = ModuleT $ do
-  me <- get
-  return (meSolverConfig me)
-
 -- | Usefule for logging.  For example: @withLogger logPutStrLn "Hello"@
 withLogger :: (Logger -> a -> IO b) -> a -> ModuleM b
 withLogger f a = do l <- getEvalOpts

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -81,7 +81,6 @@ import qualified Cryptol.TypeCheck.Error as T
 import qualified Cryptol.TypeCheck.Parseable as T
 import qualified Cryptol.TypeCheck.Subst as T
 import           Cryptol.TypeCheck.Solve(defaultReplExpr)
-import qualified Cryptol.TypeCheck.Solver.SMT as SMT
 import           Cryptol.TypeCheck.PP (dump,ppWithNames,emptyNameMap)
 import           Cryptol.Utils.PP
 import           Cryptol.Utils.Panic(panic)
@@ -1648,16 +1647,16 @@ liftModuleCmd cmd =
   do evo <- getEvalOptsAction
      env <- getModuleEnv
      callStacks <- getCallStacks
-     let cfg = M.meSolverConfig env
-     let minp s =
+     tcSolver <- getTCSolver
+     let minp =
              M.ModuleInput
                 { minpCallStacks = callStacks
                 , minpEvalOpts   = evo
                 , minpByteReader = BS.readFile
                 , minpModuleEnv  = env
-                , minpTCSolver   = s
+                , minpTCSolver   = tcSolver
                 }
-     moduleCmdResult =<< io (SMT.withSolver cfg (cmd . minp))
+     moduleCmdResult =<< io (cmd minp)
 
 moduleCmdResult :: M.ModuleRes a -> REPL a
 moduleCmdResult (res,ws0) = do
@@ -1735,9 +1734,8 @@ replEvalCheckedExpr def sig =
   do validEvalContext def
      validEvalContext sig
 
-     me <- getModuleEnv
-     let cfg = M.meSolverConfig me
-     mbDef <- io $ SMT.withSolver cfg (\s -> defaultReplExpr s def sig)
+     s <- getTCSolver
+     mbDef <- io (defaultReplExpr s def sig)
 
      (def1,ty) <-
         case mbDef of

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -36,6 +36,7 @@ module Cryptol.REPL.Monad (
   , getModuleEnv, setModuleEnv
   , getDynEnv, setDynEnv
   , getCallStacks
+  , getTCSolver
   , uniqify, freshName
   , whenDebug
   , getEvalOptsAction
@@ -91,6 +92,7 @@ import Cryptol.Parser.NoPat (Error)
 import Cryptol.Parser.Position (emptyRange, Range(from))
 import qualified Cryptol.TypeCheck.AST as T
 import qualified Cryptol.TypeCheck as T
+import qualified Cryptol.TypeCheck.Solver.SMT as SMT
 import qualified Cryptol.IR.FreeVars as T
 import qualified Cryptol.Utils.Ident as I
 import Cryptol.Utils.PP
@@ -102,6 +104,7 @@ import Cryptol.Symbolic.SBV (SBVPortfolioException)
 import Cryptol.Symbolic.What4 (W4Exception)
 import qualified Cryptol.Symbolic.SBV as SBV (proverNames, setupProver, defaultProver, SBVProverConfig)
 import qualified Cryptol.Symbolic.What4 as W4 (proverNames, setupProver, W4ProverConfig)
+
 
 import Control.Monad (ap,unless,when)
 import Control.Monad.Base
@@ -165,12 +168,27 @@ data RW = RW
     -- This is used to change the title of terminal when loading a module.
 
   , eProverConfig :: Either SBV.SBVProverConfig W4.W4ProverConfig
+
+  , eTCConfig :: T.SolverConfig
+    -- ^ Solver configuration to be used for typechecking
+
+  , eTCSolver :: Maybe SMT.Solver
+    -- ^ Solver instance to be used for typechecking
   }
 
+
 -- | Initial, empty environment.
-defaultRW :: Bool -> Bool ->Logger -> IO RW
+defaultRW :: Bool -> Bool -> Logger -> IO RW
 defaultRW isBatch callStacks l = do
   env <- M.initialModuleEnv
+  let searchPath = M.meSearchPath env
+  let solverConfig =
+             T.SolverConfig
+             { T.solverPath = "z3"
+             , T.solverArgs = [ "-smt2", "-in" ]
+             , T.solverVerbose = 0
+             , T.solverPreludePath = searchPath
+             }
   return RW
     { eLoadedMod   = Nothing
     , eEditFile    = Nothing
@@ -182,6 +200,8 @@ defaultRW isBatch callStacks l = do
     , eCallStacks  = callStacks
     , eUpdateTitle = return ()
     , eProverConfig = Left SBV.defaultProver
+    , eTCConfig    = solverConfig
+    , eTCSolver    = Nothing
     }
 
 -- | Build up the prompt for the REPL.
@@ -228,8 +248,10 @@ newtype REPL a = REPL { unREPL :: IORef RW -> IO a }
 -- | Run a REPL action with a fresh environment.
 runREPL :: Bool -> Bool -> Logger -> REPL a -> IO a
 runREPL isBatch callStacks l m = do
-  ref <- newIORef =<< defaultRW isBatch callStacks l
-  unREPL m ref
+  Ex.bracket
+    (newIORef =<< defaultRW isBatch callStacks l)
+    (unREPL resetTCSolver)
+    (unREPL m)
 
 instance Functor REPL where
   {-# INLINE fmap #-}
@@ -392,6 +414,25 @@ getPrompt  = mkPrompt `fmap` getRW
 
 getCallStacks :: REPL Bool
 getCallStacks = eCallStacks <$> getRW
+
+getTCSolver :: REPL SMT.Solver
+getTCSolver =
+  do rw <- getRW
+     case eTCSolver rw of
+       Just s -> return s
+       Nothing ->
+         do s <- io (SMT.startSolver (eTCConfig rw))
+            modifyRW_ (\rw' -> rw'{ eTCSolver = Just s })
+            return s
+
+resetTCSolver :: REPL ()
+resetTCSolver =
+  do mtc <- eTCSolver <$> getRW
+     case mtc of
+       Nothing -> return ()
+       Just s  ->
+         do io (SMT.stopSolver s)
+            modifyRW_ (\rw -> rw{ eTCSolver = Nothing })
 
 -- Get the setting we should use for displaying values.
 getPPValOpts :: REPL PPOpts
@@ -815,11 +856,11 @@ userOptions  = mkOptionMap
   , OptionDescr "tcSolver" ["tc-solver"] (EnvProg "z3" [ "-smt2", "-in" ])
     noCheck  -- TODO: check for the program in the path
     "The solver that will be used by the type checker." $
-    \case EnvProg prog args -> do me <- getModuleEnv
-                                  let cfg = M.meSolverConfig me
-                                  setModuleEnv me { M.meSolverConfig =
-                                                      cfg { T.solverPath = prog
-                                                          , T.solverArgs = args } }
+    \case EnvProg prog args -> do modifyRW_ (\rw -> rw { eTCConfig = (eTCConfig rw)
+                                                                      { T.solverPath = prog
+                                                                      , T.solverArgs = args
+                                                                      }})
+                                  resetTCSolver
           _                 -> return ()
 
   , OptionDescr "tcDebug" ["tc-debug"] (EnvNum 0)
@@ -829,9 +870,10 @@ userOptions  = mkOptionMap
       , "  *  0  no debug output"
       , "  *  1  show type-checker debug info"
       , "  * >1  show type-checker debug info and interactions with SMT solver"]) $
-    \case EnvNum n -> do me <- getModuleEnv
-                         let cfg = M.meSolverConfig me
-                         setModuleEnv me { M.meSolverConfig = cfg{ T.solverVerbose = n } }
+    \case EnvNum n -> do changed <- modifyRW (\rw -> ( rw{ eTCConfig = (eTCConfig rw){ T.solverVerbose = n } }
+                                                     , n /= T.solverVerbose (eTCConfig rw)
+                                                     ))
+                         when changed resetTCSolver
           _        -> return ()
   , OptionDescr "coreLint" ["core-lint"] (EnvBool False)
     noCheck

--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -76,7 +76,6 @@ data InferInput = InferInput
 
   , inpCallStacks :: Bool             -- ^ Are we tracking call stacks?
 
-  , inpSolverConfig :: SolverConfig   -- ^ Options for the constraint solver
   , inpSearchPath :: [FilePath]
     -- ^ Where to look for Cryptol theory file.
 


### PR DESCRIPTION
Push solver instances higher, into the REPL monad or the SolverState.

Some remaining questions regarding the remote API server:

1. Will this cause problems with concurrent clients?
2. There doesn't seem to be any way to do cleanup actions when
the server is shut down, so the solver will not be shut down
gracefully.  Is this a problem?