### PR TITLE
What4 online

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,18 @@
     - Paren blocks nested in a layout block need to respect the indentation
       if the layout block
     - We allow nested layout blocks to have the same indentation, which is
-      conveninet when writing `private` declarations as they don't need to
+      convenient when writing `private` declarations as they don't need to
       be indented as long as they are at the end of the file.
+
+## New features
+
+* What4 prover backends now feature an improved multi-SAT procedure
+  which is significantly faster than the old algorithm. Thanks to
+  Levent Erkök for the suggestion.
+
+* There is a new `w4-abc` solver option, which communicates to ABC
+  as an external process via What4.
+
 
 # 2.11.0
 

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -91,7 +91,7 @@ executable cryptol-remote-api
 
   build-depends:
     cryptol-remote-api,
-    sbv < 8.10
+    sbv
 
   if os(linux) && flag(static)
       ld-options:      -static -pthread
@@ -108,7 +108,7 @@ executable cryptol-eval-server
   build-depends:
     cryptol-remote-api,
     optparse-applicative,
-    sbv < 8.10
+    sbv
 
   if os(linux) && flag(static)
       ld-options:      -static -pthread

--- a/cryptol-remote-api/docs/Cryptol.rst
+++ b/cryptol-remote-api/docs/Cryptol.rst
@@ -557,7 +557,7 @@ Parameter fields
 
 
 ``prover``
-  The SMT solver to use to check for satisfiability. I.e., one of the following: ``w4-cvc4``, ``w4-yices``, ``w4-z3``, ``w4-boolector``, ``w4-offline``, ``w4-any``, ``cvc4``, ``yices``, ``z3``, ``boolector``, ``mathsat``, ``abc``, ``offline``, ``any``, ``sbv-cvc4``, ``sbv-yices``, ``sbv-z3``, ``sbv-boolector``, ``sbv-mathsat``, ``sbv-abc``, ``sbv-offline``, ``sbv-any``.
+  The SMT solver to use to check for satisfiability. I.e., one of the following: ``w4-cvc4``, ``w4-yices``, ``w4-z3``, ``w4-boolector``, ``w4-abc``, ``w4-offline``, ``w4-any``, ``cvc4``, ``yices``, ``z3``, ``boolector``, ``mathsat``, ``abc``, ``offline``, ``any``, ``sbv-cvc4``, ``sbv-yices``, ``sbv-z3``, ``sbv-boolector``, ``sbv-mathsat``, ``sbv-abc``, ``sbv-offline``, ``sbv-any``.
   
   
 

--- a/cryptol-remote-api/src/CryptolServer/Sat.hs
+++ b/cryptol-remote-api/src/CryptolServer/Sat.hs
@@ -118,10 +118,10 @@ offlineProveSat proverName cmd hConsing = do
         Left msg -> do
           raise $ proverError $ "error setting up " ++ proverName ++ ": " ++ msg
         Right smtlib -> pure $ OfflineSMTQuery $ T.pack smtlib
-    Right w4Cfg -> do
+    Right _w4Cfg -> do
       smtlibRef <- liftIO $ newIORef ("" :: Text)
       result <- liftModuleCmd $
-        W4.satProveOffline w4Cfg hConsing False cmd $ \f -> do
+        W4.satProveOffline hConsing False cmd $ \f -> do
           withRWTempFile "smtOutput.tmp" $ \h -> do
             f h
             hSeek h AbsoluteSeek 0

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -785,6 +785,9 @@ proveSatExpr isSat rng exprDoc texpr schema = do
             ~(EnvBool yes) <- getUser "showExamples"
             when yes $ forM_ vss (printSatisfyingModel exprDoc)
 
+            let numModels = length tevss
+            when (numModels > 1) (rPutStrLn ("Models found: " ++ show numModels))
+
             case exprs of
               [e] -> void $ bindItVariable ty e
               _   -> bindItVariables ty exprs

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -888,10 +888,10 @@ offlineProveSat proverName qtype expr schema mfile = do
                Just path -> io $ writeFile path smtlib
                Nothing -> rPutStr smtlib
 
-    Right w4Cfg ->
+    Right _w4Cfg ->
       do ~(EnvBool hashConsing) <- getUser "hashConsing"
          ~(EnvBool warnUninterp) <- getUser "warnUninterp"
-         result <- liftModuleCmd $ W4.satProveOffline w4Cfg hashConsing warnUninterp cmd $ \f ->
+         result <- liftModuleCmd $ W4.satProveOffline hashConsing warnUninterp cmd $ \f ->
                      do displayMsg
                         case mfile of
                           Just path ->

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -38,6 +38,8 @@ module Cryptol.Symbolic
  , modelPred
  , varModelPred
  , varToExpr
