### PR TITLE
CI: Improve signing and tag workflows

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -109,10 +109,14 @@ bundle_files() {
 }
 
 sign() {
+  # This is surrounded with `set +x; ...; set -x` to disable printing out
+  # statements that could leak GPG-related secrets.
+  set +x
   gpg --batch --import <(echo "$SIGNING_KEY")
   fingerprint="$(gpg --list-keys | grep galois -a1 | head -n1 | awk '{$1=$1};1')"
   echo "$fingerprint:6" | gpg --import-ownertrust
   gpg --yes --no-tty --batch --pinentry-mode loopback --default-key "$fingerprint" --detach-sign -o "$1".sig --passphrase-file <(echo "$SIGNING_PASSPHRASE") "$1"
+  set -x
 }
 
 zip_dist() {

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -113,7 +113,7 @@ sign() {
   # statements that could leak GPG-related secrets.
   set +x
   gpg --batch --import <(echo "$SIGNING_KEY")
-  fingerprint="$(gpg --list-keys | grep galois -a1 | head -n1 | awk '{$1=$1};1')"
+  fingerprint="$(gpg --list-keys | grep Galois -a1 | head -n1 | awk '{$1=$1};1')"
   echo "$fingerprint:6" | gpg --import-ownertrust
   gpg --yes --no-tty --batch --pinentry-mode loopback --default-key "$fingerprint" --detach-sign -o "$1".sig --passphrase-file <(echo "$SIGNING_PASSPHRASE") "$1"
   set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - if: runner.os == 'Windows'
         run: .github/wix.ps1
 
-      - if: needs.config.outputs.release == 'true' && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -181,8 +181,7 @@ jobs:
         env:
           OS_TAG: ${{ matrix.os }}
 
-      - if: needs.config.outputs.release == 'true'
-        shell: bash
+      - shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Cryptol
 on:
   push:
-    tags: ["?[0-9]+.[0-9]+(.[0-9]+)?"]
+    tags: ["[0-9]+.[0-9]+(.[0-9]+)?"]
     branches: [master, "release-**"]
   pull_request:
   schedule:
@@ -311,7 +311,7 @@ jobs:
   build-push-image:
     runs-on: ubuntu-20.04
     needs: [config]
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
* Always sign binary artifacts, not just for releases. Fixes #1355.
* Trigger full releases after `git tag --push`. Fixes #1351.
* Use modern GPG keys. Fixes #1354.