### PR TITLE
Build Docker images only on nightly runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,7 @@ jobs:
   build-push-image:
     runs-on: ubuntu-latest
     needs: [config]
+    if: github.event_name == 'schedule'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR adjusts the CI workflows so that Docker images only get built during nightly builds, rather than on every PR.

The one failing test, for the RPC server, will likely be fixed shortly by some separate work @pnwamk is doing.