### PR TITLE
Use correct link for GitHub Actions README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Cryptol](https://github.com/GaloisInc/cryptol/actions/workflows/build.yml/badge.svg?event=push)](https://github.com/GaloisInc/cryptol/actions/workflows/ci.yml)
+[![Cryptol](https://github.com/GaloisInc/cryptol/workflows/Cryptol/badge.svg)](https://github.com/GaloisInc/cryptol/actions?query=workflow%3ACryptol)
 
 # Cryptol, version 2
 


### PR DESCRIPTION
Currently, the GitHub Actions README badge doesn't display properly:

![cryptol](https://user-images.githubusercontent.com/2364661/115584838-19b63680-a299-11eb-830d-f2dbc3b05add.png)

After this patch, it now looks like:

![cryptol2](https://user-images.githubusercontent.com/2364661/115584853-1d49bd80-a299-11eb-94b2-e8876b35d27d.png)