### PR TITLE
Explicit stride

### DIFF
--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -195,19 +195,66 @@ length _ = `n
 /**
  * A finite sequence counting up from 'first' to 'last'.
  *
- * '[a..b]' is syntactic sugar for 'fromTo`{first=a,last=b}'.
+ * '[x .. y]' is syntactic sugar for 'fromTo`{first=x,last=y}'.
  */
-primitive fromTo : {first, last, a} (fin last, last >= first,
-                                    Literal first a, Literal last a) =>
-                                    [1 + (last - first)]a
+primitive fromTo : {first, last, a}
+  (fin last, last >= first, Literal last a) =>
+  [1 + (last - first)]a
+
+/**
+ * A finite sequence counting up from 'first' to 'last' by 'stride'
+ *
+ * '[x .. y by n]` is syntactic sugar for 'fromToBy`{first=x,last=y,stride=n}'.
+ */
+primitive fromToBy : {first, last, stride, a}
+  (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+  [1 + (last - first)/stride]a
 
 /**
  * A possibly infinite sequence counting up from 'first' up to (but not including) 'bound'.
  *
- * Note that if 'first' = 'bound' then the sequence will be empty.
+ * '[ x ..< y ]' is syntacic sugar for 'fromToLessThan`{first=x,bound=y}'.
+ *
+ * Note that if 'first' = 'bound' then the sequence will be empty.  If 'bound = inf'
+ * then the sequence will be infinite, and will eventually wrap around for bounded types.
  */
 primitive fromToLessThan :
-  {first, bound, a} (fin first, bound >= first, LiteralLessThan bound a) => [bound - first]a
+  {first, bound, a} (fin first, bound >= first, LiteralLessThan bound a) =>
+  [bound - first]a
+
+/**
+ * A finite sequence counting from 'first' up to (but not including) 'bound'
+ * by 'stride'.  Note that if 'first = bound' then the sequence will
+ * be empty.  If 'bound = inf' then the sequence will be infinite, and will
+ * eventually wrap around for bounded types.
+ *
+ * '[x ..< y by n]' is syntactic sugar for 'fromToByLessThan`{first=a,bound=b,stride=n}'.
+ */
+primitive fromToByLessThan : {first, bound, stride, a}
+  (fin first, fin stride, stride >= 1, bound >= first, LiteralLessThan bound a) =>
+  [(bound - first)/^stride]a
+
+/**
+ * A finite sequence counting from 'first' down to 'last' by 'stride'.
+ *
+ * '[x .. y down by n]` is syntactic sugar for 'fromToDownBy`{first=x,last=y,stride=n}'.
+ */
+primitive fromToDownBy : {first, last, stride, a}
+  (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+  [1 + (first - last)/stride]a
+
+/**
+ * A finite sequence counting from 'first' down to (but not including)
+ * 'bound' by 'stride'.
+ *
+ * '[x ..> y down by n]` is syntactic sugar for
+ * 'fromToDownByGreaterThan`{first=x,bound=y,stride=n}'.
+ *
+ * Note that if 'first = bound' the sequence will be empty.
+ */
+primitive fromToDownByGreaterThan : {first, bound, stride, a}
+  (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+  [(first - bound)/^stride]a
 
 
 /**

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -727,6 +727,18 @@ instance Rename Expr where
                                <*> traverse rename n
                                <*> rename e
                                <*> traverse rename t
+    EFromToBy isStrict s e b t ->
+                       EFromToBy isStrict
+                                 <$> rename s
+                                 <*> rename e
+                                 <*> rename b
+                                 <*> traverse rename t
+    EFromToDownBy isStrict s e b t ->
+                       EFromToDownBy isStrict
+                                 <$> rename s
+                                 <*> rename e
+                                 <*> rename b
+                                 <*> traverse rename t
     EFromToLessThan s e t ->
                        EFromToLessThan <$> rename s
                                        <*> rename e

--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -351,6 +351,11 @@ data Expr n   = EVar n                          -- ^ @ x @
               | EList [Expr n]                  -- ^ @ [1,2,3] @
               | EFromTo (Type n) (Maybe (Type n)) (Type n) (Maybe (Type n))
                                                 -- ^ @ [1, 5 .. 117 : t] @
+              | EFromToBy Bool (Type n) (Type n) (Type n) (Maybe (Type n))
+                                                -- ^ @ [1 .. 10 by 2 : t ] @
+
+              | EFromToDownBy Bool (Type n) (Type n) (Type n) (Maybe (Type n))
+                                                -- ^ @ [10 .. 1 down by 2 : t ] @
               | EFromToLessThan (Type n) (Type n) (Maybe (Type n))
                                                 -- ^ @ [ 1 .. < 10 : t ] @
 
@@ -817,6 +822,14 @@ instance (Show name, PPName name) => PP (Expr name) where
       EFromTo e1 e2 e3 t1 -> brackets (pp e1 <.> step <+> text ".." <+> end)
         where step = maybe empty (\e -> comma <+> pp e) e2
               end = maybe (pp e3) (\t -> pp e3 <+> colon <+> pp t) t1
+      EFromToBy isStrict e1 e2 e3 t1 -> brackets (pp e1 <+> dots <+> pp e2 <+> text "by" <+> end)
+        where end = maybe (pp e3) (\t -> pp e3 <+> colon <+> pp t) t1
+              dots | isStrict  = text ".. <"
+                   | otherwise = text ".."
+      EFromToDownBy isStrict e1 e2 e3 t1 -> brackets (pp e1 <+> dots <+> pp e2 <+> text "down by" <+> end)
+        where end = maybe (pp e3) (\t -> pp e3 <+> colon <+> pp t) t1
+              dots | isStrict  = text ".. >"
+                   | otherwise = text ".."
       EFromToLessThan e1 e2 t1 -> brackets (strt <+> text ".. <" <+> end)
         where strt = maybe (pp e1) (\t -> pp e1 <+> colon <+> pp t) t1
               end  = pp e2
@@ -1074,6 +1087,10 @@ instance NoPos (Expr name) where
       EUpd x y        -> EUpd     (noPos x) (noPos y)
       EList x         -> EList    (noPos x)
       EFromTo x y z t -> EFromTo  (noPos x) (noPos y) (noPos z) (noPos t)
+      EFromToBy isStrict x y z t
+                      -> EFromToBy isStrict (noPos x) (noPos y) (noPos z) (noPos t)
+      EFromToDownBy isStrict x y z t
+                      -> EFromToDownBy isStrict (noPos x) (noPos y) (noPos z) (noPos t)
       EFromToLessThan x y t -> EFromToLessThan (noPos x) (noPos y) (noPos t)
       EInfFrom x y    -> EInfFrom (noPos x) (noPos y)
       EComp x y       -> EComp    (noPos x) (noPos y)

--- a/src/Cryptol/Parser/Lexer.x
+++ b/src/Cryptol/Parser/Lexer.x
@@ -116,6 +116,8 @@ $white+                   { emit $ White Space }
 "as"                      { emit $ KW KW_as }
 "hiding"                  { emit $ KW KW_hiding }
 "newtype"                 { emit $ KW KW_newtype }
+"down"                    { emit $ KW KW_down }
+"by"                      { emit $ KW KW_by }
 
 "infixl"                  { emit $ KW KW_infixl }
 "infixr"                  { emit $ KW KW_infixr }
@@ -147,6 +149,7 @@ $white+                   { emit $ White Space }
 ".."                      { emit $ Sym DotDot }
 "..."                     { emit $ Sym DotDotDot }
 "..<"                     { emit $ Sym DotDotLt  }
+"..>"                     { emit $ Sym DotDotGt  }
 "|"                       { emit $ Sym Bar }
 "("                       { emit $ Sym ParenL }
 ")"                       { emit $ Sym ParenR }
@@ -168,6 +171,9 @@ $white+                   { emit $ White Space }
 
 -- < can appear in the enumeration syntax `[ x .. < y ]
 "<"                       { emit $ Sym Lt }
+
+-- > can appear in the enumeration syntax `[ x .. > y down by n ]
+">"                       { emit $ Sym Gt }
 
 -- hash is used as a kind, and as a pattern
 "#"                       { emit  (Op   Hash ) }

--- a/src/Cryptol/Parser/Names.hs
+++ b/src/Cryptol/Parser/Names.hs
@@ -82,6 +82,8 @@ namesE expr =
                      in Set.unions (e : map namesUF fs)
     EList es      -> Set.unions (map namesE es)
     EFromTo{}     -> Set.empty
+    EFromToBy{}   -> Set.empty
+    EFromToDownBy{} -> Set.empty
     EFromToLessThan{} -> Set.empty
     EInfFrom e e' -> Set.union (namesE e) (maybe Set.empty namesE e')
     EComp e arms  -> let (dss,uss) = unzip (map namesArm arms)
@@ -203,6 +205,8 @@ tnamesE expr =
                        `Set.union` maybe Set.empty tnamesT b
                        `Set.union` tnamesT c
                        `Set.union` maybe Set.empty tnamesT t
+    EFromToBy _ a b c t -> Set.unions [ tnamesT a, tnamesT b, tnamesT c, maybe Set.empty tnamesT t ]
+    EFromToDownBy _ a b c t -> Set.unions [ tnamesT a, tnamesT b, tnamesT c, maybe Set.empty tnamesT t ]
     EFromToLessThan a b t -> tnamesT a `Set.union` tnamesT b
                                        `Set.union` maybe Set.empty tnamesT t
     EInfFrom e e'   -> Set.union (tnamesE e) (maybe Set.empty tnamesE e')

--- a/src/Cryptol/Parser/NoPat.hs
+++ b/src/Cryptol/Parser/NoPat.hs
@@ -159,6 +159,8 @@ noPatE expr =
     EUpd mb fs    -> EUpd    <$> traverse noPatE mb <*> traverse noPatUF fs
     EList es      -> EList   <$> mapM noPatE es
     EFromTo {}    -> return expr
+    EFromToBy {}  -> return expr
+    EFromToDownBy {} -> return expr
     EFromToLessThan{} -> return expr
     EInfFrom e e' -> EInfFrom <$> noPatE e <*> traverse noPatE e'
     EComp e mss   -> EComp  <$> noPatE e <*> mapM noPatArm mss

--- a/src/Cryptol/Parser/ParserUtils.hs
+++ b/src/Cryptol/Parser/ParserUtils.hs
@@ -378,6 +378,43 @@ eFromTo r e1 e2 e3 =
     (Nothing, Nothing, Nothing) -> eFromToType r e1 e2 e3 Nothing
     _ -> errorMessage r ["A sequence enumeration may have at most one element type annotation."]
 
+eFromToBy :: Range -> Expr PName -> Expr PName -> Expr PName -> Bool -> ParseM (Expr PName)
+eFromToBy r e1 e2 e3 isStrictBound =
+  case (asETyped e1, asETyped e2, asETyped e3) of
+    (Just (e1', t), Nothing, Nothing) -> eFromToByTyped r e1' e2 e3 (Just t) isStrictBound
+    (Nothing, Just (e2', t), Nothing) -> eFromToByTyped r e1 e2' e3 (Just t) isStrictBound   
+    (Nothing, Nothing, Just (e3', t)) -> eFromToByTyped r e1 e2 e3' (Just t) isStrictBound
+    (Nothing, Nothing, Nothing)       -> eFromToByTyped r e1 e2 e3 Nothing isStrictBound
+    _ -> errorMessage r ["A sequence enumeration may have at most one element type annotation."]
+
+eFromToByTyped :: Range -> Expr PName -> Expr PName -> Expr PName -> Maybe (Type PName) -> Bool -> ParseM (Expr PName)
+eFromToByTyped r e1 e2 e3 t isStrictBound =
+  EFromToBy isStrictBound
+      <$> exprToNumT r e1
+      <*> exprToNumT r e2
+      <*> exprToNumT r e3
+      <*> pure t
+
+eFromToDownBy ::
+  Range -> Expr PName -> Expr PName -> Expr PName -> Bool -> ParseM (Expr PName)
+eFromToDownBy r e1 e2 e3 isStrictBound =
+  case (asETyped e1, asETyped e2, asETyped e3) of
+    (Just (e1', t), Nothing, Nothing) -> eFromToDownByTyped r e1' e2 e3 (Just t) isStrictBound
+    (Nothing, Just (e2', t), Nothing) -> eFromToDownByTyped r e1 e2' e3 (Just t) isStrictBound   
+    (Nothing, Nothing, Just (e3', t)) -> eFromToDownByTyped r e1 e2 e3' (Just t) isStrictBound
+    (Nothing, Nothing, Nothing)       -> eFromToDownByTyped r e1 e2 e3 Nothing isStrictBound
+    _ -> errorMessage r ["A sequence enumeration may have at most one element type annotation."]
+
+eFromToDownByTyped ::
+  Range -> Expr PName -> Expr PName -> Expr PName -> Maybe (Type PName) -> Bool -> ParseM (Expr PName)
+eFromToDownByTyped r e1 e2 e3 t isStrictBound =
+  EFromToDownBy isStrictBound
+      <$> exprToNumT r e1
+      <*> exprToNumT r e2
+      <*> exprToNumT r e3
+      <*> pure t
+
+
 asETyped :: Expr n -> Maybe (Expr n, Type n)
 asETyped (ELocated e _) = asETyped e
 asETyped (ETyped e t) = Just (e, t)

--- a/src/Cryptol/Parser/Token.hs
+++ b/src/Cryptol/Parser/Token.hs
@@ -51,6 +51,8 @@ data TokenKW  = KW_else
               | KW_parameter
               | KW_constraint
               | KW_Prop
+              | KW_by
+              | KW_down
                 deriving (Eq, Show, Generic, NFData)
 
 -- | The named operators are a special case for parsing types, and 'Other' is
@@ -71,13 +73,14 @@ data TokenSym = Bar
               | DotDot
               | DotDotDot
               | DotDotLt
+              | DotDotGt
               | Colon
               | BackTick
               | ParenL   | ParenR
               | BracketL | BracketR
               | CurlyL   | CurlyR
               | TriL     | TriR
-              | Lt
+              | Lt | Gt
               | Underscore
                 deriving (Eq, Show, Generic, NFData)
 

--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -278,11 +278,57 @@ checkE expr tGoal =
          es' <- mapM checkElem es
          return (EList es' a)
 
-    P.EFromToBy _isStrict _t1 _t2 _t3 _mety ->
-      error "TODO! implement typechecking for EFromToBy"
+    P.EFromToBy isStrict t1 t2 t3 mety
+      | isStrict ->
+        do l <- curRange
+           let fs = [("first",t1),("bound",t2),("stride",t3)] ++
+                    case mety of
+                      Just ety -> [("a",ety)]
+                      Nothing  -> []
+           prim <- mkPrim "fromToByLessThan"
+           let e' = P.EAppT prim
+                    [ P.NamedInst P.Named{ name = Located l (packIdent x), value = y }
+                    | (x,y) <- fs
+                    ]
+           checkE e' tGoal
+      | otherwise ->
+        do l <- curRange
+           let fs = [("first",t1),("last",t2),("stride",t3)] ++
+                    case mety of
+                      Just ety -> [("a",ety)]
+                      Nothing  -> []
+           prim <- mkPrim "fromToBy"
+           let e' = P.EAppT prim
+                    [ P.NamedInst P.Named{ name = Located l (packIdent x), value = y }
+                    | (x,y) <- fs
+                    ]
+           checkE e' tGoal
 
-    P.EFromToDownBy _isStrict _t1 _t2 _t3 _mety ->
-      error "TODO! implement typechecking for EFromToDownBy"
+    P.EFromToDownBy isStrict t1 t2 t3 mety
+      | isStrict ->
+        do l <- curRange
+           let fs = [("first",t1),("bound",t2),("stride",t3)] ++
+                    case mety of
+                      Just ety -> [("a",ety)]
+                      Nothing  -> []
+           prim <- mkPrim "fromToDownByGreaterThan"
+           let e' = P.EAppT prim
+                    [ P.NamedInst P.Named{ name = Located l (packIdent x), value = y }
+                    | (x,y) <- fs
+                    ]
+           checkE e' tGoal
+      | otherwise ->
+        do l <- curRange
+           let fs = [("first",t1),("last",t2),("stride",t3)] ++
+                    case mety of
+                      Just ety -> [("a",ety)]
+                      Nothing  -> []
+           prim <- mkPrim "fromToDownBy"
+           let e' = P.EAppT prim
+                    [ P.NamedInst P.Named{ name = Located l (packIdent x), value = y }
+                    | (x,y) <- fs
+                    ]
+           checkE e' tGoal
 
     P.EFromToLessThan t1 t2 mety ->
       do l <- curRange

--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -164,6 +164,8 @@ appTys expr ts tGoal =
     P.ESel      {} -> mono
     P.EList     {} -> mono
     P.EFromTo   {} -> mono
+    P.EFromToBy {} -> mono
+    P.EFromToDownBy {} -> mono
     P.EFromToLessThan {} -> mono
     P.EInfFrom  {} -> mono
     P.EComp     {} -> mono
@@ -275,6 +277,12 @@ checkE expr tGoal =
          let checkElem e = checkE e (WithSource a TypeOfSeqElement)
          es' <- mapM checkElem es
          return (EList es' a)
+
+    P.EFromToBy _isStrict _t1 _t2 _t3 _mety ->
+      error "TODO! implement typechecking for EFromToBy"
+
+    P.EFromToDownBy _isStrict _t1 _t2 _t3 _mety ->
+      error "TODO! implement typechecking for EFromToDownBy"
 
     P.EFromToLessThan t1 t2 mety ->
       do l <- curRange


### PR DESCRIPTION
This PR adds new syntactic forms for enumerations with explicit stride values (CF #1087).

The currently-implemented syntax steals the identifiers `by` and `down` as new keywords; we should discuss if this is acceptable, or if new syntax should be designed.