### PR TITLE
[RPC] f-string-like Cryptol quasiquotation

### DIFF
--- a/cryptol-remote-api/python/.gitignore
+++ b/cryptol-remote-api/python/.gitignore
@@ -128,3 +128,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Files generated from running tests/cryptol/test_cryptol_api.py
+*.crt
+*.csr
+*.key

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for `cryptol` Python package
 
-## 2.12.2 -- YYYY-MM-DD
+## 2.12.2 -- 2021-11-19
 
-* NEW CHANGELOG ENTRIES SINCE 2.12.0 GO HERE
+* Add an interface for Cryptol quasiquotation using an f-string-like syntax,
+  see `tests/cryptol/test_quoting` for some examples.
 
 ## 2.12.0 -- 2021-11-19
 

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for `cryptol` Python package
 
-## 2.12.2 -- 2021-11-19
+## 2.12.2 -- YYYY-MM-DD
 
 * Add an interface for Cryptol quasiquotation using an f-string-like syntax,
   see `tests/cryptol/test_quoting` for some examples.

--- a/cryptol-remote-api/python/cryptol/__init__.py
+++ b/cryptol-remote-api/python/cryptol/__init__.py
@@ -27,4 +27,4 @@ from .synchronous import Qed, Safe, Counterexample, Satisfiable, Unsatisfiable, 
 from . import synchronous
 sync = synchronous
 
-__all__ = ['bitvector', 'commands', 'connection', 'cryptoltypes', 'opaque', 'single_connection', 'solver', 'synchronous', 'quoting']
+__all__ = ['bitvector', 'commands', 'connection', 'cryptoltypes', 'opaque', 'quoting', 'single_connection', 'solver', 'synchronous']

--- a/cryptol-remote-api/python/cryptol/__init__.py
+++ b/cryptol-remote-api/python/cryptol/__init__.py
@@ -16,6 +16,8 @@ from argo_client.connection import DynamicSocketProcess, ServerConnection, Serve
 from . import cryptoltypes
 from . import solver
 from .bitvector import BV
+from .cryptoltypes import fail_with
+from .quoting import cry, cry_f
 from .commands import *
 from .connection import *
 # import everything from `.synchronous` except `connect` and `connect_stdio`
@@ -25,13 +27,4 @@ from .synchronous import Qed, Safe, Counterexample, Satisfiable, Unsatisfiable, 
 from . import synchronous
 sync = synchronous
 
-__all__ = ['bitvector', 'commands', 'connection', 'cryptoltypes', 'opaque', 'single_connection', 'solver', 'synchronous']
-
-
-def fail_with(x : Exception) -> NoReturn:
-    "Raise an exception. This is valid in expression positions."
-    raise x
-
-
-def cry(string : str) -> cryptoltypes.CryptolCode:
-    return cryptoltypes.CryptolLiteral(string)
+__all__ = ['bitvector', 'commands', 'connection', 'cryptoltypes', 'opaque', 'single_connection', 'solver', 'synchronous', 'quoting']

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -9,6 +9,8 @@ from typing_extensions import Literal
 
 import argo_client.interaction as argo
 from argo_client.connection import DynamicSocketProcess, ServerConnection, ServerProcess, StdIOProcess, HttpProcess
+from .custom_fstring import *
+from .quoting import *
 from . import cryptoltypes
 from . import solver
 from .commands import *
@@ -217,20 +219,34 @@ class CryptolConnection:
 
         :param timeout: Optional timeout for this request (in seconds).
         """
+        if hasattr(expression, '__to_cryptol__'):
+            expression = cryptoltypes.to_cryptol(expression)
         timeout = timeout if timeout is not None else self.timeout
         self.most_recent_result = CryptolEvalExprRaw(self, expression, timeout)
         return self.most_recent_result
 
     def eval(self, expression : Any, *, timeout:Optional[float] = None) -> argo.Command:
-        """Evaluate a Cryptol expression, represented according to
-        :ref:`cryptol-json-expression`, with Python datatypes standing
-        for their JSON equivalents.
+        """Evaluate a Cryptol expression, with the result represented
+        according to :ref:`cryptol-json-expression`, with Python datatypes
+        standing for their JSON equivalents.
 
         :param timeout: Optional timeout for this request (in seconds).
         """
