### PR TITLE
T1451

### DIFF
--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -574,7 +574,11 @@ typecheck act i params env = do
                            Right as ->
                              let ppIt l = mapM_ (logPrint l . T.pp)
                              in withLogger ppIt as
-                           Left err -> panic "Core lint failed:" [show err]
+                           Left (loc,err) ->
+                            panic "Core lint failed:"
+                              [ "Location: " ++ show (T.pp loc)
+                              , show (T.pp err)
+                              ]
          return o
 
     T.InferFailed nameMap warns errs ->

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -574,7 +574,7 @@ typecheck act i params env = do
            CoreLint   -> case lintCheck (tcLinter act) o input of
                            Right as ->
                              let ppIt l = mapM_ (logPrint l . T.pp)
-                             in withLogger ppIt as
+                             in withLogger ppIt (TcSanity.onlyNonTrivial as)
                            Left (loc,err) ->
                             panic "Core lint failed:"
                               [ "Location: " ++ show (T.pp loc)

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -520,7 +520,8 @@ exprLinter = TCLinter
       case TcSanity.tcExpr i e' of
         Left err     -> Left err
         Right (s1,os)
-          | TcSanity.same s s1  -> Right os
+          | TcSanity.SameIf os' <- TcSanity.same s s1 ->
+                                        Right (map T.tMono os' ++ os)
           | otherwise -> Left ( fromMaybe emptyRange (getLoc e')
                               , TcSanity.TypeMismatch "exprLinter" s s1
                               )

--- a/tests/issues/issue410.icry.stdout
+++ b/tests/issues/issue410.icry.stdout
@@ -1,8 +1,5 @@
 Loading module Cryptol
 {n, a} (Logic a) => n == min (1 + n) n
-{n, a} (Logic a) => Logic a
-{n, a} (Logic a) => Logic a
-{n, a} (Logic a) => True
 (s
  where
    s x =
@@ -11,7 +8,5 @@ Loading module Cryptol
           bs = [~b | b <- [~x] # bs
                    | _ <- bs])) :
   {n, a} (Logic a) => a -> [n]a
-{n, a} n == n
 (bs where bs = [b | b <- bs]) : {n, a} [n]a
-1 == 1
 [b | b <- [True]] : [1]


### PR DESCRIPTION
Fix the Core Linter to not use syntactic equality for numeric types.
Fixes # 1451