+ , flattenShape
+ , flattenShapes
  ) where
 
 
@@ -221,6 +223,24 @@ ppVarShape sym (VarRecord fs) =
  where
   ppField (f,v) = pp f <+> char '=' <+> ppVarShape sym v
 
+
+-- | Flatten structured shapes (like tuples and sequences), leaving only
+--   a sequence of variable shapes of base type.
+flattenShapes :: [VarShape sym] -> [VarShape sym] -> [VarShape sym]
+flattenShapes []     tl = tl
+flattenShapes (x:xs) tl = flattenShape x (flattenShapes xs tl)
+
+flattenShape :: VarShape sym -> [VarShape sym] -> [VarShape sym]
+flattenShape x tl =
+  case x of
+    VarBit{}       -> x : tl
+    VarInteger{}   -> x : tl
+    VarRational{}  -> x : tl
+    VarWord{}      -> x : tl
+    VarFloat{}     -> x : tl
+    VarFinSeq _ vs -> flattenShapes vs tl
+    VarTuple vs    -> flattenShapes vs tl
+    VarRecord fs   -> flattenShapes (recordElements fs) tl
 
 varShapeToValue :: Backend sym => sym -> VarShape sym -> GenValue sym
 varShapeToValue sym var =

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -78,9 +78,10 @@ import qualified What4.SFloat as W4
 import qualified What4.SWord as SW
 import           What4.Solver
 import qualified What4.Solver.Boolector as W4
-import qualified What4.Solver.Z3 as W4
 import qualified What4.Solver.CVC4 as W4
+import qualified What4.Solver.ExternalABC as W4
 import qualified What4.Solver.Yices as W4
+import qualified What4.Solver.Z3 as W4
 import qualified What4.Solver.Adapter as W4
 import qualified What4.Protocol.Online as W4
 import qualified What4.Protocol.SMTLib2 as W4
@@ -159,6 +160,9 @@ proverConfigs =
   , ("w4-yices"     , W4ProverConfig yicesOnlineAdapter)
   , ("w4-z3"        , W4ProverConfig z3OnlineAdapter)
   , ("w4-boolector" , W4ProverConfig boolectorOnlineAdapter)
+
+  , ("w4-abc"       , W4ProverConfig (AnAdapter W4.externalABCAdapter))
+
   , ("w4-offline"   , W4OfflineConfig )
   , ("w4-any"       , allSolvers)
   ]

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -196,6 +196,7 @@ allSolvers = W4Portfolio
   [ cvc4OnlineAdapter
   , boolectorOnlineAdapter
   , yicesOnlineAdapter
+  , AnAdapter W4.externalABCAdapter
   ]
 
 defaultProver :: W4ProverConfig

--- a/tests/issues/issue072.icry.stdout
+++ b/tests/issues/issue072.icry.stdout
@@ -2,8 +2,10 @@ Loading module Cryptol
 Satisfiable
 it : {result : Bit, arg1 : [4]}
 Satisfiable
+Models found: 11
 it : [11]{result : Bit, arg1 : [4]}
 must be an integer > 0 or "all"
 must be an integer > 0 or "all"
 Satisfiable
+Models found: 3
 it : [3]{result : Bit, arg1 : [4]}

--- a/tests/regression/allsat.cry
+++ b/tests/regression/allsat.cry
@@ -1,0 +1,3 @@
+f : (Integer, Integer, Integer) -> Bit
+f (x, y, z) =  inRange x && inRange y && inRange z
+  where inRange v = (1 <= v) && (v <= 15)

--- a/tests/regression/allsat.icry
+++ b/tests/regression/allsat.icry
@@ -2,8 +2,8 @@
 
 :set satNum=all
 :set showExamples=false
-:set prover=sbv-yices
+:set prover=sbv-z3
 :sat f
 
-:set prover=w4-yices
+:set prover=w4-z3
 :sat f

--- a/tests/regression/allsat.icry
+++ b/tests/regression/allsat.icry
@@ -1,0 +1,9 @@
+:l allsat.cry
+
+:set satNum=all
+:set showExamples=false
+:set prover=sbv-yices
+:sat f
+
+:set prover=w4-yices
+:sat f

--- a/tests/regression/allsat.icry.stdout
+++ b/tests/regression/allsat.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+Satisfiable
+Models found: 3375
+Satisfiable
+Models found: 3375


### PR DESCRIPTION
Reconfigure the What4 prover backends to use online/incremental mode instead of one-shot mode.

This significantly improve the performance of multi-SAT queries, partially addressing #1125.