### PR TITLE
Include one Ubuntu 20.04 configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,21 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2019]
         ghc-version: ["8.10.7", "9.0.2", "9.2.4"]
+        run-tests: [true]
         exclude:
           - os: windows-2019
             ghc-version: 9.0.2
+            run-tests: true
           - os: windows-2019
             ghc-version: 9.2.4
+            run-tests: true
         include:
           # We include one job from an older Ubuntu LTS release to increase our
-          # coverage of possible Linux configurations.
-          - os: ubuntu-22.04
+          # coverage of possible Linux configurations. Since we already run the
+          # tests with the newest LTS release, we won't bother testing this one.
+          - os: ubuntu-20.04
             ghc-version: 8.10.7
+            run-tests: false
     outputs:
       test-lib-json: ${{ steps.test-lib.outputs.targets-json }}
     env:
@@ -211,13 +216,13 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}
 
-      - if: matrix.ghc-version == '8.10.7'
+      - if: matrix.ghc-version == '8.10.7' && matrix.run-tests
         uses: actions/upload-artifact@v2
         with:
           path: dist/bin
           name: ${{ runner.os }}-dist-bin
 
-      - if: matrix.ghc-version == '8.10.7'
+      - if: matrix.ghc-version == '8.10.7' && matrix.run-tests
         uses: actions/upload-artifact@v2
         with:
           path: bin


### PR DESCRIPTION
PR #1403 accidentally removed our build coverage for an older Ubuntu LTS configuration. This patch adds in back and ensures that we don't accidentally run the tests on this configuration.