### PR TITLE
[RPC] Finish cleaning cryptoltypes.py

### DIFF
--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for `cryptol` Python package
 
+## 2.12.4 -- YYYY-MM-DD
+
+* NEW CHANGELOG ENTRIES SINCE 2.12.2 GO HERE
+
 ## 2.12.2 -- 2021-12-21
 
 * Add an interface for Cryptol quasiquotation using an f-string-like syntax,

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for `cryptol` Python package
 
-## 2.12.2 -- YYYY-MM-DD
+## 2.12.2 -- 2021-12-21
 
 * Add an interface for Cryptol quasiquotation using an f-string-like syntax,
   see `tests/cryptol/test_quoting` for some examples.

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -136,27 +136,57 @@ class UnaryProp(CryptolProp):
     subject : CryptolType
 
 @dataclass
-class Fin(UnaryProp):
-    pass
+class BinaryProp(CryptolProp):
+    left : CryptolType
+    right : CryptolType
 
 @dataclass
-class Cmp(UnaryProp):
-    pass
+class Equal(BinaryProp): pass
+@dataclass
+class NotEqual(BinaryProp): pass
+@dataclass
+class Geq(BinaryProp): pass
+@dataclass
+class Fin(UnaryProp): pass
+@dataclass
+class Prime(UnaryProp): pass
 
 @dataclass
-class SignedCmp(UnaryProp):
-    pass
+class Zero(UnaryProp): pass
+@dataclass
+class Logic(UnaryProp): pass
+@dataclass
+class Ring(UnaryProp): pass
+@dataclass
+class Integral(UnaryProp): pass
+@dataclass
+class Field(UnaryProp): pass
+@dataclass
+class Round(UnaryProp): pass
+@dataclass
+class Eq(UnaryProp): pass
+@dataclass
+class Cmp(UnaryProp): pass
+@dataclass
+class SignedCmp(UnaryProp): pass
+@dataclass
+class Literal(UnaryProp): pass
+@dataclass
+class LiteralLessThan(UnaryProp): pass
+@dataclass
+class FLiteral(CryptolProp):
+    numerator : CryptolType
+    denominator : CryptolType
 
 @dataclass
-class Zero(UnaryProp):
-    pass
+class ValidFloat(BinaryProp): pass
 
 @dataclass
-class Arith(UnaryProp):
-    pass
-
+class And(CryptolProp):
+    left : CryptolProp
+    right : CryptolProp
 @dataclass
-class Logic(UnaryProp):
+class True(CryptolProp):
     pass
 
 
@@ -274,7 +304,7 @@ class Sequence(CryptolType):
     contents : CryptolType
 
     def __str__(self) -> str:
-        return f"[{self.length}]{parenthesize(str(self.contents))}"
+        return f"[{self.length}]{self.contents}"
 
 @dataclass
 class Inf(CryptolType):
@@ -299,66 +329,47 @@ class Z(CryptolType):
         return f"(Z {self.modulus})"
 
 @dataclass
-class Plus(CryptolType):
+class BinaryType(CryptolType):
     left : CryptolType
     right : CryptolType
 
+@dataclass
+class Plus(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} + {self.right})"
 
 @dataclass
-class Minus(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Minus(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} - {self.right})"
 
 @dataclass
-class Times(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Times(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} * {self.right})"
 
 @dataclass
-class Div(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Div(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} / {self.right})"
 
 @dataclass
-class CeilDiv(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class CeilDiv(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} /^ {self.right})"
 
 @dataclass
-class Mod(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Mod(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} % {self.right})"
 
 @dataclass
-class CeilMod(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class CeilMod(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} %^ {self.right})"
 
 @dataclass