+        if hasattr(expression, '__to_cryptol__'):
+            expression = cryptoltypes.to_cryptol(expression)
         timeout = timeout if timeout is not None else self.timeout
         self.most_recent_result = CryptolEvalExpr(self, expression, timeout)
         return self.most_recent_result
+
+    def eval_f(self, s : str, *, timeout:Optional[float] = None) -> argo.Command:
+        """Parses the given string like ``cry_f``, then evalues it, with the
+        result represented according to :ref:`cryptol-json-expression`, with
+        Python datatypes standing for their JSON equivalents.
+
+        :param timeout: Optional timeout for this request (in seconds).
+        """
+        expression = func_customf(s, to_cryptol_str, frames=1, filename="<eval_f>")
+        return self.eval(expression, timeout=timeout)
 
     def evaluate_expression(self, expression : Any, *, timeout:Optional[float] = None) -> argo.Command:
         """Synonym for member method ``eval``.
@@ -251,7 +267,7 @@ class CryptolConnection:
         ``from_cryptol_arg`` on the ``.result()``.
         """
         timeout = timeout if timeout is not None else self.timeout
-        encoded_args = [cryptoltypes.CryptolType().from_python(a) for a in args]
+        encoded_args = [cryptoltypes.to_cryptol(a) for a in args]
         self.most_recent_result = CryptolCallRaw(self, fun, encoded_args, timeout)
         return self.most_recent_result
 
@@ -260,7 +276,7 @@ class CryptolConnection:
 
         :param timeout: Optional timeout for this request (in seconds)."""
         timeout = timeout if timeout is not None else self.timeout
-        encoded_args = [cryptoltypes.CryptolType().from_python(a) for a in args]
+        encoded_args = [cryptoltypes.to_cryptol(a) for a in args]
         self.most_recent_result = CryptolCall(self, fun, encoded_args, timeout)
         return self.most_recent_result
 

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -245,7 +245,7 @@ class CryptolConnection:
 
         :param timeout: Optional timeout for this request (in seconds).
         """
-        expression = func_customf(s, to_cryptol_str, frames=1, filename="<eval_f>")
+        expression = to_cryptol_str_customf(s, frames=1, filename="<eval_f>")
         return self.eval(expression, timeout=timeout)
 
     def evaluate_expression(self, expression : Any, *, timeout:Optional[float] = None) -> argo.Command:

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -17,8 +17,8 @@ class CryptolJSON(Protocol):
     def __to_cryptol__(self, ty : CryptolType) -> Any: ...
 
 class CryptolCode(metaclass=ABCMeta):
-    def __call__(self, other : CryptolJSON) -> CryptolCode:
-        return CryptolApplication(self, other)
+    def __call__(self, *others : CryptolJSON) -> CryptolCode:
+        return CryptolApplication(self, *others)
 
     @abstractmethod
     def __to_cryptol__(self, ty : CryptolType) -> Any: ...
@@ -31,6 +31,15 @@ class CryptolLiteral(CryptolCode):
     def __to_cryptol__(self, ty : CryptolType) -> Any:
         return self._code
 
+    def __eq__(self, other : Any) -> bool:
+        return isinstance(other, CryptolLiteral) and self._code == other._code
+
+    def __str__(self) -> str:
+        return self._code
+
+    def __repr__(self) -> str:
+        return f'CryptolLiteral({self._code!r})'
+
 
 class CryptolApplication(CryptolCode):
     def __init__(self, rator : CryptolJSON, *rands : CryptolJSON) -> None:
@@ -41,6 +50,14 @@ class CryptolApplication(CryptolCode):
         return {'expression': 'call',
                 'function': to_cryptol(self._rator),
                 'arguments': [to_cryptol(arg) for arg in self._rands]}
+
+    def __eq__(self, other : Any) -> bool:
+        return isinstance(other, CryptolApplication) and self._rator == other._rator and self._rands == other._rands
+
+    def __repr__(self) -> str:
+        args = [self._rator, *(arg for arg in self._rands)]
+        return f'CryptolApplication({", ".join(repr(x) for x in args)})'
+
 
 class CryptolArrowKind:
     def __init__(self, dom : CryptolKind, ran : CryptolKind):

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -56,7 +56,10 @@ class CryptolJSON(Protocol):
 
 class CryptolCode(metaclass=ABCMeta):
     def __call__(self, *others : CryptolJSON) -> CryptolCode:
