### PR TITLE
Defer `CallStack` computations by representing them as data constructors.

### DIFF
--- a/src/Cryptol/Backend/Monad.hs
+++ b/src/Cryptol/Backend/Monad.hs
@@ -113,6 +113,8 @@ combineCallStacks ::
   CallStack {- ^ call stack of the application context -} ->
   CallStack {- ^ call stack of the function being applied -} ->
   CallStack
+combineCallStacks appstk EmptyCallStack = appstk
+combineCallStacks EmptyCallStack fnstk = fnstk
 combineCallStacks appstk fnstk = CombineCallStacks appstk fnstk
 
 combineCallStacks' ::


### PR DESCRIPTION
This avoids expensive calls to `combineCallStacks` in the common case; the actual call stack values are only computed in the case where they need to be printed out.

This helps with #1201.