-class Expt(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Expt(BinaryType):
     def __str__(self) -> str:
         return f"({self.left} ^^ {self.right})"
 
@@ -377,20 +388,23 @@ class Width(CryptolType):
         return f"(width {self.operand})"
 
 @dataclass
-class Max(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Max(BinaryType):
     def __str__(self) -> str:
         return f"(max {self.left} {self.right})"
 
 @dataclass
-class Min(CryptolType):
-    left : CryptolType
-    right : CryptolType
-
+class Min(BinaryType):
     def __str__(self) -> str:
         return f"(min {self.left} {self.right})"
+
+@dataclass
+class LenFromThenTo(CryptolType):
+    num_from : CryptolType
+    num_then : CryptolType
+    num_to : CryptolType
+
+    def __str__(self) -> str:
+        return f"(lengthFromThenTo {self.num_from} {self.num_then} {self.num_to})"
 
 @dataclass
 class Tuple(CryptolType):
@@ -455,6 +469,8 @@ def to_type(t : Any) -> CryptolType:
         return Min(*map(to_type, t['arguments']))
     elif t['type'] == 'tuple':
         return Tuple(*map(to_type, t['contents']))
+    elif t['type'] == 'unit':
+        return Tuple()
     elif t['type'] == 'record':
         return Record({k : to_type(t['fields'][k]) for k in t['fields']})
     elif t['type'] == 'Integer':

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -457,6 +457,14 @@ def to_schema(obj : Any) -> CryptolTypeSchema:
                              [to_prop(p) for p in obj['propositions']],
                              to_type(obj['type']))
 
+def to_schema_or_type(obj : Any) -> Union[CryptolTypeSchema, CryptolType]:
+    """Convert a Cryptol JSON type schema to a ``CryptolType`` if it has no
+    variables or propositions, or to a ``CryptolTypeSchema`` otherwise."""
+    if 'forall' in obj and 'propositions' in obj and len(obj['forall']) > 0 and len(obj['propositions']) > 0:
+        return to_schema(obj)
+    else:
+        return to_type(obj['type'])
+
 def argument_types(obj : Union[CryptolTypeSchema, CryptolType]) -> List[CryptolType]:
     """Given a ``CryptolTypeSchema` or ``CryptolType`` of a function, return
     the types of its arguments."""

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -518,6 +518,8 @@ def to_type(t : Any) -> CryptolType:
         return Max(*map(to_type, t['arguments']))
     elif t['type'] == 'min':
         return Min(*map(to_type, t['arguments']))
+    elif t['type'] == 'lengthFromThenTo':
+        return LenFromThenTo(*map(to_type, t['arguments']))
     elif t['type'] == 'tuple':
         return Tuple(*map(to_type, t['contents']))
     elif t['type'] == 'unit':

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -14,6 +14,11 @@ from typing_extensions import Literal, Protocol, runtime_checkable
 
 A = TypeVar('A')
 
+
+# -----------------------------------------------------------
+# CryptolJSON and CryptolCode
+# -----------------------------------------------------------
+
 def is_parenthesized(s : str) -> bool:
     """Returns ``True`` iff the given string has balanced parentheses and is
        enclosed in a matching pair of parentheses.
@@ -112,6 +117,10 @@ class CryptolApplication(CryptolCode):
             return ' '.join(parenthesize(x.__to_cryptol_str__()) for x in [self._rator, *self._rands])
 
 
+# -----------------------------------------------------------
+# Cryptol kinds
+# -----------------------------------------------------------
+
 @dataclass
 class CryptolArrowKind:
     domain : CryptolKind
@@ -127,6 +136,11 @@ def to_kind(k : Any) -> CryptolKind:
         return CryptolArrowKind(k['from'], k['to'])
     else:
         raise ValueError(f'Not a Cryptol kind: {k!r}')
+
+
+# -----------------------------------------------------------
+# Cryptol props
+# -----------------------------------------------------------
 
 class CryptolProp:
     pass
@@ -189,6 +203,10 @@ class And(CryptolProp):
 class True(CryptolProp):
     pass
 
+
+# -----------------------------------------------------------
+# Converting Python terms to Cryptol JSON
+# -----------------------------------------------------------
 
 def to_cryptol(val : Any) -> JSON:
     """Convert a ``CryptolJSON`` value, a Python value representing a Cryptol
@@ -255,6 +273,11 @@ def is_plausible_json(val : Any) -> bool:
         return all(is_plausible_json(elt) for elt in val)
 
     return False
+
+
+# -----------------------------------------------------------
+# Cryptol types
+# -----------------------------------------------------------
 
 class CryptolType:
     def from_python(self, val : Any) -> NoReturn:
@@ -426,7 +449,6 @@ class Record(CryptolType):
     def __str__(self) -> str:
         return "{" + ",".join(str(k) + " = " + str(self.fields[k]) for k in self.fields) + "}"
 
-
 def to_type(t : Any) -> CryptolType:
     """Convert a Cryptol JSON type to a ``CryptolType``."""
     if t['type'] == 'variable':
@@ -481,6 +503,11 @@ def to_type(t : Any) -> CryptolType:
         return Z(to_type(t['modulus']))
     else:
         raise NotImplementedError(f"to_type({t!r})")
+
+
+# -----------------------------------------------------------
+# Cryptol type schema
+# -----------------------------------------------------------
 
 class CryptolTypeSchema:
     def __init__(self,

--- a/cryptol-remote-api/python/cryptol/cryptoltypes.py
+++ b/cryptol-remote-api/python/cryptol/cryptoltypes.py
@@ -101,7 +101,8 @@ class CryptolApplication(CryptolCode):
             self._rator = rator
             self._rands = rands
         else:
-            raise ValueError("Arguments given to CryptolApplication must be CryptolJSON")
+            args_str = ", ".join(map(repr, [rator, *rands]))
+            raise ValueError("Arguments given to CryptolApplication must be CryptolJSON: " + args_str)
 
     def __repr__(self) -> str:
         return f'CryptolApplication({", ".join(repr(x) for x in [self._rator, *self._rands])})'

--- a/cryptol-remote-api/python/cryptol/opaque.py
+++ b/cryptol-remote-api/python/cryptol/opaque.py
@@ -1,5 +1,7 @@
 from typing import Any
+from dataclasses import dataclass
 
+@dataclass(frozen=True)
 class OpaqueValue():
   """A value from the Cryptol server which cannot be directly represented and/or
   marshalled to an RPC client.
@@ -9,20 +11,5 @@ class OpaqueValue():
   be consulted to compute the result."""
   identifier : str
 
-  def __init__(self, identifier : str) -> None:
-    self.identifier = identifier
-
   def __str__(self) -> str:
     return self.identifier
-
-  def __repr__(self) -> str:
-      return f"Opaque({self.identifier!r})"
-
-  def __eq__(self, other : Any) -> bool:
-    if not isinstance(other, OpaqueValue):
-        return False
-    else:
-      return self.identifier == other.identifier
-
-  def __hash__(self) -> int:
-      return hash(self.identifier)

--- a/cryptol-remote-api/python/cryptol/opaque.py
+++ b/cryptol-remote-api/python/cryptol/opaque.py
@@ -1,6 +1,7 @@
 from typing import Any
 from dataclasses import dataclass
 
+# we freeze this class because ``OpaqueValue``s represent immutable objects
 @dataclass(frozen=True)
 class OpaqueValue():
   """A value from the Cryptol server which cannot be directly represented and/or

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -169,7 +169,7 @@ def check(expr : Any, *, num_tests : Union[Literal['all'], int, None] = None, ti
     """
     return __get_designated_connection().check(expr, num_tests=num_tests, timeout=timeout)
 
-def check_type(code : Any, *, timeout:Optional[float] = None) -> cryptoltypes.CryptolType:
+def check_type(code : Any, *, timeout:Optional[float] = None) -> Union[cryptoltypes.CryptolType, cryptoltypes.CryptolTypeSchema]:
     """Check the type of a Cryptol expression, represented according to
     :ref:`cryptol-json-expression`, with Python datatypes standing for
     their JSON equivalents.

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -232,12 +232,12 @@ class CryptolSyncConnection:
         """
         return to_check_report(self.connection.check_raw(expr, num_tests=num_tests, timeout=timeout).result())
 
-    def check_type(self, code : Any, *, timeout:Optional[float] = None) -> cryptoltypes.CryptolType:
+    def check_type(self, code : Any, *, timeout:Optional[float] = None) -> Union[cryptoltypes.CryptolType, cryptoltypes.CryptolTypeSchema]:
         """Check the type of a Cryptol expression, represented according to
         :ref:`cryptol-json-expression`, with Python datatypes standing for
         their JSON equivalents.
         """
-        return cryptoltypes.to_type(self.connection.check_type(code, timeout=timeout).result()['type'])
+        return cryptoltypes.to_schema_or_type(self.connection.check_type(code, timeout=timeout).result())
 
     @overload
     def sat(self, expr : Any, solver : OfflineSolver, count : int = 1, *, timeout:Optional[float] = None) -> OfflineSmtQuery: ...

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "2.12.1"
+version = "2.12.2"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol 2.12 RPC server"

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "2.12.2"
+version = "2.12.3"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol 2.12 RPC server"

--- a/cryptol-remote-api/python/tests/cryptol/test-files/Types.cry
+++ b/cryptol-remote-api/python/tests/cryptol/test-files/Types.cry
@@ -23,3 +23,6 @@ s = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
 r : {xCoord : [32], yCoord : [32]}
 r = {xCoord = 12 : [32], yCoord = 21 : [32]}
+
+id : {n} (fin n) => [n] -> [n]
+id a = a

--- a/cryptol-remote-api/python/tests/cryptol/test_basics.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_basics.py
@@ -5,6 +5,7 @@ import unittest
 import io
 import os
 import time
+from distutils.spawn import find_executable
 import cryptol
 import cryptol.cryptoltypes
 from cryptol.single_connection import *
@@ -70,7 +71,7 @@ class BasicServerTests(unittest.TestCase):
 
     def test_interrupt(self):
         # Check if this test is using a local server, if not we assume it's a remote HTTP server
-        if os.getenv('CRYPTOL_SERVER') is not None:
+        if os.getenv('CRYPTOL_SERVER') is not None or find_executable('cryptol-remote-api'):
             c = self.c
             c.load_file(str(Path('tests','cryptol','test-files', 'examples','AES.cry')))
 

--- a/cryptol-remote-api/python/tests/cryptol/test_types.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_types.py
@@ -1,10 +1,12 @@
 import unittest
+from argo_client.interaction import ArgoException
 from pathlib import Path
 import unittest
 import cryptol
 from cryptol.single_connection import *
 from cryptol.opaque import OpaqueValue
 from cryptol.bitvector import BV
+from cryptol import cryptoltypes
 
 
 class CryptolTypeTests(unittest.TestCase):
@@ -14,33 +16,59 @@ class CryptolTypeTests(unittest.TestCase):
 
         # Bits
         self.assertEqual(cry_eval('b'), True)
+        self.assertEqual(check_type('b'), cryptoltypes.Bit())
         
         # Words
         self.assertEqual(cry_eval('w'), BV(size=16, value=42))
+        self.assertEqual(check_type('w'), cryptoltypes.Bitvector(cryptoltypes.Num(16)))
         
         # Integers
         self.assertEqual(cry_eval('z'), 420000)
+        self.assertEqual(check_type('z'), cryptoltypes.Integer())
         
-        # Modular integers - not supported at all
+        # Modular integers - not supported as values
         with self.assertRaises(ValueError):
             cry_eval('m')
+        self.assertEqual(check_type('m'), cryptoltypes.Z(cryptoltypes.Num(12)))
 
         # Rationals - supported only as opaque values
         self.assertIsInstance(cry_eval('q'), OpaqueValue)
+        self.assertEqual(check_type('q'), cryptoltypes.Rational())
     
         # Tuples
         self.assertEqual(cry_eval('t'), (False, 7))
+        t_ty = cryptoltypes.Tuple(cryptoltypes.Bit(), cryptoltypes.Integer())
+        self.assertEqual(check_type('t'), t_ty)
 
         # Sequences
         self.assertEqual(cry_eval('s'),
             [[BV(size=8, value=1), BV(size=8, value=2), BV(size=8, value=3)],
              [BV(size=8, value=4), BV(size=8, value=5), BV(size=8, value=6)],
              [BV(size=8, value=7), BV(size=8, value=8), BV(size=8, value=9)]])
+        s_ty = cryptoltypes.Sequence(cryptoltypes.Num(3),
+               cryptoltypes.Sequence(cryptoltypes.Num(3),
+               cryptoltypes.Bitvector(cryptoltypes.Num(8))))
+        self.assertEqual(check_type('s'), s_ty)
         
         # Records
         self.assertEqual(cry_eval('r'),
             {'xCoord': BV(size=32, value=12),
              'yCoord': BV(size=32, value=21)})
+        r_ty = cryptoltypes.Record({
+          'xCoord': cryptoltypes.Bitvector(cryptoltypes.Num(32)),
+          'yCoord': cryptoltypes.Bitvector(cryptoltypes.Num(32))})
+        self.assertEqual(check_type('r'), r_ty)
+
+        # Functions - not supported as values
+        with self.assertRaises(ArgoException):
+            cry_eval('id')
+        n = cryptoltypes.Var('n', 'Num')
+        id_ty = cryptoltypes.CryptolTypeSchema(
+          {n.name: n.kind}, [cryptoltypes.PropCon('fin', n)],
+          cryptoltypes.Function(cryptoltypes.Bitvector(n),
+                                cryptoltypes.Bitvector(n)))
+        self.assertEqual(check_type('id'), id_ty)
+        
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR finishes cleaning up `cryptoltypes.py`, specifically:
- Finishes adding classes for all of the currently implemented Cryptol props (see [Cryptol.TypeCheck.TCon](https://github.com/GaloisInc/cryptol/blob/08cd609c4c58ebb5a4cd22ad053d8255ce8d1fc5/src/Cryptol/TypeCheck/TCon.hs#L200) and [CryptolServer.Data.Type](https://github.com/GaloisInc/cryptol/blob/08cd609c4c58ebb5a4cd22ad053d8255ce8d1fc5/cryptol-remote-api/src/CryptolServer/Data/Type.hs#L131))
- Adds class for `lengthFromTo` type operator
- Adds type annotations for all instance variables
- Finishes implementing `__str__` methods for all Cryptol types
- Uses `@dataclass` everywhere possible to avoid writing `__repr__` and `__eq__` methods
- Adds more docstrings
- Adds comments delineating sections