### PR TITLE
fix: remove automatic reset from python client connection

### DIFF
--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -258,14 +258,6 @@ class CryptolConnection:
         CryptolResetServer(self)
         self.most_recent_result = None
 
-    def __del__(self) -> None:
-        # when being deleted, ensure we don't have a lingering state on the server
-        if self.most_recent_result is not None:
-            try:
-                CryptolReset(self)
-            except Exception:
-                pass
-
 class CryptolDynamicSocketProcess(DynamicSocketProcess):
 
     def __init__(self, command: str, *,


### PR DESCRIPTION
@kquick pointed out using `__del__` in this way to send a final HTTP request to reset the server could potentially cause problems and/or hangs in certain situations.