### PR TITLE
Add `:time` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 * Fix a bug in the What4 backend that could cause applications of `(@)` with
   symbolic `Integer` indices to become out of bounds (#1359).
 
+## New features
+
+* Add a `:time` command to benchmark the evaluation time of expressions.
+
 # 2.13.0
 
 ## Language changes

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -119,6 +119,7 @@ library
                        Cryptol.Utils.Patterns,
                        Cryptol.Utils.Logger,
                        Cryptol.Utils.Benchmark,
+                       Cryptol.Utils.Types,
                        Cryptol.Version,
 
                        Cryptol.ModuleSystem,

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -52,6 +52,7 @@ library
                        bytestring        >= 0.10,
                        array             >= 0.4,
                        containers        >= 0.5,
+                       criterion-measurement,
                        cryptohash-sha1   >= 0.11 && < 0.12,
                        deepseq           >= 1.3,
                        directory         >= 1.2.2.0,
@@ -75,6 +76,7 @@ library
                        text              >= 1.1,
                        tf-random         >= 0.5,
                        transformers-base >= 0.4,
+                       vector,
                        mtl               >= 2.2.1,
                        time              >= 1.6.0.1,
                        panic             >= 0.3,
@@ -216,7 +218,9 @@ library
                        Cryptol.REPL.Command,
                        Cryptol.REPL.Browse,
                        Cryptol.REPL.Monad,
-                       Cryptol.REPL.Trie
+                       Cryptol.REPL.Trie,
+
+                       Cryptol.Benchmark
 
   Other-modules:       Cryptol.Parser.LexerUtils,
                        Cryptol.Parser.ParserUtils,

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -118,6 +118,7 @@ library
                        Cryptol.Utils.Misc,
                        Cryptol.Utils.Patterns,
                        Cryptol.Utils.Logger,
+                       Cryptol.Utils.Benchmark,
                        Cryptol.Version,
 
                        Cryptol.ModuleSystem,
@@ -218,9 +219,7 @@ library
                        Cryptol.REPL.Command,
                        Cryptol.REPL.Browse,
                        Cryptol.REPL.Monad,
-                       Cryptol.REPL.Trie,
-
-                       Cryptol.Benchmark
+                       Cryptol.REPL.Trie
 
   Other-modules:       Cryptol.Parser.LexerUtils,
                        Cryptol.Parser.ParserUtils,

--- a/src/Cryptol/Backend/FloatHelpers.hs
+++ b/src/Cryptol/Backend/FloatHelpers.hs
@@ -8,6 +8,7 @@ import LibBF
 
 import Cryptol.Utils.PP
 import Cryptol.Utils.Panic(panic)
+import Cryptol.Utils.Types
 import Cryptol.Backend.Monad( EvalError(..) )
 
 
@@ -176,3 +177,8 @@ floatFromBits e p bv = BF { bfValue = bfFromBits (fpOpts e p NearEven) bv
 -- (most significant bit in the significand is set, the rest of it is 0)
 floatToBits :: Integer -> Integer -> BigFloat -> Integer
 floatToBits e p bf = bfToBits (fpOpts e p NearEven) bf
+
+
+-- | Create a 64-bit IEEE-754 float.
+floatFromDouble :: Double -> BF
+floatFromDouble = uncurry BF float64ExpPrec . bfFromDouble

--- a/src/Cryptol/Benchmark.hs
+++ b/src/Cryptol/Benchmark.hs
@@ -1,3 +1,4 @@
+-- | Simple benchmarking of IO functions.
 module Cryptol.Benchmark
   ( BenchmarkStats (..)
   , benchmark
@@ -10,12 +11,19 @@ import           Data.Int
 import qualified Data.Vector                 as V
 import qualified Data.Vector.Unboxed         as U
 
+-- | Statistics returned by 'benchmark'.
+--
+-- This is extremely crude compared to the full analysis that criterion can do,
+-- but is enough for now.
 data BenchmarkStats = BenchmarkStats
   { benchAvgTime    :: !Double
   , benchAvgCpuTime :: !Double
   , benchAvgCycles  :: !Int64
   } deriving Show
 
+-- | Benchmark the application of the given function to the given input and the
+-- execution of the resulting IO action to WHNF, spending at least the given
+-- amount of time in seconds to collect measurements.
 benchmark :: Double -> (a -> IO b) -> a -> IO BenchmarkStats
 benchmark period f x = do
   (meas, _) <- runBenchmark (whnfAppIO f x) period

--- a/src/Cryptol/Benchmark.hs
+++ b/src/Cryptol/Benchmark.hs
@@ -1,0 +1,28 @@
+module Cryptol.Benchmark
+  ( BenchmarkStats (..)
+  , benchmark
+  , secs
+  ) where
+
+import           Criterion.Measurement       (runBenchmark, secs, threshold)
+import           Criterion.Measurement.Types
+import           Data.Int
+import qualified Data.Vector                 as V
+import qualified Data.Vector.Unboxed         as U
+
+data BenchmarkStats = BenchmarkStats
+  { benchAvgTime    :: !Double
+  , benchAvgCpuTime :: !Double
+  , benchAvgCycles  :: !Int64
+  }
+
+benchmark :: (a -> IO b) -> a -> IO BenchmarkStats
+benchmark f x = do
+  (meas, _) <- runBenchmark (whnfAppIO f x) 10
+  let len = length meas
+      meas' = rescale <$> V.filter ((>= threshold) . measTime) meas
+      sumMeasure sel = U.sum $ measure sel meas'
+  pure BenchmarkStats
+    { benchAvgTime = sumMeasure measTime / fromIntegral len
+    , benchAvgCpuTime = sumMeasure measCpuTime / fromIntegral len
+    , benchAvgCycles = sumMeasure measCycles `div` fromIntegral len }

--- a/src/Cryptol/Benchmark.hs
+++ b/src/Cryptol/Benchmark.hs
@@ -19,8 +19,8 @@ data BenchmarkStats = BenchmarkStats
 benchmark :: Double -> (a -> IO b) -> a -> IO BenchmarkStats
 benchmark period f x = do
   (meas, _) <- runBenchmark (whnfAppIO f x) period
-  let len = length meas
-      meas' = rescale <$> V.filter ((>= threshold) . measTime) meas
+  let meas' = rescale <$> V.filter ((>= threshold) . measTime) meas
+      len = length meas'
       sumMeasure sel = U.sum $ measure sel meas'
   pure BenchmarkStats
     { benchAvgTime = sumMeasure measTime / fromIntegral len

--- a/src/Cryptol/Benchmark.hs
+++ b/src/Cryptol/Benchmark.hs
@@ -16,9 +16,9 @@ data BenchmarkStats = BenchmarkStats
   , benchAvgCycles  :: !Int64
   } deriving Show
 
-benchmark :: (a -> IO b) -> a -> IO BenchmarkStats
-benchmark f x = do
-  (meas, _) <- runBenchmark (whnfAppIO f x) 10
+benchmark :: Double -> (a -> IO b) -> a -> IO BenchmarkStats
+benchmark period f x = do
+  (meas, _) <- runBenchmark (whnfAppIO f x) period
   let len = length meas
       meas' = rescale <$> V.filter ((>= threshold) . measTime) meas
       sumMeasure sel = U.sum $ measure sel meas'

--- a/src/Cryptol/Benchmark.hs
+++ b/src/Cryptol/Benchmark.hs
@@ -14,7 +14,7 @@ data BenchmarkStats = BenchmarkStats
   { benchAvgTime    :: !Double
   , benchAvgCpuTime :: !Double
   , benchAvgCycles  :: !Int64
-  }
+  } deriving Show
 
 benchmark :: (a -> IO b) -> a -> IO BenchmarkStats
 benchmark f x = do

--- a/src/Cryptol/Eval/Type.hs
+++ b/src/Cryptol/Eval/Type.hs
@@ -18,6 +18,7 @@ import Cryptol.TypeCheck.Solver.InfNat
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.Ident (Ident)
 import Cryptol.Utils.RecordMap
+import Cryptol.Utils.Types
 
 import Data.Maybe(fromMaybe)
 import qualified Data.IntMap.Strict as IntMap
@@ -85,6 +86,10 @@ isTBit _ = False
 tvSeq :: Nat' -> TValue -> TValue
 tvSeq (Nat n) t = TVSeq n t
 tvSeq Inf     t = TVStream t
+
+-- | The Cryptol @Float64@ type.
+tvFloat64 :: TValue
+tvFloat64 = uncurry TVFloat float64ExpPrec
 
 -- | Coerce an extended natural into an integer,
 --   for values known to be finite

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -20,6 +20,7 @@ module Cryptol.ModuleSystem (
   , loadModuleByName
   , checkExpr
   , evalExpr
+  , benchmarkExpr
   , checkDecls
   , evalDecls
   , noPat
@@ -35,6 +36,7 @@ module Cryptol.ModuleSystem (
 
 import Data.Map (Map)
 
+import           Cryptol.Benchmark (BenchmarkStats)
 import qualified Cryptol.Eval.Concrete as Concrete
 import           Cryptol.ModuleSystem.Env
 import           Cryptol.ModuleSystem.Interface
@@ -96,6 +98,9 @@ checkExpr e env = runModuleM env (interactive (Base.checkExpr e))
 -- | Evaluate an expression.
 evalExpr :: T.Expr -> ModuleCmd Concrete.Value
 evalExpr e env = runModuleM env (interactive (Base.evalExpr e))
+
+benchmarkExpr :: T.Expr -> ModuleCmd BenchmarkStats
+benchmarkExpr e env = runModuleM env (interactive (Base.benchmarkExpr e))
 
 -- | Typecheck top-level declarations.
 checkDecls :: [P.TopDecl PName] -> ModuleCmd (R.NamingEnv,[T.DeclGroup], Map Name T.TySyn)

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -36,7 +36,6 @@ module Cryptol.ModuleSystem (
 
 import Data.Map (Map)
 
-import           Cryptol.Benchmark (BenchmarkStats)
 import qualified Cryptol.Eval.Concrete as Concrete
 import           Cryptol.ModuleSystem.Env
 import           Cryptol.ModuleSystem.Interface
@@ -49,6 +48,7 @@ import           Cryptol.Parser.Name (PName)
 import           Cryptol.Parser.NoPat (RemovePatterns)
 import qualified Cryptol.TypeCheck.AST     as T
 import qualified Cryptol.TypeCheck.Interface as T
+import           Cryptol.Utils.Benchmark (BenchmarkStats)
 import qualified Cryptol.Utils.Ident as M
 
 -- Public Interface ------------------------------------------------------------

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -99,6 +99,7 @@ checkExpr e env = runModuleM env (interactive (Base.checkExpr e))
 evalExpr :: T.Expr -> ModuleCmd Concrete.Value
 evalExpr e env = runModuleM env (interactive (Base.evalExpr e))
 
+-- | Benchmark an expression.
 benchmarkExpr :: Double -> T.Expr -> ModuleCmd BenchmarkStats
 benchmarkExpr period e env =
   runModuleM env (interactive (Base.benchmarkExpr period e))

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -99,8 +99,9 @@ checkExpr e env = runModuleM env (interactive (Base.checkExpr e))
 evalExpr :: T.Expr -> ModuleCmd Concrete.Value
 evalExpr e env = runModuleM env (interactive (Base.evalExpr e))
 
-benchmarkExpr :: T.Expr -> ModuleCmd BenchmarkStats
-benchmarkExpr e env = runModuleM env (interactive (Base.benchmarkExpr e))
+benchmarkExpr :: Double -> T.Expr -> ModuleCmd BenchmarkStats
+benchmarkExpr period e env =
+  runModuleM env (interactive (Base.benchmarkExpr period e))
 
 -- | Typecheck top-level declarations.
 checkDecls :: [P.TopDecl PName] -> ModuleCmd (R.NamingEnv,[T.DeclGroup], Map Name T.TySyn)

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -612,8 +612,8 @@ evalExpr e = do
 
   io $ E.runEval mempty (E.evalExpr Concrete (env <> deEnv denv) e)
 
-benchmarkExpr :: T.Expr -> ModuleM BenchmarkStats
-benchmarkExpr e = do
+benchmarkExpr :: Double -> T.Expr -> ModuleM BenchmarkStats
+benchmarkExpr period e = do
   env <- getEvalEnv
   denv <- getDynEnv
   evopts <- getEvalOptsAction
@@ -626,7 +626,7 @@ benchmarkExpr e = do
 
   let eval expr = E.runEval mempty $
         E.evalExpr Concrete env' expr >>= E.forceValue
-  io $ benchmark eval e
+  io $ benchmark period eval e
 
 evalDecls :: [T.DeclGroup] -> ModuleM ()
 evalDecls dgs = do

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -51,7 +51,6 @@ import Cryptol.ModuleSystem.Env (lookupModule
                                 , ModContext(..)
                                 , ModulePath(..), modulePathLabel)
 import           Cryptol.Backend.FFI
-import           Cryptol.Benchmark
 import qualified Cryptol.Eval                 as E
 import qualified Cryptol.Eval.Concrete as Concrete
 import           Cryptol.Eval.Concrete (Concrete(..))
@@ -76,6 +75,7 @@ import Cryptol.Utils.Ident ( preludeName, floatName, arrayName, suiteBName, prim
 import Cryptol.Utils.PP (pretty)
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.Logger(logPutStrLn, logPrint)
+import Cryptol.Utils.Benchmark
 
 import Cryptol.Prelude ( preludeContents, floatContents, arrayContents
                        , suiteBContents, primeECContents, preludeReferenceContents )

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -258,7 +258,9 @@ nbCommandList  =
     (unlines
       [ "The expression will be evaluated many times to get accurate results."
       , "The amount of time to spend collecting measurements can be changed"
-      , "  with the timeMeasurementPeriod option." ])
+      , "  with the timeMeasurementPeriod option."
+      , "Reports the average wall clock time, CPU time, and cycles."
+      , "(Cycles are in unspecified units that may be CPU cycles.)"])
   ]
 
 commandList :: [CommandDescr]

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -255,7 +255,10 @@ nbCommandList  =
     ""
   , CommandDescr [ ":time" ] ["EXPR"] (ExprArg timeCmd)
     "Measure the time it takes to evaluate the given expression."
-    ""
+    (unlines
+      [ "The expression will be evaluated many times to get accurate results."
+      , "The amount of time to spend collecting measurements can be changed"
+      , "  with the timeMeasurementPeriod option." ])
   ]
 
 commandList :: [CommandDescr]

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -70,7 +70,6 @@ import qualified Cryptol.ModuleSystem.Env as M
 
 import qualified Cryptol.Backend.Monad as E
 import qualified Cryptol.Backend.SeqMap as E
-import qualified Cryptol.Benchmark as Bench
 import           Cryptol.Eval.Concrete( Concrete(..) )
 import qualified Cryptol.Eval.Concrete as Concrete
 import qualified Cryptol.Eval.Env as E
@@ -89,6 +88,7 @@ import qualified Cryptol.TypeCheck.Parseable as T
 import qualified Cryptol.TypeCheck.Subst as T
 import           Cryptol.TypeCheck.Solve(defaultReplExpr)
 import           Cryptol.TypeCheck.PP (dump,ppWithNames,emptyNameMap)
+import qualified Cryptol.Utils.Benchmark as Bench
 import           Cryptol.Utils.PP hiding ((</>))
 import           Cryptol.Utils.Panic(panic)
 import           Cryptol.Utils.RecordMap

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1013,8 +1013,8 @@ timeCmd str pos fnm = do
       Bench.BenchmarkStats {..} <-
         liftModuleCmd (rethrowEvalError . M.benchmarkExpr expr)
       rPutStrLn $ "Avg time: " ++ Bench.secs benchAvgTime
-               ++ "\tAvg CPU time: " ++ Bench.secs benchAvgCpuTime
-               ++ "\tAvg cycles: " ++ show benchAvgCycles
+           ++ "    Avg CPU time: " ++ Bench.secs benchAvgCpuTime
+           ++ "    Avg cycles: " ++ show benchAvgCycles
 
 readFileCmd :: FilePath -> REPL ()
 readFileCmd fp = do

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -258,6 +258,10 @@ nbCommandList  =
     "Measure the time it takes to evaluate the given expression."
     (unlines
       [ "The expression will be evaluated many times to get accurate results."
+      , "Note that the first evaluation of a binding may take longer due to"
+      , "  laziness, and this may affect the reported time. If this is not"
+      , "  desired then make sure to evaluate the expression once first before"
+      , "  running :time."
       , "The amount of time to spend collecting measurements can be changed"
       , "  with the timeMeasurementPeriod option."
       , "Reports the average wall clock time, CPU time, and cycles."

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1005,13 +1005,14 @@ typeOfCmd str pos fnm = do
 
 timeCmd :: String -> (Int, Int) -> Maybe FilePath -> REPL ()
 timeCmd str pos fnm = do
+  period <- getKnownUser "timeMeasurementPeriod" :: REPL Int
   pExpr <- replParseExpr str pos fnm
   (_, def, sig) <- replCheckExpr pExpr
   replPrepareCheckedExpr def sig >>= \case
     Nothing -> raise (EvalPolyError sig)
     Just (_, expr) -> do
-      Bench.BenchmarkStats {..} <-
-        liftModuleCmd (rethrowEvalError . M.benchmarkExpr expr)
+      Bench.BenchmarkStats {..} <- liftModuleCmd
+        (rethrowEvalError . M.benchmarkExpr (fromIntegral period) expr)
       rPutStrLn $ "Avg time: " ++ Bench.secs benchAvgTime
            ++ "    Avg CPU time: " ++ Bench.secs benchAvgCpuTime
            ++ "    Avg cycles: " ++ show benchAvgCycles

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1009,6 +1009,7 @@ typeOfCmd str pos fnm = do
 timeCmd :: String -> (Int, Int) -> Maybe FilePath -> REPL ()
 timeCmd str pos fnm = do
   period <- getKnownUser "timeMeasurementPeriod" :: REPL Int
+  rPutStrLn $ "Measuring for " ++ show period ++ " seconds"
   pExpr <- replParseExpr str pos fnm
   (_, def, sig) <- replCheckExpr pExpr
   replPrepareCheckedExpr def sig >>= \case

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -992,6 +992,9 @@ userOptions  = mkOptionMap
     , "This is a lower bound and the actual time taken might be higher if the"
     , "  evaluation takes a long time."
     ]
+
+  , simpleOpt "timeQuiet" ["time-quiet"] (EnvBool False) noCheck
+    "Suppress output of :time command and only bind result to `it`."
   ]
 
 

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -983,6 +983,15 @@ userOptions  = mkOptionMap
     , "  * display      try to match the order they were written in the source code"
     , "  * canonical    use a predictable, canonical order"
     ]
+
+  , simpleOpt "timeMeasurementPeriod" ["time-measurement-period"] (EnvNum 10)
+    checkTimeMeasurementPeriod
+    $ unlines
+    [ "The period of time in seconds to spend collecting measurements when"
+    , "  running :time."
+    , "This is a lower bound and the actual time taken might be higher if the"
+    , "  evaluation takes a long time."
+    ]
   ]
 
 
