### PR TITLE
[RPC] Clean up `to_cryptol` interface in cryptoltypes.py

### DIFF
--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * Add an interface for Cryptol quasiquotation using an f-string-like syntax,
   see `tests/cryptol/test_quoting` for some examples.
-
-* Fixed a bug with the client's `W4_ABC` solver, added a `W4_ANY` solver.
+* Fix a bug with the client's `W4_ABC` solver, add a `W4_ANY` solver.
+* Deprecate `CryptolType.from_python` and `CryptolType.convert`
+* Remove `CryptolType` arguments to `to_cryptol` and `__to_cryptol__`
 
 ## 2.12.0 -- 2021-11-19
 

--- a/cryptol-remote-api/python/cryptol/bitvector.py
+++ b/cryptol-remote-api/python/cryptol/bitvector.py
@@ -1,7 +1,10 @@
 
 from functools import reduce
 from typing import Any, List, Union, Optional, overload
+from typing_extensions import Literal
 from BitVector import BitVector #type: ignore
+
+ByteOrder = Union[Literal['little'], Literal['big']]
 
 
 class BV:
@@ -211,7 +214,7 @@ class BV:
         return bin(self).count("1")
 
     @staticmethod
-    def from_bytes(bs : bytes, *, size : Optional[int] =None, byteorder : str ='big') -> 'BV':
+    def from_bytes(bs : Union[bytes,bytearray], *, size : Optional[int] = None, byteorder : ByteOrder = 'big') -> 'BV':
         """Convert the given bytes ``bs`` into a ``BV``.
 
         :param bs: Bytes to convert to a ``BV``.
@@ -221,11 +224,13 @@ class BV:
             ``'big'``, ``little`` being the other acceptable value. Equivalent to the ``byteorder``
             parameter from Python's ``int.from_bytes``."""
 
-        if not isinstance(bs, bytes):
-            raise ValueError("from_bytes given not bytes value: {bs!r}")
+        if isinstance(bs, bytearray):
+            bs = bytes(bs)
+        elif not isinstance(bs, bytes):
+            raise ValueError(f"from_bytes given not a bytearray or bytes value: {bs!r}")
 
         if not byteorder == 'little' and not byteorder == 'big':
-            raise ValueError("from_bytes given not bytes value: {bs!r}")
+            raise ValueError("byteorder must be either 'little' or 'big'")
 
         if size == None:
             return BV(len(bs) * 8, int.from_bytes(bs, byteorder=byteorder))

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -469,7 +469,7 @@ class CryptolStdIOProcess(StdIOProcess):
 #         current_expr = self.name
 #         found_args = []
 #         while len(arg_types) > 0 and len(remaining_args) > 0:
-#             found_args.append(arg_types[0].from_python(remaining_args[0]))
+#             found_args.append(to_cryptol(remaining_args[0]))
 #             current_expr = {'expression': 'call', 'function': self.name, 'arguments': found_args}
 #             ty = self.connection.check_type(current_expr).result()
 #             current_type = cryptoltypes.to_schema(ty)

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -228,7 +228,11 @@ def is_plausible_json(val : Any) -> bool:
     return False
 
 class CryptolType:
-  pass
+    def from_python(self, val : Any) -> NoReturn:
+        raise Exception("CryptolType.from_python is deprecated, use to_cryptol")
+    
+    def convert(self, val : Any) -> NoReturn:
+        raise Exception("CryptolType.convert is deprecated, use to_cryptol")
 
 class Var(CryptolType):
     def __init__(self, name : str, kind : CryptolKind) -> None:

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -164,6 +164,8 @@ class Logic(UnaryProp):
 
 
 def to_cryptol(val : Any) -> JSON:
+    """Convert a ``CryptolJSON`` value, a Python value representing a Cryptol
+       term, or any combination of the two to Cryptol JSON."""
     if isinstance(val, bool):
         return val
     elif isinstance(val, tuple) and val == ():
@@ -258,13 +260,6 @@ class Bitvector(CryptolType):
 
     def __repr__(self) -> str:
         return f"Bitvector({self.width!r})"
-
-
-def eval_numeric(t : Any, default : A) -> Union[int, A]:
-    if isinstance(t, Num):
-        return t.number
-    else:
-        return default
 
 
 class Num(CryptolType):


### PR DESCRIPTION
Currently, `cryptoltypes.py` has the functions `to_cryptol`, `CryptolType.from_python`, and `CryptolType.convert`, all of which do approximately the same thing. Only the first is used in any current code in this repo or in saw-script, so this PR removes the latter two.

Currently, `__to_cryptol__` has a `CryptolType` parameter that does nothing, and `to_cryptol` has a `CryptolType` parameter that only matters in the following two cases:
```python
to_cryptol(x, Bitvector(Num(w))) == to_cryptol(BV(w, x)) # if x is an int
to_cryptol(x, Bitvector(Num(w))) == to_cryptol(BV.from_bytes(x, size=w)) # if x is a bytearray or bytes
```
Otherwise every Python value has a unique `CryptolType`, so the parameter is unused. These `CryptolType` parameters are never actually used in any current code in this repo or in saw-script, and I prefer the expressions on the RHS of the equalities above anyway, so this PR also removes these parameters.

NB: This could potentially break someone's code if they use one of the deleted functions or parameters. 