### PR TITLE
Update `what4` dependency to `1.3`

### DIFF
--- a/cabal.GHC-8.10.7.config
+++ b/cabal.GHC-8.10.7.config
@@ -294,7 +294,7 @@ constraints: any.Cabal ==3.2.1.0,
              any.warp-tls ==3.3.2,
              any.wcwidth ==0.0.2,
              wcwidth -cli +split-base,
-             any.what4 ==1.2.1,
+             any.what4 ==1.3,
              what4 -drealtestdisable -solvertests -stptestdisable,
              any.witherable ==0.4.2,
              any.word8 ==0.1.3,
@@ -306,4 +306,4 @@ constraints: any.Cabal ==3.2.1.0,
              any.zlib ==0.6.2.3,
              zlib -bundled-c-zlib -non-blocking-ffi -pkg-config,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2022-01-13T19:44:37Z
+index-state: hackage.haskell.org 2022-04-21T14:15:08Z

--- a/cabal.GHC-8.8.4.config
+++ b/cabal.GHC-8.8.4.config
@@ -295,7 +295,7 @@ constraints: any.Cabal ==3.0.1.0,
              any.warp-tls ==3.3.2,
              any.wcwidth ==0.0.2,
              wcwidth -cli +split-base,
-             any.what4 ==1.2.1,
+             any.what4 ==1.3,
              what4 -drealtestdisable -solvertests -stptestdisable,
              any.witherable ==0.4.2,
              any.word8 ==0.1.3,
@@ -307,4 +307,4 @@ constraints: any.Cabal ==3.0.1.0,
              any.zlib ==0.6.2.3,
              zlib -bundled-c-zlib -non-blocking-ffi -pkg-config,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2022-01-13T19:44:37Z
+index-state: hackage.haskell.org 2022-04-21T14:15:08Z

--- a/cabal.GHC-9.0.2.config
+++ b/cabal.GHC-9.0.2.config
@@ -295,7 +295,7 @@ constraints: any.Cabal ==3.4.1.0,
              any.warp-tls ==3.3.2,
              any.wcwidth ==0.0.2,
              wcwidth -cli +split-base,
-             any.what4 ==1.2.1,
+             any.what4 ==1.3,
              what4 -drealtestdisable -solvertests -stptestdisable,
              any.witherable ==0.4.2,
              any.word8 ==0.1.3,
@@ -307,4 +307,4 @@ constraints: any.Cabal ==3.4.1.0,
              any.zlib ==0.6.2.3,
              zlib -bundled-c-zlib -non-blocking-ffi -pkg-config,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2022-01-13T19:44:37Z
+index-state: hackage.haskell.org 2022-04-21T14:15:08Z

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -74,7 +74,7 @@ library
                        mtl               >= 2.2.1,
                        time              >= 1.6.0.1,
                        panic             >= 0.3,
-                       what4             >= 1.2 && < 1.3
+                       what4             >= 1.3 && < 1.4
 
   if impl(ghc >= 9.0)
     build-depends:     ghc-bignum        >= 1.0 && < 1.3


### PR DESCRIPTION
Among other things, `what4-1.3` includes [a bugfix](https://github.com/GaloisInc/what4/pull/148) that allows `what4` to correctly invoke modern versions of Boolector.