### PR TITLE
Fix the nightly `cryptol-remote-api` Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ on:
 
 env:
   SOLVER_PKG_VERSION: "snapshot-20220114"
+  # The CACHE_VERSION can be updated to force the use of a new cache if
+  # the current cache contents become corrupted/invalid.  This can
+  # sometimes happen when (for example) the OS version is changed but
+  # older .so files are cached, which can have various effects
+  # (e.g. cabal complains it can't find a valid version of the "happy"
+  # tool).
+  CACHE_VERSION: 1
 
 jobs:
   config:
@@ -88,9 +95,9 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
-          key: cabal-${{ runner.os }}-${{ matrix.ghc-version }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc-version)) }}-${{ github.sha }}
+          key: ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc-version }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc-version)) }}-${{ github.sha }}
           restore-keys: |
-            cabal-${{ runner.os }}-${{ matrix.ghc-version }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc-version)) }}-
+            ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc-version }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc-version)) }}-
 
       - shell: bash
         run: .github/ci.sh install_system_deps

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 RUN curl https://i.jpillora.com/chisel! | bash
 
 # Install GHC
-ARG GHCVER="8.10.3"
+ARG GHCVER="8.10.7"
 ENV GHCUP_INSTALL_BASE_PREFIX=/opt \
     PATH=/opt/.ghcup/bin:$PATH
-RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.14/x86_64-linux-ghcup-0.1.14" && \
+RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.17.7/x86_64-linux-ghcup-0.1.17.7" && \
     chmod +x /usr/local/bin/ghcup
 RUN ghcup install cabal --set
 ENV PATH=/root/.cabal/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER cryptol
 WORKDIR /cryptol
 RUN mkdir -p rootfs/usr/local/bin
 WORKDIR /cryptol/rootfs/usr/local/bin
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20210917/ubuntu-18.04-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220114/ubuntu-18.04-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 WORKDIR /cryptol
 ENV PATH=/cryptol/rootfs/usr/local/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cryptol currently uses Microsoft Research's [Z3 SMT
 solver](https://github.com/Z3Prover/z3) by default to solve constraints
 during type checking, and as the default solver for the `:sat` and
 `:prove` commands.  Cryptol generally requires the most recent version
-of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20210917).
+of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20220114).
 
 You can download Z3 binaries for a variety of platforms from their
 [releases page](https://github.com/Z3Prover/z3/releases). If you

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -1,4 +1,4 @@
-ARG GHCVER="8.10.3"
+ARG GHCVER="8.10.7"
 ARG GHCVER_BOOTSTRAP="8.10.2"
 FROM debian:buster-20210511 AS toolchain
 ARG PORTABILITY=false
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y libncurses-dev libz-dev unzip \
     $(if ${PORTABILITY}; then echo git autoconf python3; fi)
 ENV GHCUP_INSTALL_BASE_PREFIX=/opt \
     PATH=/opt/.ghcup/bin:$PATH
-RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.14/x86_64-linux-ghcup-0.1.14" && \
+RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.17.7/x86_64-linux-ghcup-0.1.17.7" && \
     chmod +x /usr/local/bin/ghcup
 RUN ghcup install cabal --set
 ENV PATH=/root/.cabal/bin:$PATH

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -57,7 +57,7 @@ ENV PATH=/usr/local/bin:/cryptol/rootfs/usr/local/bin:$PATH
 RUN mkdir -p rootfs/"${CRYPTOLPATH}" \
     && cp -r lib/* rootfs/"${CRYPTOLPATH}"
 WORKDIR /cryptol/rootfs/usr/local/bin
-RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20210917/ubuntu-18.04-bin.zip" && \
+RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220114/ubuntu-18.04-bin.zip" && \
     unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /cryptol/rootfs

--- a/cryptol-remote-api/ghc-portability.patch
+++ b/cryptol-remote-api/ghc-portability.patch
@@ -1,8 +1,8 @@
 diff --git a/configure.ac b/configure.ac
-index d1462db837..55053cefe1 100644
+index 6eac557b93..fd87983730 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -918,7 +918,7 @@ dnl    off_t, because it will affect the result of that test.
+@@ -922,7 +922,7 @@ dnl    off_t, because it will affect the result of that test.
  AC_SYS_LARGEFILE
  
  dnl ** check for specific header (.h) files that we are interested in
@@ -11,8 +11,8 @@ index d1462db837..55053cefe1 100644
  
  dnl sys/cpuset.h needs sys/param.h to be included first on FreeBSD 9.1; #7708
  AC_CHECK_HEADERS([sys/cpuset.h], [], [],
-@@ -1174,10 +1174,6 @@ AC_TRY_LINK(
-     AC_MSG_RESULT(no)
+@@ -1230,10 +1230,6 @@ AC_LINK_IFELSE([
+   AC_MSG_RESULT(no)
  )
  
 -dnl ** check for eventfd which is needed by the I/O manager
@@ -23,11 +23,11 @@ index d1462db837..55053cefe1 100644
  AC_MSG_CHECKING(for __thread support)
  AC_COMPILE_IFELSE(
 diff --git a/libraries/base/configure.ac b/libraries/base/configure.ac
-index d34224acc7..a67bdef684 100644
+index 716e46cc05..694bf6aa81 100644
 --- a/libraries/base/configure.ac
 +++ b/libraries/base/configure.ac
-@@ -30,7 +30,7 @@ dnl ** check for full ANSI header (.h) files
- AC_HEADER_STDC
+@@ -23,7 +23,7 @@ AC_MSG_RESULT($WINDOWS)
+ AC_CHECK_TYPES([long long])
  
  # check for specific header (.h) files that we are interested in
 -AC_CHECK_HEADERS([ctype.h errno.h fcntl.h inttypes.h limits.h signal.h sys/file.h sys/resource.h sys/select.h sys/stat.h sys/syscall.h sys/time.h sys/timeb.h sys/timers.h sys/times.h sys/types.h sys/utsname.h sys/wait.h termios.h time.h unistd.h utime.h windows.h winsock.h langinfo.h poll.h sys/epoll.h sys/event.h sys/eventfd.h sys/socket.h])
@@ -35,7 +35,7 @@ index d34224acc7..a67bdef684 100644
  
  # Enable large file support. Do this before testing the types ino_t, off_t, and
  # rlim_t, because it will affect the result of that test.
-@@ -47,7 +47,7 @@ AC_CHECK_FUNCS([clock_gettime])
+@@ -40,7 +40,7 @@ AC_CHECK_FUNCS([clock_gettime])
  AC_CHECK_FUNCS([getclock getrusage times])
  AC_CHECK_FUNCS([_chsize ftruncate])
  


### PR DESCRIPTION
This converts the `cryptol-remote-api` Dockerfiles to use GHC 8.10.7 instead of GHC 8.10.3, now that we have switched over to using 8.10.7 in the CI. This also updates `cryptol-remote-api`'s `ghc.portability` patch to use the 8.10.7 branch of GHC.

Fixes #1347.