### PR TITLE
Add a field order option for the pretty-printer

### DIFF
--- a/cryptol-remote-api/src/CryptolServer/Options.hs
+++ b/cryptol-remote-api/src/CryptolServer/Options.hs
@@ -7,12 +7,15 @@ module CryptolServer.Options (Options(..), WithOptions(..)) where
 
 import qualified Argo.Doc as Doc
 import Data.Aeson hiding (Options)
+import Data.Aeson.Types (Parser, typeMismatch)
+import Data.Coerce
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
 
 import Cryptol.Eval(EvalOpts(..))
-import Cryptol.REPL.Monad (parsePPFloatFormat)
+import Cryptol.REPL.Monad (parseFieldOrder, parsePPFloatFormat)
 import Cryptol.Utils.Logger (quietLogger)
-import Cryptol.Utils.PP (PPOpts(..), PPFloatFormat(..), PPFloatExp(..))
+import Cryptol.Utils.PP (PPOpts(..), PPFloatFormat(..), PPFloatExp(..), FieldOrder(..), defaultPPOpts)
 
 data Options = Options { optCallStacks :: Bool, optEvalOpts :: EvalOpts }
 
@@ -27,9 +30,17 @@ instance FromJSON JSONEvalOpts where
            o .:! "base" .!= 10 <*>
            o .:! "prefix of infinite lengths" .!= 5 <*>
            o .:! "floating point base" .!= 10 <*>
-           (getFloatFormat <$>
-            o .:! "floating point format" .!=
-            JSONFloatFormat (FloatFree AutoExponent))
+           newtypeField getFloatFormat o "floating point format" (FloatFree AutoExponent) <*>
+           newtypeField getFieldOrder o "field order" DisplayOrder
+
+newtypeField :: forall wrapped bare proxy.
+  (Coercible wrapped bare, FromJSON wrapped) =>
+  proxy wrapped bare ->
+  Object -> T.Text -> bare -> Parser bare
+newtypeField _proxy o field def = unwrap (o .:! field) .!= def where
+  unwrap :: Parser (Maybe wrapped) -> Parser (Maybe bare)
+  unwrap = coerce
+
 
 newtype JSONFloatFormat = JSONFloatFormat { getFloatFormat :: PPFloatFormat }
 
@@ -44,6 +55,14 @@ instance FromJSON JSONFloatFormat where
              pure fmt
            Nothing ->
              fail $ "Expected a valid floating point spec as in the Cryptol REPL, but got " ++ str
+
+
+newtype JSONFieldOrder = JSONFieldOrder { getFieldOrder :: FieldOrder }
+
+instance FromJSON JSONFieldOrder where
+  parseJSON (String t)
+    | Just order <- parseFieldOrder (T.unpack t) = pure $ JSONFieldOrder order
+  parseJSON v = typeMismatch "field order (\"display\" or \"canonical\")" v
 
 
 instance FromJSON Options where
@@ -68,4 +87,7 @@ defaultOpts :: Options
 defaultOpts = Options False theEvalOpts
 
 theEvalOpts :: EvalOpts
-theEvalOpts = EvalOpts quietLogger (PPOpts False 10 25 10 (FloatFree AutoExponent))
+theEvalOpts = EvalOpts quietLogger defaultPPOpts
+  { useInfLength = 25
+  , useFPBase = 10
+  }

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -165,7 +165,7 @@ ppValue x opts = loop
   loop :: GenValue sym -> SEval sym Doc
   loop val = case val of
     VRecord fs         -> do fs' <- traverse (>>= loop) fs
