### PR TITLE
fastTypeOf panic tweak

### DIFF
--- a/src/Cryptol/TypeCheck/TypeOf.hs
+++ b/src/Cryptol/TypeCheck/TypeOf.hs
@@ -54,8 +54,12 @@ fastTypeOf tyenv expr =
     polymorphic =
       case fastSchemaOf tyenv expr of
         Forall [] [] ty -> ty
-        _ -> panic "Cryptol.TypeCheck.TypeOf.fastTypeOf"
-               [ "unexpected polymorphic type" ]
+        s@Forall {} -> panic "Cryptol.TypeCheck.TypeOf.fastTypeOf"
+               [ "unexpected polymorphic type in expression:"
+               , pretty expr
+               , "with schema:"
+               , pretty s
+               ]
 
 fastSchemaOf :: Map Name Schema -> Expr -> Schema
 fastSchemaOf tyenv expr =


### PR DESCRIPTION
This adds a bit more information to the `panic` message in `Cryptol.TypeCheck.TypeOf.fastTypeOf`.