### PR TITLE
File deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,13 @@
   is extracted from `.. code-block:: cryptol` and `.. sourcecode:: cryptol`
   directives.
 
+* Add a syntax highlight file for Vim,
+  available in `syntax-highlight/cryptol.vim`
+
+* Add `:new-seed` and `:set-seed` commands to the REPL. 
+  These affect random test generation,
+  and help write reproducable Cryptol scripts.
+
 ## Bug fixes
 
 * Fix a bug in the What4 backend that could cause applications of `(@)` with
@@ -34,6 +41,8 @@
 
 * Fix a bug that caused finite bitvector enumerations to panic when used in
   combination with `(#)` (e.g., `[0..1] # 0`).
+
+* Improve documentation for `fromInteger` (#1465)
 
 # 2.13.0
 

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -14,6 +14,7 @@ Category:            Language
 Build-type:          Simple
 extra-source-files:  bench/data/*.cry
                      CHANGES.md
+                     lib/*.cry lib/*.z3
 
 data-files:          **/*.cry **/*.z3
 data-dir:            lib

--- a/docs/ProgrammingCryptol/crashCourse/CrashCourse.tex
+++ b/docs/ProgrammingCryptol/crashCourse/CrashCourse.tex
@@ -791,7 +791,7 @@ Here are Cryptol's responses:
   []
   invalid sequence index: 12
    -- Backtrace --
-  (Cryptol::@) called at Cryptol:875:14--875:20
+  (Cryptol::@) called at Cryptol:885:14--885:20
   (Cryptol::@@) called at <interactive>:9:1--9:28
   [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
   9

--- a/lib/Cryptol.cry
+++ b/lib/Cryptol.cry
@@ -339,11 +339,21 @@ primitive complement : {a} (Logic a) => a -> a
 primitive type Ring : * -> Prop
 
 /**
- * Converts an unbounded integer to a value in a Ring. When converting
- * to the bitvector type [n], the value is reduced modulo 2^^n. Likewise,
- * when converting to Z n, the value is reduced modulo n.  When converting
- * to a floating-point value, the value is rounded to the nearest
- * representable value.
+ * Converts an unbounded integer to a value in a Ring using the following rules:
+ *   * to bitvector type [n]:
+ *     the value is reduced modulo 2^^n,
+ *   * to Z n:
+ *     the value is reduced modulo n,
+ *   * floating point types:
+ *     the value is rounded to the nearest representable value,
+ *   * sequences other than bitvectors:
+ *     elements are computed by using `fromInteger` pointwise
+ *     Example: (fromInteger 2 : [3][8]) === [ 0x02, 0x02, 0x02 ]
+ *   * tuples and records:
+ *     elements are computed by using `fromInteger` pointwise
+ *     Example: (fromInteger 2 : (Integer,[3][8])) === (2, [ 0x2, 0x2, 0x2 ])
+ *   * functions:
+ *     a constant function returning `fromInteger` on the result type
  */
 primitive fromInteger : {a} (Ring a) => Integer -> a
 

--- a/src/Cryptol/ModuleSystem/Fingerprint.hs
+++ b/src/Cryptol/ModuleSystem/Fingerprint.hs
@@ -10,6 +10,7 @@ module Cryptol.ModuleSystem.Fingerprint
   ( Fingerprint
   , fingerprint
   , fingerprintFile
+  , fingerprintHexString
   ) where
 
 import Control.DeepSeq          (NFData (rnf))
@@ -17,6 +18,7 @@ import Crypto.Hash.SHA1         (hash)
 import Data.ByteString          (ByteString)
 import Control.Exception        (try)
 import qualified Data.ByteString as B
+import qualified Data.Vector as Vector
 
 newtype Fingerprint = Fingerprint ByteString
   deriving (Eq, Show)
@@ -37,3 +39,13 @@ fingerprintFile path =
        case res :: Either IOError ByteString of
          Left{}  -> Nothing
          Right b -> Just $! fingerprint b
+
+fingerprintHexString :: Fingerprint -> String
+fingerprintHexString (Fingerprint bs) = B.foldr hex "" bs
+  where
+  digits   = Vector.fromList "0123456789ABCDEF"
+  digit x  = digits Vector.! fromIntegral x
+  hex b cs = let (x,y) = divMod b 16
+             in digit x : digit y : cs
+
+

--- a/src/Cryptol/Parser/Lexer.x
+++ b/src/Cryptol/Parser/Lexer.x
@@ -98,7 +98,6 @@ $white+                   { emit $ White Space }
 
 -- Please update the docs, if you add new entries.
 "else"                    { emit $ KW KW_else }
-"extern"                  { emit $ KW KW_extern }
 "if"                      { emit $ KW KW_if }
 "private"                 { emit $ KW KW_private }
 "include"                 { emit $ KW KW_include }
@@ -116,7 +115,6 @@ $white+                   { emit $ White Space }
 "import"                  { emit $ KW KW_import }
 "as"                      { emit $ KW KW_as }
 "hiding"                  { emit $ KW KW_hiding }
-"newtype"                 { emit $ KW KW_newtype }
 "down"                    { emit $ KW KW_down }
 "by"                      { emit $ KW KW_by }
 

--- a/src/Cryptol/Parser/Token.hs
+++ b/src/Cryptol/Parser/Token.hs
@@ -21,7 +21,6 @@ data TokenW   = BlockComment | LineComment | Space | DocStr
                 deriving (Eq, Show, Generic, NFData)
 
 data TokenKW  = KW_else
-              | KW_extern
               | KW_fin
               | KW_if
               | KW_private

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -110,6 +110,8 @@ import qualified Control.Exception as X
 import Control.Monad hiding (mapM, mapM)
 import qualified Control.Monad.Catch as Ex
 import Control.Monad.IO.Class(liftIO)
+import Text.Read (readMaybe)
+import Control.Applicative ((<|>))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -129,7 +131,8 @@ import System.Directory(getHomeDirectory,setCurrentDirectory,doesDirectoryExist
 import System.IO
          (Handle,hFlush,stdout,openTempFile,hClose,openFile
          ,IOMode(..),hGetContents,hSeek,SeekMode(..))
-import System.Random.TF(newTFGen)
+import qualified System.Random.TF as TF
+import qualified System.Random.TF.Instances as TFI
 import Numeric (showFFloat)
 import qualified Data.Text as T
 import Data.IORef(newIORef,readIORef,writeIORef)
@@ -140,6 +143,8 @@ import Prelude ()
 import Prelude.Compat
 
 import qualified Data.SBV.Internals as SBV (showTDiff)
+
+
 
 -- Commands --------------------------------------------------------------------
 
@@ -271,6 +276,17 @@ nbCommandList  =
       , "  it : { avgTime : Float64"
       , "       , avgCpuTime : Float64"
       , "       , avgCycles : Integer }" ])
