### PR TITLE
Improve CI for Windows and portable Docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,10 @@ jobs:
             target: ''
             os: macos-latest
             continue-on-error: false
-          - suite: rpc
-            target: ''
-            os: windows-latest
-            continue-on-error: true  # TODO: get Python client to work on Windows
+          #- suite: rpc
+          #  target: ''
+          #  os: windows-latest
+          #  continue-on-error: true  # TODO: get Python client to work on Windows
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,15 +181,13 @@ jobs:
           path: bin
           name: ${{ runner.os }}-bin
 
-# This is commented out because it appears to fail uploading
-# and the entire build fails.  XXX: investigate why.
-#      - uses: actions/upload-artifact@v2
-#        if: runner.os == 'Windows'
-#        with:
-#          name: ${{ env.NAME }}
-#          path: "cryptol.msi*"
-#          if-no-files-found: error
-#          retention-days: ${{ needs.config.outputs.retention-days }}
+      - uses: actions/upload-artifact@v2
+        if: runner.os == 'Windows'
+        with:
+          name: ${{ env.NAME }}
+          path: "cryptol.msi*"
+          if-no-files-found: error
+          retention-days: ${{ needs.config.outputs.retention-days }}
 
   test:
     runs-on: ${{ matrix.os }}
@@ -210,10 +208,10 @@ jobs:
             target: ''
             os: macos-latest
             continue-on-error: false
-          #- suite: rpc
-          #  target: ''
-          #  os: windows-latest
-          #  continue-on-error: true  # TODO: get Python client to work on Windows
+          - suite: rpc
+            target: ''
+            os: windows-latest
+            continue-on-error: true  # TODO: get Python client to work on Windows
     steps:
       - uses: actions/checkout@v2
         with:
@@ -281,10 +279,11 @@ jobs:
             file: Dockerfile
             image: ghcr.io/galoisinc/cryptol
             cache: ghcr.io/galoisinc/cache-cryptol
-#          - build-args: PORTABILITY=true
-#            file: cryptol-remote-api/Dockerfile
-#            image: ghcr.io/galoisinc/cryptol-remote-api
-#            cache: ghcr.io/galoisinc/cache-cryptol-remote-api
+          - build-args: PORTABILITY=true
+            file: cryptol-remote-api/Dockerfile
+            image: ghcr.io/galoisinc/cryptol-remote-api
+            cache: ghcr.io/galoisinc/cache-cryptol-remote-api
+            if: ${{ github.event_name == 'schedule' }}
           - build-args: PORTABILITY=false
             file: cryptol-remote-api/Dockerfile
             image: ghcr.io/galoisinc/cryptol-remote-api


### PR DESCRIPTION
This should move the creation of the portable Docker image to run only on nightly jobs, but that won't take effect until it's merged, due to how GitHub treats Actions.