### PR TITLE
Copy the syntax-highlight directory under share/cyrptol for installation

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -102,6 +102,7 @@ bundle_files() {
   cp docs/*pdf $doc
   mkdir -p $lib
   cp -r lib/* $lib
+  cp -r syntax-highlight $lib
 
   # Copy the two interesting examples over
   cp docs/ProgrammingCryptol/{aes/AES,enigma/Enigma}.cry $doc/examples/


### PR DESCRIPTION
Add syntax highlighting to installation script