### PR TITLE
Fix off-by-one error in What4 implementation of `(@)`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# next
+
+## Bug fixes
+
+* Fix a bug in the What4 backend that could cause applications of `(@)` with
+  symbolic `Integer` indices to become out of bounds (#1359).
+
 # 2.13.0
 
 ## Language changes

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -540,7 +540,7 @@ indexFront_int sym mblen _a xs _ix idx
     -- isn't much we can do.
     maxIdx =
       case mblen of
-        Nat n -> Just n
+        Nat n -> Just (n - 1)
         Inf   -> Nothing
 indexFront_segs ::
   W4.IsSymExprBuilder sym =>

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -505,7 +505,7 @@ indexFront_int ::
   TValue ->
   SInteger (What4 sym) ->
   SEval (What4 sym) (Value sym)
-indexFront_int sym mblen _a xs ix idx
+indexFront_int sym mblen _a xs _ix idx
   | Just i <- W4.asInteger idx
   = lookupSeqMap xs i
 
@@ -535,16 +535,13 @@ indexFront_int sym mblen _a xs ix idx
           _                        -> Nothing
       )
 
-    -- Maximum possible in-bounds index given `Z m`
-    -- type information and the length
-    -- of the sequence. If the sequences is infinite and the
-    -- integer is unbounded, there isn't much we can do.
+    -- Maximum possible in-bounds index given the length
+    -- of the sequence. If the sequence is infinite, there
+    -- isn't much we can do.
     maxIdx =
-      case (mblen, ix) of
-        (Nat n, TVIntMod m)  -> Just (min (toInteger n) (toInteger m))
-        (Nat n, _)           -> Just n
-        (_    , TVIntMod m)  -> Just m
-        _                    -> Nothing
+      case mblen of
+        Nat n -> Just n
+        Inf   -> Nothing
 indexFront_segs ::
   W4.IsSymExprBuilder sym =>
   What4 sym ->

--- a/tests/issues/issue1359.icry
+++ b/tests/issues/issue1359.icry
@@ -1,0 +1,7 @@
+:set prover=sbv-z3
+:safe \a -> sortBy (\c1 c2 -> c2 != ' ') (split`{8} a)
+:safe \(a : [64]) (i : Integer) -> (split`{8} a)@(max 0 (min i 7))
+
+:set prover=w4-z3
+:safe \a -> sortBy (\c1 c2 -> c2 != ' ') (split`{8} a)
+:safe \(a : [64]) (i : Integer) -> (split`{8} a)@(max 0 (min i 7))

--- a/tests/issues/issue1359.icry.stdout
+++ b/tests/issues/issue1359.icry.stdout
@@ -1,0 +1,5 @@
+Loading module Cryptol
+Safe
+Safe
+Safe
+Safe


### PR DESCRIPTION
In the case where the index is a symbolic `Integer` and the sequence is of length `n`, the What4 backend mistakenly chose `n` to be the largest possible index. This corrects it to instead be `n - 1`.

Fixes #1359.