### PR TITLE
CI: Work around GHC installation issues on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc-version }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - uses: actions/cache@v2
         name: Cache cabal store
         with:


### PR DESCRIPTION
This should avoid nasty linker errors as observed in https://gitlab.haskell.org/ghc/ghc/-/issues/21111 until the upstream tools can be fixed.