-        return CryptolApplication(self, *others)
+        if all(hasattr(other, '__to_cryptol__') for other in others):
+            return CryptolApplication(self, *others)
+        else:
+            raise ValueError("Argument to __call__ on CryptolCode is not CryptolJSON")
 
     @abstractmethod
     def __to_cryptol__(self, ty : CryptolType) -> Any: ...
@@ -100,8 +103,7 @@ class CryptolApplication(CryptolCode):
         return isinstance(other, CryptolApplication) and self._rator == other._rator and self._rands == other._rands
 
     def __repr__(self) -> str:
-        args = [self._rator, *(arg for arg in self._rands)]
-        return f'CryptolApplication({", ".join(repr(x) for x in args)})'
+        return f'CryptolApplication({", ".join(repr(x) for x in [self._rator, *self._rands])})'
 
 
 class CryptolArrowKind:

--- a/cryptol-remote-api/python/cryptol/custom_fstring.py
+++ b/cryptol-remote-api/python/cryptol/custom_fstring.py
@@ -1,0 +1,70 @@
+"""An interface for defining custom f-string wrappers"""
+
+from typing import Any, Callable, Dict, List
+import builtins
+import ast
+import sys
+
+def customf(body : str, onAST : Callable[[ast.FormattedValue], List[ast.expr]],
+            frames : int = 0, globals : Dict[str, Any] = {},
+                              locals : Dict[str, Any] = {},
+            filename : str = "<custom f-string>") -> str:
+    """This function parses the given string as if it were an f-string,
+    applies the given function to the AST of each of the formatting fields in
+    the string, then evaluates the result to get the resulting string.
+    
+    By default, the global and local variables used in the call to ``eval``
+    are the value of ``sys.__getframe(1+frames).f_globals`` and the value of
+    ``sys.__getframe(1+frames).f_locals``, respectively. This is meant to
+    ensure that the all the variables which were in scope when the custom
+    f-string is formed are also in scope when it is evaluated. Thus, the value
+    of ``frames`` should be incremented for each wrapper function defined
+    around this function (e.g. see the definition of ``func_customf``).
+    
+    To add additional global or local variable values (which are combined with,
+    but take precedence over, the values mentioned in the previous paragraph)
+    use the ``globals`` and ``locals`` keyword arguments.
+    """
+    # Get the global/local variable context of the previous frame so the local
+    #  names 'body', 'onAST', etc. aren't shadowed our the call to ``eval``
+    previous_frame = sys._getframe(1 + frames)
+    all_globals = {**previous_frame.f_globals, **globals}
+    all_locals = {**previous_frame.f_locals, **locals}
+    # The below line should be where any f-string syntax errors are raised
+    tree = ast.parse('f' + str(repr(body)), filename=filename, mode='eval')
+    if not isinstance(tree, ast.Expression) or not isinstance(tree.body, ast.JoinedStr):
+       raise ValueError(f'Invalid custom f-string: {str(repr(body))}')
+    joined_values : List[ast.expr] = []
+    for node in tree.body.values:
+        if isinstance(node, ast.FormattedValue):
+            joined_values += onAST(node)
+        else:
+            joined_values += [node]
+    tree.body.values = joined_values
+    try:
+        return str(eval(compile(tree, filename=filename, mode='eval'), all_globals, all_locals))
+    except SyntaxError as e:
+        # I can't think of a case where we would raise an error here, but if
+        # we do it's worth telling the user that the column numbers are all
+        # messed up
+        msg = '\nNB: Column numbers refer to positions in the original string'
+        raise type(e)(str(e) + msg).with_traceback(sys.exc_info()[2])
+
+def func_customf(body : str, func : Callable,
+                 frames : int = 0, globals : Dict[str, Any] = {},
+                                   locals : Dict[str, Any] = {},
+                 filename : str = "<custom f-string>",
+                 func_id : str = "_func_customf__func_id") -> str:
+    """Like ``customf``, but can be provided a function to apply to the values
+    of each of the formatting fields before they are formatted as strings,
+    instead of a function applied to their ASTs.
+    """
+    def onAST(node : ast.FormattedValue) -> List[ast.expr]:
+        kwargs = {'lineno': node.lineno, 'col_offset': node.col_offset}
+        func = ast.Name(id=func_id, ctx=ast.Load(), **kwargs)
+        node.value = ast.Call(func=func, args=[node.value], keywords=[], **kwargs)
+        return [node]
+    return customf(body, onAST, frames=1+frames,
+                                globals={**globals, func_id:func},
+                                locals=locals,
+                                filename=filename)

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -46,11 +46,30 @@ def cry_f(s : str) -> CryptolLiteral:
     """Embed a string of cryptol syntax as ``CryptolCode``, where the given
        string is parsed as an f-string, and the values within brackets are
        converted to cryptol syntax using ``to_cryptol_str``.
-       
-       Example:
-           >>> x = BV(size=7, value=1)
-           >>> y = cry_f('fun1 {x}')
-           >>> cry_f('fun2 {y}')
-           'fun2 (fun1 (1 : [7]))'
+
+       Like f-strings, values in brackets (``{``, ``}``) are parsed as python
+       expressions in the caller's context of local and global variables, and
+       to include a literal bracket in the final string, it must be doubled
+       (i.e. ``{{`` or ``}}``). The latter is needed when using explicit type
+       application or record syntax. For example, if ``x = [0,1]`` then
+       ``cry_f('length `{{2}} {x}')`` is equal to ``cry('length `{2} [0,1]')``
+       and ``cry_f('{{ x = {x} }}')`` is equal to ``cry('{ x = [0,1] }')``.
+
+       When formatting Cryptol, it is recomended to always use this function
+       and never any of python's built-in methods of string formatting (e.g.
+       f-strings, ``str.format``) as the latter will not always produce valid
+       cryptol syntax. Specifically, this function differs from these methods
+       in the cases of ``BV``s, string literals, function application (this
+       function will add parentheses as needed), and dicts. For example,
+       ``cry_f('{ {"x": 5, "y": 4} }')`` equals ``cry('{x = 5, y = 4}')``
+       but ``f'{ {"x": 5, "y": 4} }'`` equals ``'{"x": 5, "y": 4}'``. Only
+       the former is valid cryptol syntax for a record.
+
+       :example:
+
+       >>> x = BV(size=7, value=1)
+       >>> y = cry_f('fun1 {x}')
+       >>> cry_f('fun2 {y}')
+       'fun2 (fun1 (1 : [7]))'
     """
     return CryptolLiteral(func_customf(s, to_cryptol_str, frames=1, filename="<cry_f>"))

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -1,0 +1,56 @@
+"""Cryptol quasiquotation using an f-string-like syntax"""
+
+from typing import Any, Union
+
+from .bitvector import BV
+from .opaque import OpaqueValue
+from .commands import CryptolValue
+from .cryptoltypes import CryptolLiteral
+from .custom_fstring import *
+
+def to_cryptol_str(val : Union[CryptolValue, str, CryptolLiteral]) -> str:
+    """Converts a ``CryptolValue``, string literal, or ``CryptolLiteral`` into
+       a string of cryptol syntax."""
+    if isinstance(val, bool):
+        return 'True' if val else 'False'
+    elif isinstance(val, tuple):
+        return '(' + ', '.join(to_cryptol_str(x) for x in val) + ')'
+    elif isinstance(val, dict):
+        return '{' + ', '.join(f'{k} = {to_cryptol_str(v)}' for k,v in val.items()) + '}'
+    elif isinstance(val, int):
+        return str(val)
+    elif isinstance(val, list):
+        return '[' + ', '.join(to_cryptol_str(x) for x in val) + ']'
+    elif isinstance(val, BV):
+        if val.size() % 4 == 0:
+            return val.hex()
+        else:
+            return f'({val.to_signed_int()} : [{val.size()}])'
+    elif isinstance(val, OpaqueValue):
+        return str(val)
+    elif isinstance(val, str):
+        return f'"{val}"'
+    elif isinstance(val, CryptolLiteral):
+        if len(str(val)) > 0 and str(val)[0] == '(' and str(val)[-1] == ')':
+            return str(val)
+        else:
+            return f'({val})'
+    else:
+        raise TypeError("Unable to convert value to Cryptol syntax: " + str(val))
+
+def cry(s : str) -> CryptolLiteral:
+    """Embed a string of cryptol syntax as ``CryptolCode``"""
+    return CryptolLiteral(s)
+
+def cry_f(s : str) -> CryptolLiteral:
+    """Embed a string of cryptol syntax as ``CryptolCode``, where the given
+       string is parsed as an f-string, and the values within brackets are
+       converted to cryptol syntax using ``to_cryptol_str``.
+       
+       Example:
+           >>> x = BV(size=7, value=1)
+           >>> y = cry_f('fun1 {x}')
+           >>> cry_f('fun2 {y}')
+           'fun2 (fun1 (1 : [7]))'
+    """
+    return CryptolLiteral(func_customf(s, to_cryptol_str, frames=1, filename="<cry_f>"))

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -10,7 +10,7 @@ from .custom_fstring import *
 
 def to_cryptol_str(val : Union[CryptolValue, str, CryptolCode]) -> str:
     """Converts a ``CryptolValue``, string literal, or ``CryptolCode`` into
-       a string of cryptol syntax."""
+       a string of Cryptol syntax."""
     if isinstance(val, bool):
         return 'True' if val else 'False'
     elif isinstance(val, tuple):
@@ -42,13 +42,13 @@ def to_cryptol_str_customf(s : str, *, frames : int = 0,
                                            filename=filename)
 
 def cry(s : str) -> CryptolLiteral:
-    """Embed a string of cryptol syntax as ``CryptolCode``"""
+    """Embed a string of Cryptol syntax as ``CryptolCode``"""
     return CryptolLiteral(s)
 
 def cry_f(s : str) -> CryptolLiteral:
-    """Embed a string of cryptol syntax as ``CryptolCode``, where the given
+    """Embed a string of Cryptol syntax as ``CryptolCode``, where the given
        string is parsed as an f-string, and the values within brackets are
-       converted to cryptol syntax using ``to_cryptol_str``.
+       converted to Cryptol syntax using ``to_cryptol_str``.
 
        Like f-strings, values in brackets (``{``, ``}``) are parsed as python
        expressions in the caller's context of local and global variables, and
@@ -61,15 +61,15 @@ def cry_f(s : str) -> CryptolLiteral:
        When formatting Cryptol, it is recomended to use this function rather
        than any of python's built-in methods of string formatting (e.g.
        f-strings, ``str.format``) as the latter will not always produce valid
-       cryptol syntax. Specifically, this function differs from these methods
+       Cryptol syntax. Specifically, this function differs from these methods
        in the cases of ``BV``s, string literals, function application (this
        function will add parentheses as needed), and dicts. For example,
        ``cry_f('{ {"x": 5, "y": 4} }')`` equals ``cry('{x = 5, y = 4}')``
        but ``f'{ {"x": 5, "y": 4} }'`` equals ``'{"x": 5, "y": 4}'``. Only
-       the former is valid cryptol syntax for a record.
+       the former is valid Cryptol syntax for a record.
        
        Note that any conversion or format specifier will always result in the
-       argument being rendered as a cryptol string literal with the conversion
+       argument being rendered as a Cryptol string literal with the conversion
        and/or formating applied. For example, `cry('f {5}')` is equal to
        ``cry('f 5')`` but ``cry_f('f {5!s}')`` is equal to ``cry(`f "5"`)``
        and ``cry_f('f {5:+.2%}')`` is equal to ``cry('f "+500.00%"')``.

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -5,11 +5,11 @@ from typing import Any, Union
 from .bitvector import BV
 from .opaque import OpaqueValue
 from .commands import CryptolValue
-from .cryptoltypes import CryptolLiteral
+from .cryptoltypes import CryptolCode, CryptolLiteral, parenthesize
 from .custom_fstring import *
 
-def to_cryptol_str(val : Union[CryptolValue, str, CryptolLiteral]) -> str:
-    """Converts a ``CryptolValue``, string literal, or ``CryptolLiteral`` into
+def to_cryptol_str(val : Union[CryptolValue, str, CryptolCode]) -> str:
+    """Converts a ``CryptolValue``, string literal, or ``CryptolCode`` into
        a string of cryptol syntax."""
     if isinstance(val, bool):
         return 'True' if val else 'False'
