### PR TITLE
Add a primitive for `arrayEq`

### DIFF
--- a/lib/Array.cry
+++ b/lib/Array.cry
@@ -10,6 +10,7 @@ primitive type Array : * -> * -> *
 primitive arrayConstant : {a, b} b -> (Array a b)
 primitive arrayLookup : {a, b} (Array a b) -> a -> b
 primitive arrayUpdate : {a, b} (Array a b) -> a -> b -> (Array a b)
+primitive arrayEq : {n, a} (Array [n] a) -> (Array [n] a) -> Bool
 
 /**
  * Copy elements from the source array to the destination array.

--- a/tests/regression/array.icry.stdout
+++ b/tests/regression/array.icry.stdout
@@ -12,6 +12,7 @@ Symbols
   arrayConstant : {a, b} b -> Array a b
   arrayCopy :
     {n, a} Array [n] a -> [n] -> Array [n] a -> [n] -> [n] -> Array [n] a
+  arrayEq : {n, a} Array [n] a -> Array [n] a -> Bool
   arrayLookup : {a, b} Array a b -> a -> b
   arrayRangeEqual :
     {n, a} Array [n] a -> [n] -> Array [n] a -> [n] -> [n] -> Bool


### PR DESCRIPTION
Currently, this primitive (like the other Array primitives) has
no computational interpretation, and is only used for stating
specifications that are used in SAW. As such, there are no changes to
the interpreter.