+
+  , CommandDescr [ ":set-seed" ] ["SEED"] (OptionArg seedCmd)
+      "Seed the random number generator for operations using randomness"
+      (unlines
+        [ "A seed takes the form of either a single integer or a 4-tuple"
+        , "of unsigned 64-bit integers.  Examples of commands using randomness"
+        , "are dumpTests and check."
+        ])
+  , CommandDescr [ ":new-seed"] [] (NoArg newSeedCmd)
+      "Randomly generate and set a new seed for the random number generator"
+      ""
   ]
 
 commandList :: [CommandDescr]
@@ -316,6 +332,8 @@ commandList  =
       [ "Converts all foreign declarations in the given Cryptol file into C"
       , "function declarations, and writes them to a file with the same name"
       , "but with a .h extension." ])
+
+
   ]
 
 genHelp :: [CommandDescr] -> [String]
@@ -394,14 +412,13 @@ dumpTestsCmd outFile str pos fnm =
      (val, ty) <- replEvalExpr expr
      ppopts <- getPPValOpts
      testNum <- getKnownUser "tests" :: REPL Int
-     g <- io newTFGen
      tenv <- E.envTypes . M.deEnv <$> getDynEnv
      let tyv = E.evalValType tenv ty
      gens <-
        case TestR.dumpableType tyv of
          Nothing -> raise (TypeNotTestable ty)
          Just gens -> return gens