@@ -30,11 +30,8 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolLiteral]) -> str:
         return str(val)
     elif isinstance(val, str):
         return f'"{val}"'
-    elif isinstance(val, CryptolLiteral):
-        if len(str(val)) > 0 and str(val)[0] == '(' and str(val)[-1] == ')':
-            return str(val)
-        else:
-            return f'({val})'
+    elif isinstance(val, CryptolCode):
+        return parenthesize(str(val))
     else:
         raise TypeError("Unable to convert value to Cryptol syntax: " + str(val))
 

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -38,6 +38,12 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolLiteral]) -> str:
     else:
         raise TypeError("Unable to convert value to Cryptol syntax: " + str(val))
 
+def to_cryptol_str_customf(s : str, *, frames : int = 0,
+                                       filename : str = "<cry_f>") -> str:
+    """The function used to parse strings given to ``cry_f``"""
+    return func_customf(s, to_cryptol_str, frames=1+frames,
+                                           filename=filename)
+
 def cry(s : str) -> CryptolLiteral:
     """Embed a string of cryptol syntax as ``CryptolCode``"""
     return CryptolLiteral(s)
@@ -72,4 +78,4 @@ def cry_f(s : str) -> CryptolLiteral:
        >>> cry_f('fun2 {y}')
        'fun2 (fun1 (1 : [7]))'
     """
-    return CryptolLiteral(func_customf(s, to_cryptol_str, frames=1, filename="<cry_f>"))
+    return CryptolLiteral(to_cryptol_str_customf(s, frames=1))

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -61,8 +61,8 @@ def cry_f(s : str) -> CryptolLiteral:
        ``cry_f('length `{{2}} {x}')`` is equal to ``cry('length `{2} [0,1]')``
        and ``cry_f('{{ x = {x} }}')`` is equal to ``cry('{ x = [0,1] }')``.
 
-       When formatting Cryptol, it is recomended to always use this function
-       and never any of python's built-in methods of string formatting (e.g.
+       When formatting Cryptol, it is recomended to use this function rather
+       than any of python's built-in methods of string formatting (e.g.
        f-strings, ``str.format``) as the latter will not always produce valid
        cryptol syntax. Specifically, this function differs from these methods
        in the cases of ``BV``s, string literals, function application (this
@@ -70,6 +70,12 @@ def cry_f(s : str) -> CryptolLiteral:
        ``cry_f('{ {"x": 5, "y": 4} }')`` equals ``cry('{x = 5, y = 4}')``
        but ``f'{ {"x": 5, "y": 4} }'`` equals ``'{"x": 5, "y": 4}'``. Only
        the former is valid cryptol syntax for a record.
+       
+       Note that any conversion or format specifier will always result in the
+       argument being rendered as a cryptol string literal with the conversion
+       and/or formating applied. For example, `cry('f {5}')` is equal to
+       ``cry('f 5')`` but ``cry_f('f {5!s}')`` is equal to ``cry(`f "5"`)``
+       and ``cry_f('f {5:+.2%}')`` is equal to ``cry('f "+500.00%"')``.
 
        :example:
 

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -5,11 +5,11 @@ from typing import Any, Union
 from .bitvector import BV
 from .opaque import OpaqueValue
 from .commands import CryptolValue
-from .cryptoltypes import CryptolCode, CryptolLiteral, parenthesize
+from .cryptoltypes import CryptolJSON, CryptolLiteral, parenthesize
 from .custom_fstring import *
 
-def to_cryptol_str(val : Union[CryptolValue, str, CryptolCode]) -> str:
-    """Converts a ``CryptolValue``, string literal, or ``CryptolCode`` into
+def to_cryptol_str(val : Union[CryptolValue, str, CryptolJSON]) -> str:
+    """Converts a ``CryptolValue``, string literal, or ``CryptolJSON`` into
        a string of Cryptol syntax."""
     if isinstance(val, bool):
         return 'True' if val else 'False'
