### PR TITLE
`cryptol-remote-api`: Don't use verbose SBV settings

### DIFF
--- a/cryptol-remote-api/src/CryptolServer/Sat.hs
+++ b/cryptol-remote-api/src/CryptolServer/Sat.hs
@@ -67,7 +67,7 @@ proveSat (ProveSatParams queryType (ProverName proverName) jsonExpr hConsing) = 
             ProverCommand
             { pcQueryType    = queryType
             , pcProverName   = proverName
-            , pcVerbose      = True
+            , pcVerbose      = False
             , pcProverStats  = timing
             , pcExtraDecls   = decls
             , pcSmtFile      = Nothing


### PR DESCRIPTION
We should try to match Cryptol's default settings when invoking the remote API, but the `pcVerbose` value (`True`) didn't match the defaults. Changing this to `False` should fix #1378. There is a separate question of whether remote API users should be able to change this default, but for the time being, let's at least be consistent between Cryptol's settings and the remote API's settings.