@@ -1077,6 +1086,14 @@ getUserSatNum = do
     _ | Just n <- readMaybe s -> return (SomeSat n)
     _                         -> panic "REPL.Monad.getUserSatNum"
                                    [ "invalid satNum option" ]
+
+checkTimeMeasurementPeriod :: Checker
+checkTimeMeasurementPeriod (EnvNum n)
+  | n >= 1 = noWarns Nothing
+  | otherwise = noWarns $
+    Just "timeMeasurementPeriod must be a positive integer"
+checkTimeMeasurementPeriod _ = noWarns $
+  Just "unable to parse value for timeMeasurementPeriod"
 
 -- Environment Utilities -------------------------------------------------------
 

--- a/src/Cryptol/TypeCheck/FFI.hs
+++ b/src/Cryptol/TypeCheck/FFI.hs
@@ -16,6 +16,7 @@ import           Cryptol.TypeCheck.FFI.FFIType
 import           Cryptol.TypeCheck.SimpType
 import           Cryptol.TypeCheck.Type
 import           Cryptol.Utils.RecordMap
+import           Cryptol.Utils.Types
 
 -- | Convert a 'Schema' to a 'FFIFunType', along with any 'Prop's that must be
 -- satisfied for the 'FFIFunType' to be valid.
@@ -96,8 +97,8 @@ toFFIBasicType t =
       | otherwise -> Just $ Left $ FFITypeError t FFIBadWordSize
       where word = Just . Right . FFIWord n
     TCon (TC TCFloat) [TCon (TC (TCNum e)) [], TCon (TC (TCNum p)) []]