@@ -30,8 +30,8 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolCode]) -> str:
         return str(val)
     elif isinstance(val, str):
         return f'"{val}"'
-    elif isinstance(val, CryptolCode):
-        return parenthesize(str(val))
+    elif hasattr(val, '__to_cryptol_str__'):
+        return parenthesize(val.__to_cryptol_str__())
     else:
         raise TypeError("Unable to convert value to Cryptol syntax: " + str(val))
 

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -6,6 +6,8 @@ import sys
 from typing import Any, Optional, Union, List, Dict, TextIO, overload
 from typing_extensions import Literal
 
+from .custom_fstring import *
+from .quoting import *
 from .solver import OfflineSmtQuery, Solver, OnlineSolver, OfflineSolver, Z3
 from .connection import CryptolValue, CheckReport
 from . import synchronous
@@ -143,6 +145,14 @@ def cry_eval(expression : Any, *, timeout:Optional[float] = None) -> CryptolValu
     standing for their JSON equivalents.
     """
     return __get_designated_connection().eval(expression, timeout=timeout)
+
+def cry_eval_f(s : str, *, timeout:Optional[float] = None) -> CryptolValue:
+    """Parses the given string like ``cry_f``, then evalues it, with the
+    result represented according to :ref:`cryptol-json-expression`, with
+    Python datatypes standing for their JSON equivalents.
+    """
+    expression = func_customf(s, to_cryptol_str, frames=1, filename="<cry_eval_f>")
+    return cry_eval(expression, timeout=timeout)
 
 def call(fun : str, *args : List[Any], timeout:Optional[float] = None) -> CryptolValue:
     """Evaluate a Cryptol functiom by name, with the arguments and the

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -151,7 +151,7 @@ def cry_eval_f(s : str, *, timeout:Optional[float] = None) -> CryptolValue:
     result represented according to :ref:`cryptol-json-expression`, with
     Python datatypes standing for their JSON equivalents.
     """
-    expression = func_customf(s, to_cryptol_str, frames=1, filename="<cry_eval_f>")
+    expression = to_cryptol_str_customf(s, frames=1, filename="<cry_eval_f>")
     return cry_eval(expression, timeout=timeout)
 
 def call(fun : str, *args : List[Any], timeout:Optional[float] = None) -> CryptolValue:

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -214,7 +214,7 @@ class CryptolSyncConnection:
         result represented according to :ref:`cryptol-json-expression`, with
         Python datatypes standing for their JSON equivalents.
         """