-     tests <- io $ TestR.returnTests g gens val testNum
+     tests <- withRandomGen (\g -> io $ TestR.returnTests' g gens val testNum)
      out <- forM tests $
             \(args, x) ->
               do argOut <- mapM (rEval . E.ppValue Concrete ppopts) args
@@ -493,11 +510,11 @@ qcExpr qcMode exprDoc texpr schema =
        Just (sz,tys,_,gens) | qcMode == QCRandom -> do
             rPutStrLn "Using random testing."
             prt testingMsg
-            g <- io newTFGen
             (res,num) <-
-                  Ex.catch (randomTests (\n -> ppProgress percentRef testsRef n testNum)
-                                        testNum val gens g)
-                         (\ex -> do rPutStrLn "\nTest interrupted..."
+              withRandomGen
+                (randomTests' (\n -> ppProgress percentRef testsRef n testNum)
+                                      testNum val gens)
+              `Ex.catch` (\ex -> do rPutStrLn "\nTest interrupted..."
                                     num <- io $ readIORef testsRef
                                     let report = TestReport exprDoc Pass num sz
                                     ppReport tys False report
@@ -1638,6 +1655,31 @@ replEdit file = do
 
 type CommandMap = Trie CommandDescr
 
+newSeedCmd :: REPL ()
+newSeedCmd =
+  do  seed <- createAndSetSeed
+      rPutStrLn "Seed initialized to:"
+      rPutStrLn (show seed)
+  where
+    createAndSetSeed =
+      withRandomGen $ \g0 ->
+        let (s1, g1) = TFI.random g0
+            (s2, g2) = TFI.random g1
+            (s3, g3) = TFI.random g2
+            (s4, _)  = TFI.random g3
+            seed = (s1, s2, s3, s4)
+        in  pure (seed, TF.seedTFGen seed)
+
+seedCmd :: String -> REPL ()
+seedCmd s =
+  case mbGen of
+    Nothing -> rPutStrLn "Could not parse seed argument - expecting an integer or 4-tuple of integers."
+    Just gen -> setRandomGen gen
+
+  where
+    mbGen =
+          (TF.mkTFGen <$> readMaybe s)
+      <|> (TF.seedTFGen <$> readMaybe s)
 
 -- Command Parsing -------------------------------------------------------------
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -68,6 +68,7 @@ import qualified Cryptol.ModuleSystem.Renamer as M
     (RenamerWarning(SymbolShadowed, PrefixAssocChanged))
 import qualified Cryptol.Utils.Ident as M
 import qualified Cryptol.ModuleSystem.Env as M
+import Cryptol.ModuleSystem.Fingerprint(fingerprintHexString)
 
 import           Cryptol.Backend.FloatHelpers as FP
 import qualified Cryptol.Backend.Monad as E
@@ -112,6 +113,8 @@ import qualified Control.Monad.Catch as Ex
 import Control.Monad.IO.Class(liftIO)
 import Text.Read (readMaybe)
 import Control.Applicative ((<|>))
+import qualified Data.Set as Set
+import qualified Data.Map as Map
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -127,7 +130,7 @@ import qualified System.Process as Process(runCommand)
 import System.FilePath((</>), (-<.>), isPathSeparator)
 import System.Directory(getHomeDirectory,setCurrentDirectory,doesDirectoryExist
                        ,getTemporaryDirectory,setPermissions,removeFile
-                       ,emptyPermissions,setOwnerReadable)
+                       ,emptyPermissions,setOwnerReadable,canonicalizePath)
 import System.IO
          (Handle,hFlush,stdout,openTempFile,hClose,openFile
          ,IOMode(..),hGetContents,hSeek,SeekMode(..))
@@ -334,6 +337,12 @@ commandList  =
       , "but with a .h extension." ])
 
 