-      | e == 8, p == 24 -> float FFIFloat32
-      | e == 11, p == 53 -> float FFIFloat64
+      | (e, p) == float32ExpPrec -> float FFIFloat32
+      | (e, p) == float64ExpPrec -> float FFIFloat64
       | otherwise -> Just $ Left $ FFITypeError t FFIBadFloatSize
       where float = Just . Right . FFIFloat e p
     _ -> Nothing

--- a/src/Cryptol/Utils/Benchmark.hs
+++ b/src/Cryptol/Utils/Benchmark.hs
@@ -1,5 +1,5 @@
 -- | Simple benchmarking of IO functions.
-module Cryptol.Benchmark
+module Cryptol.Utils.Benchmark
   ( BenchmarkStats (..)
   , benchmark
   , secs

--- a/src/Cryptol/Utils/Types.hs
+++ b/src/Cryptol/Utils/Types.hs
@@ -1,0 +1,10 @@
+-- | Useful information about various types.
+module Cryptol.Utils.Types where
+
+-- | Exponent and precision of 32-bit IEEE-754 floating point.
+float32ExpPrec :: (Integer, Integer)
+float32ExpPrec = (8, 24)
+
+-- | Exponent and precision of 64-bit IEEE-754 floating point.
+float64ExpPrec :: (Integer, Integer)
+float64ExpPrec = (11, 53)

--- a/tests/issues/issue1415.icry
+++ b/tests/issues/issue1415.icry
@@ -1,0 +1,3 @@
+:set timeQuiet=on
+:time 0x1 + 0x2
+:t it

--- a/tests/issues/issue1415.icry.stdout
+++ b/tests/issues/issue1415.icry.stdout
@@ -1,0 +1,2 @@
+Loading module Cryptol
+it : {avgTime : Float 11 53, avgCpuTime : Float 11 53, avgCycles : Integer}


### PR DESCRIPTION
Adds a `:time` command in the REPL for measuring the evaluation time of an expression. Uses [criterion-measurement](https://hackage.haskell.org/package/criterion-measurement) to do measurements.

The analysis that we do is very crude compared to what the full `criterion` package does (we basically just calculate the average times), but `criterion` pulls in much more dependencies so I don't think it's worth adding it.

Closes #1415.