### PR TITLE
feat(rpc): safe for python api

### DIFF
--- a/cryptol-remote-api/python/cryptol/__init__.py
+++ b/cryptol-remote-api/python/cryptol/__init__.py
@@ -206,7 +206,7 @@ class CryptolProveSat(argo.Command):
         if res['result'] == 'unsatisfiable':
             if self.qtype == SmtQueryType.SAT:
                 return False
-            elif self.qtype == SmtQueryType.PROVE or self.qtype == SmtQueryType.SAT:
+            elif self.qtype == SmtQueryType.PROVE or self.qtype == SmtQueryType.SAFE:
                 return True
             else:
                 raise ValueError("Unknown SMT query type: " + self.qtype)

--- a/cryptol-remote-api/python/cryptol/__init__.py
+++ b/cryptol-remote-api/python/cryptol/__init__.py
@@ -209,7 +209,7 @@ class CryptolProveSat(argo.Command):
             elif self.qtype == SmtQueryType.PROVE or self.qtype == SmtQueryType.SAT:
                 return True
             else:
-                raise ValueError("Unknown prove/sat query type: " + self.qtype)
+                raise ValueError("Unknown SMT query type: " + self.qtype)
         elif res['result'] == 'invalid':
             return [from_cryptol_arg(arg['expr'])
                     for arg in res['counterexample']]

--- a/cryptol-remote-api/python/tests/cryptol/test_AES.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_AES.py
@@ -28,8 +28,8 @@ class TestAES(unittest.TestCase):
         decrypted_ct = c.call("aesDecrypt", (ct, key)).result()
         self.assertEqual(pt, decrypted_ct)
 
-        # c.safe("aesEncrypt")
-        # c.safe("aesDecrypt")
+        self.assertTrue(c.safe("aesEncrypt"))
+        self.assertTrue(c.safe("aesDecrypt"))
         self.assertTrue(c.check("AESCorrect").result().success)
         # c.prove("AESCorrect") # probably takes too long for this script...?
 

--- a/cryptol-remote-api/python/tests/cryptol/test_cryptol_api.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_cryptol_api.py
@@ -138,6 +138,15 @@ class CryptolTests(unittest.TestCase):
         self.assertEqual(len(res.args), 1)
         self.assertIsInstance(res.error_msg, str)
 
+    def test_safe(self):
+        c = self.c
+        res = c.safe("\\x -> x==(x:[8])").result()
+        self.assertTrue(res)
+
+        res = c.safe("\\x -> x / (x:[8])").result()
+        self.assertEqual(res, [BV(size=8, value=0)])
+
+
     def test_many_usages_one_connection(self):
         c = self.c
         for i in range(0,100):

--- a/cryptol-remote-api/src/CryptolServer/Sat.hs
+++ b/cryptol-remote-api/src/CryptolServer/Sat.hs
@@ -157,6 +157,7 @@ instance FromJSON ProveSatParams where
            \case
              "sat" -> pure (SatQuery numResults)
              "prove" -> pure ProveQuery
+             "safe" -> pure SafetyQuery
              _ -> empty)
       num v = ((JSON.withText "all" $
                \t -> if t == "all" then pure AllSat else empty) v) <|>
@@ -174,17 +175,23 @@ instance Doc.DescribedParams ProveSatParams where
                      ++ (concat (map (\p -> [Doc.Literal (T.pack p), Doc.Text ", "]) proverNames))
                      ++ [Doc.Text "."]))
     , ("expression",
-      Doc.Paragraph [Doc.Text "The predicate (i.e., function) to check for satisfiability; "
-                    , Doc.Text "must be a monomorphic function with return type Bit." ])
+      Doc.Paragraph [ Doc.Text "The function to check for validity, satisfiability, or safety"
+                    , Doc.Text " depending on the specified value for "
+                    , Doc.Literal "query type"
+                    , Doc.Text ". For validity and satisfiability checks, the function must be a predicate"
+                    , Doc.Text " (i.e., monomorphic function with return type Bit)."
+                    ])
     , ("result count",
       Doc.Paragraph [Doc.Text "How many satisfying results to search for; either a positive integer or "
-                    , Doc.Literal "all", Doc.Text"."])
+                    , Doc.Literal "all", Doc.Text". Only affects satisfiability checks."])
     , ("query type",
-      Doc.Paragraph [ Doc.Text "Whether to attempt to prove ("
+      Doc.Paragraph [ Doc.Text "Whether to attempt to prove the predicate is true for all possible inputs ("
                     , Doc.Literal "prove"
-                    , Doc.Text ") or satisfy ("
+                    , Doc.Text "), find some inputs which make the predicate true ("
                     , Doc.Literal "sat"
-                    , Doc.Text ") the predicate."
+                    , Doc.Text "), or prove a function is safe ("
+                    , Doc.Literal "safe"
+                    , Doc.Text ")."
                     ]
       )
     ]


### PR DESCRIPTION
Add an equivalent to the REPL's `:safe` to the python API.

Addresses https://github.com/GaloisInc/cryptol/issues/1166