### PR TITLE
Add new declaration forms that can be parsed at the REPL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@
 * There is a new `w4-abc` solver option, which communicates to ABC
   as an external process via What4.
 
+* Expanded support for declaration forms in the REPL. You can now
+  define infix operators, type synonyms and mutually-recursive functions,
+  and state signatures and fixity declarations. Multiple declarations
+  can be combined into a single line by separating them with `;`,
+  which is necessary for stating a signature together with a
+  definition, etc.
 
 # 2.11.0
 

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -33,6 +33,8 @@ module Cryptol.ModuleSystem (
   , IfaceTySyn, IfaceDecl(..)
   ) where
 
+import Data.Map (Map)
+
 import qualified Cryptol.Eval.Concrete as Concrete
 import           Cryptol.ModuleSystem.Env
 import           Cryptol.ModuleSystem.Interface
@@ -94,7 +96,7 @@ evalExpr :: T.Expr -> ModuleCmd Concrete.Value
 evalExpr e env = runModuleM env (interactive (Base.evalExpr e))
 
 -- | Typecheck top-level declarations.
-checkDecls :: [P.TopDecl PName] -> ModuleCmd (R.NamingEnv,[T.DeclGroup])
+checkDecls :: [P.TopDecl PName] -> ModuleCmd (R.NamingEnv,[T.DeclGroup], Map Name T.TySyn)
 checkDecls ds env = runModuleM env
                   $ interactive
                   $ Base.checkDecls ds

--- a/src/Cryptol/ModuleSystem/Exports.hs
+++ b/src/Cryptol/ModuleSystem/Exports.hs
@@ -15,23 +15,25 @@ import Cryptol.ModuleSystem.Name
 
 modExports :: Ord name => ModuleG mname name -> ExportSpec name
 modExports m = fold (concat [ exportedNames d | d <- mDecls m ])
-  where
-  names by td = [ td { tlValue = thing n } | n <- fst (by (tlValue td)) ]
 
-  exportedNames (Decl td) = map exportBind  (names  namesD td)
-                         ++ map exportType (names tnamesD td)
-  exportedNames (DPrimType t) = [ exportType (thing . primTName <$> t) ]
-  exportedNames (TDNewtype nt) = map exportType (names tnamesNT nt)
-  exportedNames (Include {})  = []
-  exportedNames (DImport {}) = []
-  exportedNames (DParameterFun {}) = []
-  exportedNames (DParameterType {}) = []
-  exportedNames (DParameterConstraint {}) = []
-  exportedNames (DModule nested) =
-    case tlValue nested of
-      NestedModule x ->
-        [exportName NSModule nested { tlValue = thing (mName x) }]
 
+exportedNames :: Ord name => TopDecl name -> [ExportSpec name]
+exportedNames (Decl td) = map exportBind  (names namesD td)
+                       ++ map exportType (names tnamesD td)
+exportedNames (DPrimType t) = [ exportType (thing . primTName <$> t) ]
+exportedNames (TDNewtype nt) = map exportType (names tnamesNT nt)
+exportedNames (Include {})  = []
+exportedNames (DImport {}) = []
+exportedNames (DParameterFun {}) = []
+exportedNames (DParameterType {}) = []
+exportedNames (DParameterConstraint {}) = []
+exportedNames (DModule nested) =
+  case tlValue nested of
+    NestedModule x ->
+      [exportName NSModule nested { tlValue = thing (mName x) }]
+
+names :: (a -> ([Located a'], b)) -> TopLevel a -> [TopLevel a']
+names by td = [ td { tlValue = thing n } | n <- fst (by (tlValue td)) ]
 
 
 newtype ExportSpec name = ExportSpec (Map Namespace (Set name))
@@ -78,6 +80,3 @@ isExportedBind = isExported NSValue
 -- | Check to see if a type synonym is exported.
 isExportedType :: Ord name => name -> ExportSpec name -> Bool
 isExportedType = isExported NSType
-
-
-

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -90,8 +90,12 @@ renameTopDecls m ds0 =
      setNestedModule (nestedModuleNames nested)
        do ds1 <- shadowNames' CheckOverlap env
                                         (renameTopDecls' (nested,mpath) ds)
-          pure (env,ds1)
+          -- record a use of top-level names to avoid
+          -- unused name warnings
+          let exports = concatMap exportedNames ds1
+          mapM_ recordUse (foldMap (exported NSType) exports)
 
+          pure (env,ds1)
 
 -- | Returns declarations with additional imports and the public module names
 -- of this module and its children

--- a/src/Cryptol/Parser.y
+++ b/src/Cryptol/Parser.y
@@ -361,6 +361,8 @@ let_decl                :: { Decl PName }
                                           , bExport    = Public
                                           } }
 
+  | 'let' vars_comma ':' schema  { at (head $2,$4) $ DSignature (reverse $2) $4   }
+
   | 'type' name '=' type   {% at ($1,$4) `fmap` mkTySyn $2 [] $4 }
   | 'type' name tysyn_params '=' type
                            {% at ($1,$5) `fmap` mkTySyn $2 (reverse $3) $5  }

--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -300,7 +300,7 @@ data PrimType name = PrimType { primTName :: Located name
 -- | Input at the REPL, which can be an expression, a @let@
 -- statement, or empty (possibly a comment).
 data ReplInput name = ExprInput (Expr name)
-                    | LetInput (Decl name)
+                    | LetInput [Decl name]
                     | EmptyInput
                       deriving (Eq, Show)
 

--- a/src/Cryptol/TypeCheck.hs
+++ b/src/Cryptol/TypeCheck.hs
@@ -29,6 +29,7 @@ module Cryptol.TypeCheck
   ) where
 
 import Data.IORef(IORef,modifyIORef')
+import Data.Map(Map)
 
 import           Cryptol.ModuleSystem.Name
                     (liftSupply,mkDeclared,NameSource(..),ModPath(..))
@@ -133,7 +134,7 @@ tcExpr e0 inp = runInferM inp
                           : map show res
                           )
 
-tcDecls :: [P.TopDecl Name] -> InferInput -> IO (InferOutput [DeclGroup])
+tcDecls :: [P.TopDecl Name] -> InferInput -> IO (InferOutput ([DeclGroup],Map Name TySyn))
 tcDecls ds inp = runInferM inp $
   do newLocalScope
      checkTopDecls ds

--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -1027,7 +1027,7 @@ checkLocalDecls ds0 k =
   do newLocalScope
      forM_ ds0 \d -> checkDecl False d Nothing
      a <- k
-     ds <- endLocalScope
+     (ds,_tySyns) <- endLocalScope
      pure (a,ds)
 
 

--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -804,13 +804,12 @@ updScope f = IM $ sets_ \rw -> rw { iScope = upd (iScope rw) }
       []       -> panic "updTopScope" [ "No top scope" ]
       s : more -> f s : more
 
-endLocalScope :: InferM [DeclGroup]
+endLocalScope :: InferM ([DeclGroup], Map Name TySyn)
 endLocalScope =
   IM $ sets \rw ->
        case iScope rw of
          x : xs | LocalScope <- mName x ->
-                    (reverse (mDecls x), rw { iScope = xs })
-            -- This ignores local type synonyms... Where should we put them?
+                    ( (reverse (mDecls x), mTySyns x), rw { iScope = xs })
 
          _ -> panic "endLocalScope" ["Missing local scope"]
 

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -336,6 +336,14 @@ apSubstTypeMapKeys su = go (\_ x -> x) id
                                      (cons k)
                          }
 
