### PR TITLE
python client 2.12.4 PyPI release

### DIFF
--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Revision history for `cryptol` Python package
 
-## 2.12.4 -- YYYY-MM-DD
+## 2.12.4 -- 2022-03-21
 
-* NEW CHANGELOG ENTRIES SINCE 2.12.2 GO HERE
 * fix: add `typing-extensions` as an explicit dependency for the client.
 
 ## 2.12.2 -- 2021-12-21

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "2.12.3"
+version = "2.12.4"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol 2.12 RPC server"


### PR DESCRIPTION
This is intended to be what is committed to PyPI for the 2.12.4 release. After the release we'll bump again to the dev version 2.12.5.