### PR TITLE
Reset the TC solver on CTRL^C

### DIFF
--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1404,8 +1404,8 @@ cdCmd f | null f = rPutStrLn $ "[error] :cd requires a path argument"
 -- XXX this should probably do something a bit more specific.
 handleCtrlC :: a -> REPL a
 handleCtrlC a = do rPutStrLn "Ctrl-C"
+                   resetTCSolver
                    return a
-
 
 -- Utilities -------------------------------------------------------------------
 

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -37,6 +37,7 @@ module Cryptol.REPL.Monad (
   , getDynEnv, setDynEnv
   , getCallStacks
   , getTCSolver
+  , resetTCSolver
   , uniqify, freshName
   , whenDebug
   , getEvalOptsAction


### PR DESCRIPTION
Generally, the CTRL^C will cause the solver to exit, so
this shuts down the current instance forces the REPL to
reopen a fresh instance the next time it is required.

Fixes #1157