+  , CommandDescr [ ":module-info" ] [ "[MODULE]" ] (FilenameArg moduleInfoCmd)
+    "Show information about the source of a loaded module."
+    (unlines
+      [ "If the module name is not specified,"
+      , "then show information for all loaded modules."
+      ])
   ]
 
 genHelp :: [CommandDescr] -> [String]
@@ -1779,3 +1788,69 @@ parseCommand findCmd line = do
         '"':rest  -> Just $ quoted '"' rest
         _         -> let (a,b) = break isSpace ipt in
                      if null a then Nothing else Just (length a, a, b)
+
+
+
+moduleInfoCmd :: String -> REPL ()
+moduleInfoCmd modString
+  | null modString =
+    do env <- getModuleEnv
+       let es = Map.toList (M.getLoadedEntities (M.meLoadedModules env))
+       case es of
+         [] -> rPutStrLn "[]"
+         i : is ->
+           do showInfoEither "[ " i
+              mapM_ (showInfoEither (", ")) is
+              rPutStrLn "]"
+
+  | otherwise =
+    case parseModName modString of
+      Just m ->
+        do env <- getModuleEnv
+           case M.lookupTCEntity m env of
+             Nothing -> rPutStrLn "Module is not leaded."
+             Just lm -> showInfo "" lm
+
+      Nothing -> rPutStrLn "Invalid module name."
+
+  where
+  showInfoEither pref (k,x) =
+    do rPutStrLn (pref ++ show (show (pp k)) ++ ":")
+       let newPref = replicate (length pref + 2) ' '
+       case x of
+         Left a  -> showInfo newPref a
+         Right a -> showInfo newPref a
+
+  showInfo pref lm =
+    do rPutStr (pref ++ "{ \"source\": ")
+       let n = length pref
+           tab x = replicate n ' ' ++ x
+       case M.lmFilePath lm of
+         M.InFile f' ->
+            do f <- io (canonicalizePath f')
+               rPutStrLn (show f)
+         M.InMem l _ -> rPutStrLn ("{ \"internal\": " ++ show l ++ " }")
+
+       let fi = M.lmFileInfo lm
+       rPutStrLn (tab (", \"fingerprint\":\" 0x" ++
+                       fingerprintHexString (M.fiFingerprint fi) ++ "\""))
+
+
+       let depList f x ys =
+             do rPutStr (tab (", " ++ show (x :: String) ++ ":"))
+                case ys of
+                  [] -> rPutStrLn " []"
+                  i : is ->
+                    do rPutStrLn ""
+                       rPutStrLn (tab ("     [ " ++ f i))
+                       mapM_ (\j -> rPutStrLn (tab ("   , " ++ f j))) is
+                       rPutStrLn (tab "     ]")
+
+       depList show               "includes" (Set.toList (M.fiIncludeDeps fi))
+       depList (show . show . pp) "imports"  (Set.toList (M.fiImportDeps  fi))
+       depList show               "foreign"  (Set.toList (M.fiForeignDeps fi))
+
+       rPutStrLn (tab "}")
+
+
+

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -23,8 +23,10 @@ module Cryptol.Testing.Random
 , TestResult(..)
 , isPass
 , returnTests
+, returnTests'
 , exhaustiveTests
 , randomTests
+, randomTests'
 ) where
 
 import qualified Control.Exception as X
@@ -96,23 +98,32 @@ returnOneTest fun argGens sz g0 =
      go _ (_ : _) = panic "Cryptol.Testing.Random" ["Too many arguments to function while generating tests"]
      go v [] = return v
 
-
--- | Return a collection of random tests.
 returnTests :: RandomGen g
          => g -- ^ The random generator state
          -> [Gen g Concrete] -- ^ Generators for the function arguments
          -> Value -- ^ The function itself
          -> Int -- ^ How many tests?
          -> IO [([Value], Value)] -- ^ A list of pairs of random arguments and computed outputs
