### PR TITLE
Always embed `git` commit into `--version` output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
       release: ${{ steps.config.outputs.release }}
       retention-days: ${{ steps.config.outputs.retention-days }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: config
         id: config
@@ -88,9 +89,10 @@ jobs:
       VERSION: ${{ needs.config.outputs.version }}
       RELEASE: ${{ needs.config.outputs.release }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-python@v2
         with:
@@ -262,9 +264,10 @@ jobs:
           #  os: windows-2019
           #  continue-on-error: true  # TODO: get Python client to work on Windows
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: haskell/actions/setup@v2
         with:
@@ -423,7 +426,9 @@ jobs:
           cache-to: type=registry,ref=${{ matrix.cache }}:cache-${{ steps.common-tag.outputs.common-tag }},mode=max
 
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
         uses: actions/setup-python@v2

--- a/cry
+++ b/cry
@@ -44,25 +44,17 @@ case $COMMAND in
     # XXX: This is a workaround the fact that currently Cabal
     # will not rebuild this file, even though it has TH code, that
     # depends on the environment.  For now, we temporarily modify the
-    # file, then build, then revert it back after build.
+    # file, then build, then revert it back, then build once more.
 
     dirty_string="-- Last build $(date)"
     echo "$dirty_string" >> src/GitRev.hs
-
-    if [[ -n "$RELEASE" ]]; then
-      sed -i.bak -e 's/^commitShortHash = .*$/commitShortHash = "UNKNOWN"/' \
-        -e 's/^commitHash = .*$/commitHash = "UNKNOWN"/' \
-        -e 's/^commitBranch = .*$/commitBranch = "UNKNOWN"/' \
-        -e 's/^commitDirty = .*$/commitDirty = False/' \
-        -e '/import qualified GitRev/d' \
-        src/Cryptol/Version.hs
-      rm -f src/Cryptol/Version.hs.bak
-    fi
 
     cabal v2-build "$@" exe:cryptol
 
     sed -i.bak "/^-- Last build/d" src/GitRev.hs
     rm -f src/GitRev.hs.bak
+
+    cabal v2-build "$@" exe:cryptol
     ;;
 
   haddock) echo Building Haddock documentation && cabal v2-haddock ;;


### PR DESCRIPTION
Previously, we attempted to scrub out `git` commits from release binaries using a `sed` invocation in the `cry` script, but as was observed in #1353, this ended up scrubbing out `git` commits on all builds, not just release ones. We have decided that we should just include `git` commits on all builds, so we can fix the issue by removing the buggy use of `sed`.

Unfortunately, `cabal`'s recompilation logic is not smart enough to always rebuild `GitRev.hs` on every new commit, even though it should. For this reason, we make the `./cry build` command temporarily dirty the `GitRev.hs` file so that it is forcibly rebuilt, then revert the change to `GitRev.hs` and rebuild. It's rather heavy-handed, but it works.

Fixes #1353.