### PR TITLE
Temporarily disable uploading artifacts for Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,15 @@ jobs:
           path: bin
           name: ${{ runner.os }}-bin
 
-      - uses: actions/upload-artifact@v2
-        if: runner.os == 'Windows'
-        with:
-          name: ${{ env.NAME }}
-          path: "cryptol.msi*"
-          if-no-files-found: error
-          retention-days: ${{ needs.config.outputs.retention-days }}
+# This is commented out because it appears to fail uploading
+# and the entire build fails.  XXX: investigate why.
+#      - uses: actions/upload-artifact@v2
+#        if: runner.os == 'Windows'
+#        with:
+#          name: ${{ env.NAME }}
+#          path: "cryptol.msi*"
+#          if-no-files-found: error
+#          retention-days: ${{ needs.config.outputs.retention-days }}
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,10 +281,10 @@ jobs:
             file: Dockerfile
             image: ghcr.io/galoisinc/cryptol
             cache: ghcr.io/galoisinc/cache-cryptol
-          - build-args: PORTABILITY=true
-            file: cryptol-remote-api/Dockerfile
-            image: ghcr.io/galoisinc/cryptol-remote-api
-            cache: ghcr.io/galoisinc/cache-cryptol-remote-api
+#          - build-args: PORTABILITY=true
+#            file: cryptol-remote-api/Dockerfile
+#            image: ghcr.io/galoisinc/cryptol-remote-api
+#            cache: ghcr.io/galoisinc/cache-cryptol-remote-api
           - build-args: PORTABILITY=false
             file: cryptol-remote-api/Dockerfile
             image: ghcr.io/galoisinc/cryptol-remote-api


### PR DESCRIPTION
This seems to break the CI, we need to investigate why