-        expression = func_customf(s, to_cryptol_str, frames=1, filename="<eval_f>")
+        expression = to_cryptol_str_customf(s, frames=1, filename="<eval_f>")
         return self.eval(expression, timeout=timeout)
 
     def call(self, fun : str, *args : List[Any], timeout:Optional[float] = None) -> CryptolValue:

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -7,6 +7,8 @@ from typing import Any, Optional, Union, List, Dict, TextIO, overload
 from typing_extensions import Literal
 from dataclasses import dataclass
 
+from .custom_fstring import *
+from .quoting import *
 from .solver import OfflineSmtQuery, Solver, OnlineSolver, OfflineSolver, Z3
 from . import connection
 from . import cryptoltypes
@@ -206,6 +208,14 @@ class CryptolSyncConnection:
         standing for their JSON equivalents.
         """
         return from_cryptol_arg(self.connection.eval_raw(expression, timeout=timeout).result())
+
+    def eval_f(self, s : str, *, timeout:Optional[float] = None) -> CryptolValue:
+        """Parses the given string like ``cry_f``, then evalues it, with the
+        result represented according to :ref:`cryptol-json-expression`, with
+        Python datatypes standing for their JSON equivalents.
+        """
+        expression = func_customf(s, to_cryptol_str, frames=1, filename="<eval_f>")
+        return self.eval(expression, timeout=timeout)
 
     def call(self, fun : str, *args : List[Any], timeout:Optional[float] = None) -> CryptolValue:
         """Evaluate a Cryptol functiom by name, with the arguments and the

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -27,6 +27,11 @@ class TestQuoting(unittest.TestCase):
 
         self.assertEqual(cry_f('{ {"a": x, "b": x} }'), cry('{a = 0x01, b = 0x01}'))
         self.assertEqual(cry_f('{{a = {x}, b = {x}}}'), cry('{a = 0x01, b = 0x01}'))