-returnTests g gens fun num = go gens g 0
+                                       --   as well as the new state of the RNG
+returnTests g gens fun num = fst <$> returnTests' g gens fun num
+
+-- | Return a collection of random tests.
+returnTests' :: RandomGen g
+         => g -- ^ The random generator state
+         -> [Gen g Concrete] -- ^ Generators for the function arguments
+         -> Value -- ^ The function itself
+         -> Int -- ^ How many tests?
+         -> IO ([([Value], Value)], g) -- ^ A list of pairs of random arguments and computed outputs
+                                       --   as well as the new state of the RNG
+returnTests' g gens fun num = go gens g 0
   where
     go args g0 n
-      | n >= num = return []
+      | n >= num = return ([], g0)
       | otherwise =
         do let sz = toInteger (div (100 * (1 + n)) num)
            (inputs, output, g1) <- returnOneTest fun args sz g0
-           more <- go args g1 (n + 1)
-           return ((inputs, output) : more)
+           (more, g2) <- go args g1 (n + 1)
+           return ((inputs, output) : more, g2)
 
 {- | Given a (function) type, compute generators for the function's
 arguments. -}
@@ -447,14 +458,23 @@ randomTests :: (MonadIO m, RandomGen g) =>
   [Gen g Concrete] {- ^ input value generators -} ->
   g {- ^ Inital random generator -} ->
   m (TestResult, Integer)
-randomTests ppProgress maxTests val gens = go 0
+randomTests ppProgress maxTests val gens g = fst <$> randomTests' ppProgress maxTests val gens g
+
+randomTests' :: (MonadIO m, RandomGen g) =>
+  (Integer -> m ()) {- ^ progress callback -} ->
+  Integer {- ^ Maximum number of tests to run -} ->
+  Value {- ^ function under test -} ->
+  [Gen g Concrete] {- ^ input value generators -} ->
+  g {- ^ Inital random generator -} ->
+  m ((TestResult, Integer), g)
+randomTests' ppProgress maxTests val gens = go 0
   where
   go !testNum g
-    | testNum >= maxTests = return (Pass, testNum)
+    | testNum >= maxTests = return ((Pass, testNum), g)
     | otherwise =
       do ppProgress testNum
          let sz' = div (100 * (1 + testNum)) maxTests
          (res, g') <- liftIO (runOneTest val gens sz' g)
          case res of
            Pass -> go (testNum+1) g'
