### PR TITLE
CI: Don't sign build artifacts on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - if: runner.os == 'Windows'
         run: .github/wix.ps1
 
-      - if: runner.os == 'Windows'
+      - if: runner.os == 'Windows' && github.event.pull_request.head.repo.fork == false
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -183,7 +183,8 @@ jobs:
         env:
           OS_TAG: ${{ matrix.os }}
 
-      - shell: bash
+      - if: github.event.pull_request.head.repo.fork == false
+        shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
The GPG signing step requires access to repository secrets that (apparently) aren't visible to forks. Let's just not sign build artifacts on forks to avoid this issue.

This mirrors a corresponding change made to `saw-script`'s CI in GaloisInc/saw-script@eedcba1126f7c501ae443ee3fb5b8b07358acbe1 and GaloisInc/saw-script@ac082b0dd95b966a006a26de6e6564b2ffe523e3.