### PR TITLE
`cryptol-remote-api`: Allow building with `aeson-2.0.*`

### DIFF
--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -42,7 +42,7 @@ common deps
   build-depends:
     base                 >=4.11.1.0 && <4.15,
     argo,
-    aeson                >= 1.4.2 && < 2.0,
+    aeson                >= 1.4.2 && < 2.1,
     base64-bytestring    >= 1.0,
     bytestring           ^>= 0.10.8,
     containers           >=0.6.0.1 && <0.7,
@@ -80,6 +80,9 @@ library
     CryptolServer.Names
     CryptolServer.Sat
     CryptolServer.TypeCheck
+
+  other-modules:
+    CryptolServer.AesonCompat
 
 executable cryptol-remote-api
   import:              deps, warnings, errors

--- a/cryptol-remote-api/src/CryptolServer/AesonCompat.hs
+++ b/cryptol-remote-api/src/CryptolServer/AesonCompat.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE CPP #-}
+
+-- | A compatibility shim for papering over the differences between
+-- @aeson-2.0.*@ and pre-2.0.* versions of @aeson@.
+--
+-- TODO: When the ecosystem widely uses @aeson-2.0.0.0@ or later, remove this
+-- module entirely.
+module CryptolServer.AesonCompat where
+
+import Data.HashMap.Strict (HashMap)
+import Data.Text (Text)
+
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.Key (Key)
+import qualified Data.Aeson.Key as K
+import Data.Aeson.KeyMap (KeyMap)
+import qualified Data.Aeson.KeyMap as KM
+#else
+import qualified Data.HashMap.Strict as HM
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+type KeyCompat = Key
+
+deleteKM :: Key -> KeyMap v -> KeyMap v
+deleteKM = KM.delete
+
+fromListKM :: [(Key, v)] -> KeyMap v
+fromListKM = KM.fromList
+
+keyFromText :: Text -> Key
+keyFromText = K.fromText
+
+keyToText :: Key -> Text
+keyToText = K.toText
+
+lookupKM :: Key -> KeyMap v -> Maybe v
+lookupKM = KM.lookup
+
+toHashMapTextKM :: KeyMap v -> HashMap Text v
+toHashMapTextKM = KM.toHashMapText
+
+toListKM :: KeyMap v -> [(Key, v)]
+toListKM = KM.toList
+#else
+type KeyCompat = Text
+
+deleteKM :: Text -> HashMap Text v -> HashMap Text v
+deleteKM = HM.delete
+
+fromListKM :: [(Text, v)] -> HashMap Text v
+fromListKM = HM.fromList
+
+keyFromText :: Text -> Text
+keyFromText = id
+
+keyToText :: Text -> Text
+keyToText = id
+
+lookupKM :: Text -> HashMap Text v -> Maybe v
+lookupKM = HM.lookup
+
+toHashMapTextKM :: HashMap Text v -> HashMap Text v
+toHashMapTextKM = id
+
+toListKM :: HashMap Text v -> [(Text, v)]
+toListKM = HM.toList
+#endif

--- a/cryptol-remote-api/src/CryptolServer/Check.hs
+++ b/cryptol-remote-api/src/CryptolServer/Check.hs
@@ -39,6 +39,7 @@ import CryptolServer
       liftModuleCmd,
       CryptolMethod(raise),
       CryptolCommand )
+import CryptolServer.AesonCompat (KeyCompat)
 import CryptolServer.Exceptions (evalPolyErr)
 import CryptolServer.Data.Expression
     ( readBack, getExpr, Expression)
@@ -118,7 +119,7 @@ data CheckResult =
   , checkTestsPossible :: Maybe Integer
   }
 
-convertServerTestResult :: ServerTestResult -> [(Text, JSON.Value)]
+convertServerTestResult :: ServerTestResult -> [(KeyCompat, JSON.Value)]
 convertServerTestResult Pass = ["result" .= ("pass" :: Text)]
 convertServerTestResult (FailFalse args) =
   [ "result" .= ("fail" :: Text)

--- a/cryptol-remote-api/src/CryptolServer/Exceptions.hs
+++ b/cryptol-remote-api/src/CryptolServer/Exceptions.hs
@@ -25,12 +25,12 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.HashMap.Strict as HashMap
 
 import Cryptol.Parser
 import qualified Cryptol.TypeCheck.Type as TC
 
 import Argo
+import CryptolServer.AesonCompat
 import CryptolServer.Data.Type
 
 cryptolError :: ModuleError -> [ModuleWarning] -> JSONRPCException
@@ -167,7 +167,7 @@ unwantedDefaults defs =
   makeJSONRPCException
     20210 "Execution would have required these defaults"
     (Just (JSON.object ["defaults" .=
-      [ jsonTypeAndString ty <> HashMap.fromList ["parameter" .= pretty param]
+      [ jsonTypeAndString ty <> fromListKM ["parameter" .= pretty param]
       | (param, ty) <- defs ] ]))
 
 evalInParamMod :: [CM.Name] -> JSONRPCException
@@ -204,6 +204,6 @@ cryptolParseErr expr err =
 -- human-readable string
 jsonTypeAndString :: TC.Type -> JSON.Object
 jsonTypeAndString ty =
-  HashMap.fromList
+  fromListKM
     [ "type" .= JSONSchema (TC.Forall [] [] ty)
     , "type string" .= pretty ty ]


### PR DESCRIPTION
This introduces some CPP, unfortunately, but this probably necessary to
continue allowing `cryptol-remote-api` to be buildable with old versions of
`aeson` until the ecosystem catches up with `aeson-2.0.*`.