-           failure -> return (failure, testNum)
+           failure -> return ((failure, testNum), g)

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -82,7 +82,6 @@ data ModuleG mname =
               Module { mName             :: !mname
                      , mDoc              :: !(Maybe Text)
                      , mExports          :: ExportSpec Name
-                     , mImports          :: [Import]
 
                      -- Functors:
                      , mParamTypes       :: Map Name ModTParam
@@ -117,7 +116,6 @@ emptyModule nm =
     { mName             = nm
     , mDoc              = Nothing
     , mExports          = mempty
-    , mImports          = []
 
     , mParams           = mempty
     , mParamTypes       = mempty
@@ -455,7 +453,6 @@ instance PP n => PP (WithNames (ModuleG n)) where
   ppPrec _ (WithNames Module { .. } nm) =
     vcat [ text "module" <+> pp mName
          -- XXX: Print exports?
-         , vcat (map pp mImports)
          , vcat (map pp' (Map.elems mTySyns))
          -- XXX: Print abstarct types/functions
          , vcat (map pp' mDecls)

--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -81,8 +81,7 @@ inferTopModule :: P.Module Name -> InferM TCTopEntity
 inferTopModule m =
   case P.mDef m of
     P.NormalModule ds ->
-      do newModuleScope (thing (P.mName m)) (map thing (P.mImports m))
-                                            (P.exportedDecls ds)
+      do newModuleScope (thing (P.mName m)) (P.exportedDecls ds)
          checkTopDecls ds
          proveModuleTopLevel
          endModule
@@ -1324,7 +1323,6 @@ checkTopDecls = mapM_ checkTopDecl
            P.NormalModule ds ->
              do newSubmoduleScope (thing (P.mName m))
                                   (thing <$> P.tlDoc tl)
-                                  (map thing (P.mImports m))
                                   (P.exportedDecls ds)
                 checkTopDecls ds
                 proveModuleTopLevel

--- a/src/Cryptol/TypeCheck/Module.hs
+++ b/src/Cryptol/TypeCheck/Module.hs
@@ -59,8 +59,8 @@ doFunctorInst m f as inst doc =
      newGoals CtModuleInstance (map thing (mParamConstraints m1))
 
      case thing m of
-       P.ImpTop mn    -> newModuleScope mn (mImports m2) (mExports m2)
-       P.ImpNested mn -> newSubmoduleScope mn doc (mImports m2) (mExports m2)
+       P.ImpTop mn    -> newModuleScope mn (mExports m2)
+       P.ImpNested mn -> newSubmoduleScope mn doc (mExports m2)
 
      mapM_ addTySyn     (Map.elems (mTySyns m2))
      mapM_ addNewtype   (Map.elems (mNewtypes m2))

--- a/src/Cryptol/TypeCheck/ModuleInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleInstance.hs
@@ -63,7 +63,6 @@ instance ModuleInstance (ModuleG name) where
     Module { mName             = mName m
            , mDoc              = Nothing
            , mExports          = doVInst (mExports m)
-           , mImports          = mImports m
            , mParamTypes       = doMap (mParamTypes m)
            , mParamFuns        = doMap (mParamFuns m)
            , mParamConstraints = moduleInstance (mParamConstraints m)

--- a/src/Cryptol/TypeCheck/Monad.hs
+++ b/src/Cryptol/TypeCheck/Monad.hs
@@ -991,16 +991,16 @@ newTopSignatureScope x = newScope (TopSignatureScope x)
 to initialize an empty module.  As we type check declarations they are
 added to this module's scope. -}
 newSubmoduleScope ::
-  Name -> Maybe Text -> [Import] -> ExportSpec Name -> InferM ()
-newSubmoduleScope x docs is e =
+  Name -> Maybe Text -> ExportSpec Name -> InferM ()
+newSubmoduleScope x docs e =
   do updScope \o -> o { mNested = Set.insert x (mNested o) }
      newScope (SubModule x)
-     updScope \m -> m { mDoc = docs, mImports = is, mExports = e }
+     updScope \m -> m { mDoc = docs, mExports = e }
 
-newModuleScope :: P.ModName -> [Import] -> ExportSpec Name -> InferM ()
-newModuleScope x is e =
+newModuleScope :: P.ModName -> ExportSpec Name -> InferM ()
+newModuleScope x e =
   do newScope (MTopModule x)
-     updScope \m -> m { mDoc = Nothing, mImports = is, mExports = e }
+     updScope \m -> m { mDoc = Nothing, mExports = e }
 
 -- | Update the current scope (first in the list). Assumes there is one.
 updScope :: (ModuleG ScopeName -> ModuleG ScopeName) -> InferM ()
@@ -1043,7 +1043,6 @@ endSubmodule =
                  , mParams           = mParams y
                  , mNested           = mNested y
 
-                 , mImports     = add mImports -- just for deps
                  , mTySyns      = add mTySyns
                  , mNewtypes    = add mNewtypes
                  , mPrimTypes   = add mPrimTypes

--- a/syntax-highlight/cryptol.vim
+++ b/syntax-highlight/cryptol.vim
@@ -1,0 +1,172 @@
+" Cryptol syntax file
+" Language:     cryptol
+" Author:       Iavor S. Diatchki
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn keyword cryKeywordImport import
+syn keyword cryKeywordImport include
+
+syn keyword cryKeyword module
+syn keyword cryKeyword private
+syn keyword cryKeyword infixl
+syn keyword cryKeyword infixr
+syn keyword cryKeyword infix
+syn keyword cryKeyword submodule
+syn keyword cryKeyword interface
+syn keyword cryKeyword foreign
+syn keyword cryKeyword newtype
+syn keyword cryKeyword type
+syn keyword cryKeyword primitive
+syn keyword cryKeyword parameter
+syn keyword cryKeyword constraint
+syn keyword cryKeyword property
+syn keyword cryKeyword if
+syn keyword cryKeyword then
+syn keyword cryKeyword else
+syn keyword cryKeyword where
+syn keyword cryKeyword let
+syn keyword cryKeyword pragma
+syn keyword cryKeyword down
+syn keyword cryKeyword by
+
+syn keyword cryKeywordType Prop
+syn keyword cryKeywordType Bit Bool Word Char String Integer Z Rational
+syn keyword cryKeywordType inf
+syn keyword cryKeywordType Literal FLiteral LiteralLessThan
+syn keyword cryKeywordType Zero Logic Ring Integral Field Round Eq Cmp SignedCmp
+syn keyword cryKeywordType fin prime width lg2
+
+syn keyword cryKeywordConst False True zero
+syn keyword cryKeywordFun   min max abs
+syn keyword cryKeywordFun   length
+syn keyword cryKeywordFun   complement negate
+syn keyword cryKeywordFun   fromInteger toInteger toSignedInteger fromZ
+syn keyword cryKeywordFun   recip
+syn keyword cryKeywordFun   error undefined assert
+syn keyword cryKeywordFun   ceiling floor trunc roundAway roundToEven
+syn keyword cryKeywordFun   carry scarry sborrow zext sext ratio
+syn keyword cryKeywordFun   splitAt join split groupBy
+syn keyword cryKeywordFun   reverse transpose take drop
+syn keyword cryKeywordFun   head tail last
+syn keyword cryKeywordFun   update updates updateEnd updatesEnd
+syn keyword cryKeywordFun   generate
+syn keyword cryKeywordFun   sort sortBy
+syn keyword cryKeywordFun   pmult pdiv pmod
+syn keyword cryKeywordFun   parmap
+syn keyword cryKeywordFun   deepseq rnf
+syn keyword cryKeywordFun   random trace traceVal
+syn keyword cryKeywordFun   and or all any
+syn keyword cryKeywordFun   map foldl foldr sum product scanl scanr elem
+syn keyword cryKeywordFun   repeat iterate
+syn keyword cryKeywordFun   zip zipWith
+syn keyword cryKeywordFun   curry uncurry
+
+syn match cryOperator "!"
+syn match cryOperator "!!"
+syn match cryOperator "@"
+syn match cryOperator "@@"
+
+syn match cryOperator "+"
+syn match cryOperator "-"
+syn match cryOperator "*"
+syn match cryOperator "/"
+syn match cryOperator "%"
+syn match cryOperator "\^"
+syn match cryOperator "/\^"
+syn match cryOperator "/\."
+syn match cryOperator "/\$"
+syn match cryOperator "%\$"
+syn match cryOperator "\^\^"
+
+syn match cryOperator ">"
+syn match cryOperator "<"
+syn match cryOperator "!="
+syn match cryOperator ">="
+syn match cryOperator "<="
+syn match cryOperator "<\$"
+syn match cryOperator ">\$"
+syn match cryOperator "<=\$"
+syn match cryOperator ">=\$"
+syn match cryOperator "!=="
+
+syn match cryOperator ">>"
+syn match cryOperator ">>\$"
+syn match cryOperator "<<"
+syn match cryOperator ">>>"
+syn match cryOperator "<<<"
+
+syn match cryOperator "#"
+
+syn match cryOperator "&&"
+syn match cryOperator "||"
+syn match cryOperator "\\/"
+syn match cryOperator "/\\"
+
+syn match cryDelimiter ","
+syn match cryDelimiter "`"
+syn match cryDelimiter "\.\."
+syn match cryDelimiter "\.\.\."
+syn match cryDelimiter ":"
+syn match cryDelimiter "("
+syn match cryDelimiter ")"
+syn match cryDelimiter "{"
+syn match cryDelimiter "}"
+syn match cryDelimiter "\["
+syn match cryDelimiter "|"
+syn match cryDelimiter "\]"
+syn match cryDelimiter "="
+syn match cryDelimiter "<-"
+
+" Needs to be after =
+syn match cryOperator "=="
+syn match cryOperator "==="
+syn match cryOperator "==>"
+
+syn match   cryLineComment      "//.*$"
+syn region  cryBlockComment     start="/\*" end="\*/" contains=cryBlockComment
+
+
+
+syn match   cryEsc contained "\\\""
+syn match   cryEsc contained "\\'"
+syn match   cryEsc contained "\\\\"
+syn match   cryEsc contained "\\n"
+syn match   cryEsc contained "\\t"
+syn match   cryEsc contained "\\r"
+syn match   cryEsc contained "\\\d\+"
+syn match   cryEsc contained "\\\(x\|X\)\x\+"
+syn region  cryString start="\"" skip="\\\"" end="\"" contains=cryEsc
+syn region  cryByte   start="'"  skip="\\'"  end="'"  contains=cryEsc
+
+
+syn match   cryNumber "\(0\(x\|X\|b\|B\|o\|O\)\x\+\)\|-\?\(\d\|_\)\+"
+
+
+" This is here so that we don't highlight numbers in X23 for example
+" or x'
+syn match ddlIdent "\(\l\|\u\)\(\a\|\d\|_\|'\)*"
+
+
+hi def link cryKeywordImport  Include
+hi def link cryKeyword        Structure
+
+hi def link cryKeywordFun     Keyword
+hi def link cryKeywordConst   Constant
+hi def link cryKeywordType    Keyword
+
+hi def link cryOperator       Operator
+hi def link cryDelimiter      Delimiter
+
+hi def link cryString         String
+hi def link cryByte           String
+hi def link cryEsc            Special
+
+hi def link cryNumber         Number
+
+hi def link cryLineComment    Comment
+hi def link cryBlockComment   Comment
+
+let b:current_syntax = "cryptol"

--- a/tests/issues/issue103.icry.stdout
+++ b/tests/issues/issue103.icry.stdout
@@ -2,7 +2,7 @@ Loading module Cryptol
 
 Run-time error: undefined
 -- Backtrace --
-Cryptol::error called at Cryptol:1033:13--1033:18
+Cryptol::error called at Cryptol:1043:13--1043:18
 Cryptol::undefined called at issue103.icry:1:9--1:18
 Using exhaustive testing.
 Testing... ERROR for the following inputs:

--- a/tests/modsys/T16.icry.stdout
+++ b/tests/modsys/T16.icry.stdout
@@ -5,5 +5,5 @@ Loading module T16::B
 
 [error] at T16/B.cry:5:5--5:11
     Multiple definitions for symbol: update
-    (at Cryptol:899:11--899:17, update)
+    (at Cryptol:909:11--909:17, update)
     (at ./T16/A.cry:3:1--3:7, T16::A::update)

--- a/tests/modsys/T16.icry.stdout.mingw32
+++ b/tests/modsys/T16.icry.stdout.mingw32
@@ -5,5 +5,5 @@ Loading module T16::B
 
 [error] at T16\B.cry:5:5--5:11
     Multiple definitions for symbol: update
-    (at Cryptol:899:11--899:17, update)
+    (at Cryptol:909:11--909:17, update)
     (at .\T16\A.cry:3:1--3:7, T16::A::update)

--- a/tests/regression/safety.icry.stdout
+++ b/tests/regression/safety.icry.stdout
@@ -3,7 +3,7 @@ Counterexample
 (\x -> assert x "asdf" "asdf") False ~> ERROR
 Run-time error: asdf
 -- Backtrace --
-Cryptol::error called at Cryptol:1041:41--1041:46
+Cryptol::error called at Cryptol:1051:41--1051:46
 Cryptol::assert called at safety.icry:3:14--3:20
 <interactive>::it called at safety.icry:3:7--3:37
 Counterexample


### PR DESCRIPTION
This PR add functionality to track the dependencies of loaded modules.

At the moment this can only be done at the REPL with the new `:module-info` command.
Python API support coming soon, hopefully.

This should help with #1332 