### PR TITLE
Only include bindist-related files in `cryptol.msi`

### DIFF
--- a/.github/wix.ps1
+++ b/.github/wix.ps1
@@ -1,4 +1,4 @@
-& "$env:WIX\bin\heat.exe" dir "$pwd" -o allfiles.wxs -nologo -var var.pkg -ag -wixvar -cg ALLFILES -srd -dr INSTALLDIR -sfrag
-& "$env:WIX\bin\candle.exe" -ext WixUIExtension -ext WixUtilExtension -dversion="$env:VERSION" -dpkg="$pwd" win32\cryptol.wxs
-& "$env:WIX\bin\candle.exe" -ext WixUIExtension -ext WixUtilExtension -dversion="$env:VERSION" -dpkg="$pwd" allfiles.wxs
+& "$env:WIX\bin\heat.exe" dir "$pwd/dist" -o allfiles.wxs -nologo -var var.pkg -ag -wixvar -cg ALLFILES -srd -dr INSTALLDIR -sfrag
+& "$env:WIX\bin\candle.exe" -ext WixUIExtension -ext WixUtilExtension -dversion="$env:VERSION" win32\cryptol.wxs
+& "$env:WIX\bin\candle.exe" -ext WixUIExtension -ext WixUtilExtension -dversion="$env:VERSION" -dpkg="$pwd/dist" allfiles.wxs
 & "$env:WIX\bin\light.exe" -ext WixUIExtension -ext WixUtilExtension -sval -o cryptol.msi cryptol.wixobj allfiles.wixobj

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ cryptol-2.*
 /bin
 /output
 /tests/regression/*.out
+
+# WiX-generated files
+allfiles.wixobj
+allfiles.wxs
+cryptol.msi
+cryptol.wixobj
+cryptol.wixpdb

--- a/win32/cryptol.wxs
+++ b/win32/cryptol.wxs
@@ -32,7 +32,7 @@
             <Shortcut Id="startmenuCryptol"
                       Name="Cryptol $(var.version)"
                       WorkingDirectory='INSTALLDIR'
-                      Target="[INSTALLDIR]\dist\bin\cryptol.exe"
+                      Target="[INSTALLDIR]\bin\cryptol.exe"
                       Icon="crypto.ico"
                       IconIndex="0" />
             <!-- <Shortcut Id="startmenuTutorial" -->
@@ -56,7 +56,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Component Id="Path" Guid="4D7F78E6-DA16-4C1B-96C4-B33C87502C81">
-        <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]\dist\bin" Permanent="no" Part="last" Action="set" System="no" />
+        <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]\bin" Permanent="no" Part="last" Action="set" System="no" />
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
Previously, we would include every file in the current `cryptol` checkout in `cryptol.msi`, which would result in horribly bloated installer files. We now only include those files under the `dist` directory (created by `.github/ci.sh bundle_files`), which curates only those files we want to include in a binary distribution.

While I was in town, I modified the conventioned used in `win32/cryptol.wxs` so that we no longer need to reference `dist`, which does not show up in `.tar.gz`-based bindists.

Fixes #977.