-                             return $ braces (sep (punctuate comma (map ppField (displayFields fs'))))
+                             return $ braces (sep (punctuate comma (map ppField (fields fs'))))
       where
       ppField (f,r) = pp f <+> char '=' <+> r
     VTuple vals        -> do vals' <- traverse (>>=loop) vals
@@ -184,6 +184,11 @@ ppValue x opts = loop
     VFun{}             -> return $ text "<function>"
     VPoly{}            -> return $ text "<polymorphic value>"
     VNumPoly{}         -> return $ text "<polymorphic value>"
+
+  fields :: RecordMap Ident Doc -> [(Ident, Doc)]
+  fields = case useFieldOrder opts of
+    DisplayOrder -> displayFields
+    CanonicalOrder -> canonicalFields
 
   ppWordVal :: WordValue sym -> SEval sym Doc
   ppWordVal w = ppSWord x opts =<< asWordVal x w

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -433,24 +433,24 @@ resetTCSolver =
 -- Get the setting we should use for displaying values.
 getPPValOpts :: REPL PPOpts
 getPPValOpts =
-  do base      <- getKnownUser "base"
-     ascii     <- getKnownUser "ascii"
-     infLength <- getKnownUser "infLength"
+  do base       <- getKnownUser "base"
+     ascii      <- getKnownUser "ascii"
+     infLength  <- getKnownUser "infLength"
 
-     fpBase    <- getKnownUser "fpBase"
-     fpFmtTxt  <- getKnownUser "fpFormat"
-     fieldOrder<- getKnownUser "fieldOrder"
+     fpBase     <- getKnownUser "fpBase"
+     fpFmtTxt   <- getKnownUser "fpFormat"
+     fieldOrder <- getKnownUser "fieldOrder"
      let fpFmt = case parsePPFloatFormat fpFmtTxt of
                    Just f  -> f
                    Nothing -> panic "getPPOpts"
                                       [ "Failed to parse fp-format" ]
 
-     return PPOpts { useBase      = base
-                   , useAscii     = ascii
-                   , useInfLength = infLength
-                   , useFPBase    = fpBase
-                   , useFPFormat  = fpFmt
-                   , useFieldOrder= fieldOrder
+     return PPOpts { useBase       = base
+                   , useAscii      = ascii
+                   , useInfLength  = infLength
+                   , useFPBase     = fpBase
+                   , useFPFormat   = fpFmt
+                   , useFieldOrder = fieldOrder
                    }
 
 getEvalOptsAction :: REPL (IO EvalOpts)

--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -223,9 +223,6 @@ data RO = RO
     -- modules we are currently constructing.
     -- XXX: this sould probably be an interface
 
-    -- ^ Information about top-level declarations in modules under
-    -- construction, most nested first.
-
   , iSolvedHasLazy :: Map Int HasGoalSln
     -- ^ NOTE: This field is lazy in an important way!  It is the
     -- final version of 'iSolvedHas' in 'RW', and the two are tied
@@ -813,7 +810,7 @@ endLocalScope =
        case iScope rw of
          x : xs | LocalScope <- mName x ->
                     (reverse (mDecls x), rw { iScope = xs })
-            -- ^ This ignores local type synonyms... Where should we put them?
+            -- This ignores local type synonyms... Where should we put them?
 
          _ -> panic "endLocalScope" ["Missing local scope"]
 

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -35,6 +35,7 @@ data PPOpts = PPOpts
   , useInfLength :: Int
   , useFPBase    :: Int
   , useFPFormat  :: PPFloatFormat
+  , useFieldOrder:: FieldOrder
   }
  deriving Show
 
@@ -51,11 +52,14 @@ data PPFloatExp = ForceExponent -- ^ Always show an exponent
                 | AutoExponent  -- ^ Only show exponent when needed
  deriving Show
 
+data FieldOrder = DisplayOrder | CanonicalOrder deriving (Bounded, Enum, Eq, Ord, Read, Show)
+
 
 defaultPPOpts :: PPOpts
 defaultPPOpts = PPOpts { useAscii = False, useBase = 10, useInfLength = 5
                        , useFPBase = 16
                        , useFPFormat = FloatFree AutoExponent
+                       , useFieldOrder = DisplayOrder
                        }
 
 

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -30,12 +30,12 @@ import Prelude.Compat
 
 -- | How to pretty print things when evaluating
 data PPOpts = PPOpts
-  { useAscii     :: Bool
-  , useBase      :: Int
-  , useInfLength :: Int
-  , useFPBase    :: Int
-  , useFPFormat  :: PPFloatFormat
-  , useFieldOrder:: FieldOrder
+  { useAscii      :: Bool
+  , useBase       :: Int
+  , useInfLength  :: Int
+  , useFPBase     :: Int
+  , useFPFormat   :: PPFloatFormat
+  , useFieldOrder :: FieldOrder
   }
  deriving Show
 


### PR DESCRIPTION
We're working on a cryptol-to-C compiler, and one way we've been validating that it's working right is to use the cryptol repl's `:dumptests` feature and a small C wrapper that treats them as golden tests. I'd like to keep the C wrapper's parser simple, and if records get printed with a predictable field order, that simplifies the parser a lot.

This pull request adds a feature for this: a new setting, `fieldOrder`/`field-order` in the REPL, which can be set to `canonical` or `display`, and which controls the pretty-printer for records. It defaults to `display` for backwards compatibility.

(Actually, I'm going to use a different branch than `master` for the C compiler, but I'd like to minimize drift between them if possible.)