+instance TVars a => TVars (Map.Map k a) where
+  -- NB, strict map
+  apSubst su m = Map.map (apSubst su) m
+
+instance TVars TySyn where
+  apSubst su (TySyn nm params props t doc) =
+    (\props' t' -> TySyn nm params props' t' doc)
+      !$ apSubst su props !$ apSubst su t
 
 {- | This instance does not need to worry about bound variable
 capture, because we rely on the 'Subst' datatype invariant to ensure

--- a/tests/regression/repl-decls.icry
+++ b/tests/regression/repl-decls.icry
@@ -1,0 +1,42 @@
+let x -<- y = x - y; infixl 5 -<-; let (-<-) : Integer -> Integer -> Integer
+let x ->- y = x - y; infixr 5 ->-; let (->-) : Integer -> Integer -> Integer
+
+42 -<- 10 -<- 100
+42 ->- 10 ->- 100
+42 ->- 10 -<- 100
+
+let even x = if x == 0 then True else odd (x-1);\
+let odd x = if x == 0 then False else even (x-1)
+
+:t even
+:t odd
+
+even 5
+even 4
+
+odd 5
+odd 6
+
+let even' : Integer -> Bool;\
+let even' x = if x == 0 then True else odd' (x-1);\
+let odd' x = if x == 0 then False else even' (x-1)
+
+:t even'
+:t odd'
+
+even' 5
+even' 4
+
+odd' 5
+odd' 6
+
+type X n = [n]Integer
+take [1...] : X 42
+
+type constraint CS t = (Ring t, Logic t, Integral t)
+
+let f : {a} CS a => a -> Integer;\
+let f x = [1..100]@( (x + fromInteger 5) && fromInteger `0x1f)
+
+:t f
+f 0x1234

--- a/tests/regression/repl-decls.icry.stdout
+++ b/tests/regression/repl-decls.icry.stdout
@@ -1,0 +1,27 @@
+Loading module Cryptol
+-68
+132
+
+[error] at repl-decls.icry:6:4--6:7 and repl-decls.icry:6:11--6:14
+    The fixities of
+      • (->-) (precedence 5, right-associative)
+      • (-<-) (precedence 5, left-associative)
+    are not compatible.
+    You may use explicit parentheses to disambiguate.
+even : {a} (Eq a, Ring a, Literal 1 a) => a -> Bit
+odd : {a} (Eq a, Ring a, Literal 1 a) => a -> Bit
+False
+True
+True
+False
+even' : Integer -> Bool
+odd' : Integer -> Bit
+False
+True
+True
+False
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+ 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+ 37, 38, 39, 40, 41, 42]
+f : {a} (Ring a, Logic a, Integral a) => a -> Integer
+26


### PR DESCRIPTION
In particular, we can now define operators using `let` in the
same way that they can be inside modules and `where`.

In addition, we allow `type` and `type constraint` definitions
at the REPL, and `infix`, `infixl` and `infixr` declarations.

Becase it is an error for an infix declaration to be stated
without its corresponding declaration, we have added the ability
to enter multiple definitions at once, separated by `;`.  This
is also useful for definition mutually recursive definitions using
`let`.