+        
+        self.assertEqual(cry_f('id {5}'),       cry('id 5'))
+        self.assertEqual(cry_f('id {5!s}'),     cry('id "5"'))
+        self.assertEqual(cry_f('id {5:#x}'),    cry('id "0x5"'))
+        self.assertEqual(cry_f('id {BV(4,5)}'), cry('id 0x5'))
 
 
 if __name__ == "__main__":

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -18,8 +18,8 @@ class TestQuoting(unittest.TestCase):
         self.assertEqual(cry_eval(z), [x,x])
 
         y = cry_eval_f('g {x}')
-        self.assertEqual(y, [x,x])
         z = cry_eval_f('h {y}')
+        self.assertEqual(y, [x,x])
         self.assertEqual(z, [x,x])
         
         self.assertEqual(cry_f('id {BV(size=7, value=1)}'), cry('id (1 : [7])'))

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -33,11 +33,15 @@ class TestQuoting(unittest.TestCase):
         self.assertEqual(cry_f('id {5:#x}'),    cry('id "0x5"'))
         self.assertEqual(cry_f('id {BV(4,5)}'), cry('id 0x5'))
 
+        # Only here to check backwards compatability, the above syntax is preferred
         y = cry('g')(cry_f('{x}'))
         z = cry('h')(cry_f('{y}'))
         self.assertEqual(str(z), str(cry('(h) ((g) (0x01))')))
         self.assertEqual(cry_eval(z), [x,x])
         self.assertEqual(str(cry('id')(cry_f('{BV(size=7, value=1)}'))), str(cry('(id) (1 : [7])')))
