### PR TITLE
CI: Use macOS 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  SOLVER_PKG_VERSION: "snapshot-20220114"
+  SOLVER_PKG_VERSION: "snapshot-20220721"
   # The CACHE_VERSION can be updated to force the use of a new cache if
   # the current cache contents become corrupted/invalid.  This can
   # sometimes happen when (for example) the OS version is changed but
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         ghc-version: ["8.8.4", "8.10.7", "9.0.2", "9.2.2"]
         exclude:
           # https://gitlab.haskell.org/ghc/ghc/-/issues/18550
@@ -231,7 +231,7 @@ jobs:
       matrix:
         suite: [test-lib]
         target: ${{ fromJson(needs.build.outputs.test-lib-json) }}
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         continue-on-error: [false]
         include:
           - suite: rpc
@@ -240,7 +240,7 @@ jobs:
             continue-on-error: false
           #- suite: rpc
           #  target: ''
-          #  os: macos-10.05
+          #  os: macos-12
           #  continue-on-error: false
           #- suite: rpc
           #  target: ''

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cryptol currently uses Microsoft Research's [Z3 SMT
 solver](https://github.com/Z3Prover/z3) by default to solve constraints
 during type checking, and as the default solver for the `:sat` and
 `:prove` commands.  Cryptol generally requires the most recent version
-of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20220114).
+of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20220721).
 
 You can download Z3 binaries for a variety of platforms from their
 [releases page](https://github.com/Z3Prover/z3/releases). If you
@@ -74,7 +74,7 @@ on [GitHub](https://github.com/GaloisInc/cryptol).
 Cryptol builds and runs on various flavors of Linux, Mac OS X, and
 Windows. We regularly build and test it in the following environments:
 
-- macOS 10.15, 64-bit
+- macOS 12, 64-bit
 - Ubuntu 18.04, 64-bit
 - Ubuntu 20.04, 64-bit
 - Windows Server 2019, 64-bit


### PR DESCRIPTION
GitHub is deprecating (and eventually removing) its macOS 10.15 runners. See actions/virtual-environments#5583. Let's upgrade to a newer version in the CI. This proves relatively straightforward—the only other change required is to upgrade to a newer version of `what4-solvers`.