### PR TITLE
Add a shortcut to speed up concrete evaluation of pmod.

### DIFF
--- a/src/Cryptol/F2.hs
+++ b/src/Cryptol/F2.hs
@@ -32,7 +32,7 @@ pdiv w x m = go (w-1) 0 0
 
 
 pmod :: Int -> Integer -> Integer -> Integer
-pmod w x m = mask .&. go 0 0 (reduce 1)
+pmod w x m = go degree (x .&. mask) (clearBit m degree)
   where
     degree :: Int
     degree = fromInteger (widthInteger m - 1)
@@ -43,6 +43,7 @@ pmod w x m = mask .&. go 0 0 (reduce 1)
 
     mask = bit degree - 1
 
+    -- invariant: z and p are in the range [0..mask]
     go !i !z !p
       | i < w     = go (i+1) (if testBit x i then z `xor` p else z) (reduce (p `shiftL` 1))
       | otherwise = z


### PR DESCRIPTION
Used with a modulus of degree `d`, the low `d` bits of the input can be copied directly to the output unchanged. This lets us skip the first `d` iterations of the main loop.

This change reduces the runtime of my 42,000-bit polynomial GCD function from just over 3 minutes to less than 2.