+        # This is why this syntax is not preferred
+        with self.assertRaises(ValueError):
+            cry('g')(x) # x is not CryptolJSON
 
 
 if __name__ == "__main__":

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -1,0 +1,33 @@
+import unittest
+from pathlib import Path
+import unittest
+import cryptol
+from cryptol.single_connection import *
+from cryptol.bitvector import BV
+from cryptol.quoting import *
+
+class TestQuoting(unittest.TestCase):
+    def test_quoting(self):
+        connect(verify=False)
+        load_file(str(Path('tests','cryptol','test-files', 'M.cry')))
+
+        x = BV(size=8, value=1)
+        y = cry_f('g {x}')
+        z = cry_f('h {y}')
+        self.assertEqual(z, cry('h (g 0x01)'))
+        self.assertEqual(cry_eval(z), [x,x])
+
+        y = cry_eval_f('g {x}')
+        self.assertEqual(y, [x,x])
+        z = cry_eval_f('h {y}')
+        self.assertEqual(z, [x,x])
+        
+        self.assertEqual(cry_f('id {BV(size=7, value=1)}'), cry('id (1 : [7])'))
+        self.assertEqual(cry_eval_f('id {BV(size=7, value=1)}'), BV(size=7, value=1))
+
+        self.assertEqual(cry_f('{ {"a": x, "b": x} }'), cry('{a = 0x01, b = 0x01}'))
+        self.assertEqual(cry_f('{{a = {x}, b = {x}}}'), cry('{a = 0x01, b = 0x01}'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -21,17 +21,23 @@ class TestQuoting(unittest.TestCase):
         z = cry_eval_f('h {y}')
         self.assertEqual(y, [x,x])
         self.assertEqual(z, [x,x])
-        
+
         self.assertEqual(cry_f('id {BV(size=7, value=1)}'), cry('id (1 : [7])'))
         self.assertEqual(cry_eval_f('id {BV(size=7, value=1)}'), BV(size=7, value=1))
 
         self.assertEqual(cry_f('{ {"a": x, "b": x} }'), cry('{a = 0x01, b = 0x01}'))
         self.assertEqual(cry_f('{{a = {x}, b = {x}}}'), cry('{a = 0x01, b = 0x01}'))
-        
+
         self.assertEqual(cry_f('id {5}'),       cry('id 5'))
         self.assertEqual(cry_f('id {5!s}'),     cry('id "5"'))
         self.assertEqual(cry_f('id {5:#x}'),    cry('id "0x5"'))
         self.assertEqual(cry_f('id {BV(4,5)}'), cry('id 0x5'))
+
+        y = cry('g')(cry_f('{x}'))
+        z = cry('h')(cry_f('{y}'))
+        self.assertEqual(str(z), str(cry('(h) ((g) (0x01))')))
+        self.assertEqual(cry_eval(z), [x,x])
+        self.assertEqual(str(cry('id')(cry_f('{BV(size=7, value=1)}'))), str(cry('(id) (1 : [7])')))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the function `cry_f` for quasiquoting cryptol using an f-string-like syntax. The example from GaloisInc/saw-script#1188 can now be written as:
```python
a = cry('g x')
b = cry_f('foo {a}')
```
This PR also adds `cry_eval_f` and `Connection.eval_f` which behave the same as composing `cry_eval` (or `Connection.eval`) with `cry_f`. See `tests/cryptol/test_quoting.py` for more examples.

Under the hood, `cry_f` uses Python's f-string parser and converts all of the bracketed arguments it is given into Cryptol syntax. This enables it to handle more complex expressions, like:
```python
cry_f('{ {"x": BV(size=8, value=1)} }')
cry_f('{{x = {BV(size=8, value=1)}}}')
```
both of which produce `cry('{x = 0x01}')`.

In making this PR I realized `cryptoltypes.py` needs a lot of cleaning up. I pulled out most of the changes I made to that file along the way and will be making a separate PR for that soon.