### PR TITLE
Module dependencies without loading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@
 
 * Add `:file-deps` commnads ro the REPL and Python API.
   It shows information about the source files and dependencies of
-  loaded modules.
+  modules or Cryptol files.
 
 ## Bug fixes
 

--- a/cryptol-remote-api/docs/Cryptol.rst
+++ b/cryptol-remote-api/docs/Cryptol.rst
@@ -391,14 +391,19 @@ No return fields
 file-deps (command)
 ~~~~~~~~~~~~~~~~~~~
 
-Get information about the dependencies of a loaded top-level module. The dependencies include the dependencies of modules nested in this one.
+Get information about the dependencies of a file or module. The dependencies include the dependencies of modules nested in this one.
 
 Parameter fields
 ++++++++++++++++
 
 
-``module name``
-  Get information about this loaded module.
+``name``
+  Get information about this entity.
+  
+  
+
+``is-file``
+  Indicates if the name is a file (true) or module (false)
   
   
 

--- a/cryptol-remote-api/python/cryptol/commands.py
+++ b/cryptol-remote-api/python/cryptol/commands.py
@@ -76,8 +76,16 @@ class CryptolLoadFile(argo.Command):
         return res
 
 class CryptolFileDeps(argo.Command):
-  def __init__(self, connection : HasProtocolState, mod_name : str, timeout: Optional[float]) -> None:
-    super(CryptolFileDeps, self).__init__('file-deps', {'module name': mod_name}, connection, timeout=timeout)
+  def __init__( self
+              , connection : HasProtocolState
+              , name : str, isFile : bool
+              , timeout: Optional[float]
+              ) -> None:
+    super(CryptolFileDeps, self).__init__('file-deps'
+                                         , {'name': name, 'is-file': isFile }
+                                         , connection
+                                         , timeout=timeout
+                                         )
 
   def process_result(self, res : Any) -> Any:
       return res

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -213,13 +213,13 @@ class CryptolConnection:
         self.most_recent_result = CryptolLoadModule(self, module_name, timeout)
         return self.most_recent_result
 
-    def file_deps(self, module_name : str, *, timeout:Optional[float] = None) -> argo.Command:
-        """Get information about a loaded module.
+    def file_deps(self, name : str, isFile : bool, *, timeout:Optional[float] = None) -> argo.Command:
+        """Get information about a module or a file.
 
         :param timeout: Optional timeout for this request (in seconds).
         """
         timeout = timeout if timeout is not None else self.timeout
-        self.most_recent_result = CryptolFileDeps(self, module_name, timeout)
+        self.most_recent_result = CryptolFileDeps(self, name, isFile, timeout)
         return self.most_recent_result
 
     def eval_raw(self, expression : Any, *, timeout:Optional[float] = None) -> argo.Command:

--- a/cryptol-remote-api/python/cryptol/file_deps.py
+++ b/cryptol-remote-api/python/cryptol/file_deps.py
@@ -1,12 +1,14 @@
-def nestedFileDeps(getDeps, name, isFile):
-  done  = {}
+from typing import Dict, Any
+
+def nestedFileDeps(getDeps : Any, name : str, isFile : bool) -> Any:
+  done : Dict[str,Any]  = {}
   start = getDeps(name, isFile)
   todo  = start["imports"].copy()
   while len(todo) > 0:
     m = todo.pop()
     if m in done:
       continue
-    deps = file_deps(m, False)
+    deps = getDeps(m, False)
     todo.extend(deps["imports"])
   return (start, deps)
 

--- a/cryptol-remote-api/python/cryptol/file_deps.py
+++ b/cryptol-remote-api/python/cryptol/file_deps.py
@@ -1,4 +1,4 @@
-def nestedFileDeps(getDeps, name : str, isFile : bool) -> Any:
+def nestedFileDeps(getDeps, name, isFile):
   done  = {}
   start = getDeps(name, isFile)
   todo  = start["imports"].copy()

--- a/cryptol-remote-api/python/cryptol/file_deps.py
+++ b/cryptol-remote-api/python/cryptol/file_deps.py
@@ -1,0 +1,12 @@
+def nestedFileDeps(getDeps, name : str, isFile : bool) -> Any:
+  done  = {}
+  start = getDeps(name, isFile)
+  todo  = start["imports"].copy()
+  while len(todo) > 0:
+    m = todo.pop()
+    if m in done:
+      continue
+    deps = file_deps(m, False)
+    todo.extend(deps["imports"])
+  return (start, deps)
+

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -243,8 +243,8 @@ def logging(on : bool, *, dest : TextIO = sys.stderr) -> None:
     """Whether to log received and transmitted JSON."""
     __get_designated_connection().logging(on=on,dest=dest)
 
-def file_deps(m : str, timeout:Optional[float] = None) -> Any:
-    """Get information about a loaded module."""
-    return __get_designated_connection().file_deps(m,timeout=timeout)
+def file_deps(m : str, isFile:bool, timeout:Optional[float] = None) -> Any:
+    """Get information about a module or a file."""
+    return __get_designated_connection().file_deps(m,isFile,timeout=timeout)
 
 

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -380,6 +380,8 @@ class CryptolSyncConnection:
         """Whether to log received and transmitted JSON."""
         self.connection.server_connection.logging(on=on,dest=dest)
 
-    def file_deps(self, m : str, timeout:Optional[float] = None) -> Any:
-        """Get information about a loaded module."""
-        return self.connection.file_deps(m,timeout=timeout).result()
+    def file_deps( self
+                 , m : str, isFile:bool
+                 , timeout:Optional[float] = None) -> Any:
+        """Get information about a module or a file."""
+        return self.connection.file_deps(m,isFile,timeout=timeout).result()

--- a/cryptol-remote-api/python/poetry.lock
+++ b/cryptol-remote-api/python/poetry.lock
@@ -20,26 +20,26 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.9"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
-python-versions = ">=3.5.0"
+python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -71,21 +71,21 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "typed-ast"
@@ -97,23 +97,23 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.7"
+version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
@@ -130,16 +130,16 @@ bitvector = [
     {file = "BitVector-3.5.0.tar.gz", hash = "sha256:cac2fbccf11e325115827ed7be03e5fd62615227b0bbf3fa5a18a842a221839c"},
 ]
 certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+    {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
+    {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
-    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
 ]
 idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 mypy = [
     {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
@@ -170,8 +170,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -206,10 +206,10 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
-    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+    {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},
+    {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]

--- a/cryptol-remote-api/python/tests/cryptol/test_filedeps.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_filedeps.py
@@ -4,11 +4,12 @@ import unittest
 import cryptol
 from cryptol.single_connection import *
 
+
 class TestFileDeps(unittest.TestCase):
-    def test_FileDeps(self):
+    def test_FileDeps(self) -> None:
         connect(verify=False)
-        load_file(str(Path('tests','cryptol','test-files','Id.cry')))
-        result = file_deps('Id',False)
+        path = str(Path('tests','cryptol','test-files','Id.cry'))
+        result = file_deps(path,True)
         self.assertEqual(result['fingerprint'],"8A49C6A461AF276DF56C4FE4279BCFC51D891214")
         self.assertEqual(result['foreign'],[])
         self.assertEqual(result['imports'],['Cryptol'])

--- a/cryptol-remote-api/python/tests/cryptol/test_filedeps.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_filedeps.py
@@ -8,7 +8,7 @@ class TestFileDeps(unittest.TestCase):
     def test_FileDeps(self):
         connect(verify=False)
         load_file(str(Path('tests','cryptol','test-files','Id.cry')))
-        result = file_deps('Id')
+        result = file_deps('Id',False)
         self.assertEqual(result['fingerprint'],"8A49C6A461AF276DF56C4FE4279BCFC51D891214")
         self.assertEqual(result['foreign'],[])
         self.assertEqual(result['imports'],['Cryptol'])

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -7,6 +7,7 @@
 -- Portability :  portable
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE BlockArguments #-}
 
 module Cryptol.ModuleSystem (
     -- * Module System
@@ -32,6 +33,11 @@ module Cryptol.ModuleSystem (
 
     -- * Interfaces
   , Iface, IfaceG(..), IfaceDecls(..), T.genIface, IfaceDecl(..)
+
+    -- * Dependencies
+  , M.ModName
+  , getFileDependencies
+  , getModuleDependencies
   ) where
 
 import Data.Map (Map)
@@ -137,3 +143,18 @@ renameVar names n env = runModuleM env $ interactive $
 renameType :: R.NamingEnv -> PName -> ModuleCmd Name
 renameType names n env = runModuleM env $ interactive $
   Base.rename M.interactiveName names (R.renameType R.NameUse n)
+
+--------------------------------------------------------------------------------
+-- Dependencies
+
+
+-- | Get information about the dependencies of a module.
+getFileDependencies :: FilePath -> ModuleCmd (FilePath, FileInfo)
+getFileDependencies path env = runModuleM env (Base.findDepsOfFile path)
+
+-- | Get information about the dependencies of a module.
+-- May return 'Nothing' if this is an `InMem` module
+getModuleDependencies :: M.ModName -> ModuleCmd (Maybe (FilePath, FileInfo))
+getModuleDependencies m env = runModuleM env (Base.findDepsOfModule m)
+
+

--- a/src/Cryptol/ModuleSystem.hs
+++ b/src/Cryptol/ModuleSystem.hs
@@ -35,7 +35,6 @@ module Cryptol.ModuleSystem (
   , Iface, IfaceG(..), IfaceDecls(..), T.genIface, IfaceDecl(..)
 
     -- * Dependencies
-  , M.ModName
   , getFileDependencies
   , getModuleDependencies
   ) where
@@ -148,13 +147,11 @@ renameType names n env = runModuleM env $ interactive $
 -- Dependencies
 
 
--- | Get information about the dependencies of a module.
-getFileDependencies :: FilePath -> ModuleCmd (FilePath, FileInfo)
-getFileDependencies path env = runModuleM env (Base.findDepsOfFile path)
+-- | Get information about the dependencies of a file.
+getFileDependencies :: FilePath -> ModuleCmd (ModulePath, FileInfo)
+getFileDependencies f env = runModuleM env (Base.findDepsOf (InFile f))
 
 -- | Get information about the dependencies of a module.
--- May return 'Nothing' if this is an `InMem` module
-getModuleDependencies :: M.ModName -> ModuleCmd (Maybe (FilePath, FileInfo))
+getModuleDependencies :: M.ModName -> ModuleCmd (ModulePath, FileInfo)
 getModuleDependencies m env = runModuleM env (Base.findDepsOfModule m)
-
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -114,7 +114,6 @@ import Control.Monad.IO.Class(liftIO)
 import Text.Read (readMaybe)
 import Control.Applicative ((<|>))
 import qualified Data.Set as Set
-import qualified Data.Map as Map
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -130,7 +129,7 @@ import qualified System.Process as Process(runCommand)
 import System.FilePath((</>), (-<.>), isPathSeparator)
 import System.Directory(getHomeDirectory,setCurrentDirectory,doesDirectoryExist
                        ,getTemporaryDirectory,setPermissions,removeFile
-                       ,emptyPermissions,setOwnerReadable,canonicalizePath)
+                       ,emptyPermissions,setOwnerReadable)
 import System.IO
          (Handle,hFlush,stdout,openTempFile,hClose,openFile
          ,IOMode(..),hGetContents,hSeek,SeekMode(..))
@@ -337,12 +336,15 @@ commandList  =
       , "but with a .h extension." ])
 
 
-  , CommandDescr [ ":file-deps" ] [ "[MODULE]" ] (FilenameArg moduleInfoCmd)
-    "Show information about the source of a loaded module."
-    (unlines
-      [ "If the module name is not specified,"
-      , "then show information for all loaded modules."
-      ])
+  , CommandDescr [ ":file-deps" ] [ "FILE" ]
+    (FilenameArg (moduleInfoCmd True))
+    "Show information about the dependencies of a file"
+    ""
+
+  , CommandDescr [ ":module-deps" ] [ "MODULE" ]
+    (ModNameArg (moduleInfoCmd False))
+    "Show information about the dependencies of a module"
+    ""
   ]
 
 genHelp :: [CommandDescr] -> [String]
@@ -1791,66 +1793,39 @@ parseCommand findCmd line = do
 
 
 
-moduleInfoCmd :: String -> REPL ()
-moduleInfoCmd modString
-  | null modString =
-    do env <- getModuleEnv
-       let es = Map.toList (M.getLoadedEntities (M.meLoadedModules env))
-       case es of
-         [] -> rPutStrLn "[]"
-         i : is ->
-           do showInfoEither "[ " i
-              mapM_ (showInfoEither (", ")) is
-              rPutStrLn "]"
-
+moduleInfoCmd :: Bool -> String -> REPL ()
+moduleInfoCmd isFile name
+  | isFile = showInfo =<< liftModuleCmd (M.getFileDependencies name)
   | otherwise =
-    case parseModName modString of
-      Just m ->
-        do env <- getModuleEnv
-           case M.lookupTCEntity m env of
-             Nothing -> rPutStrLn "Module is not leaded."
-             Just lm -> showInfo "" lm
-
+    case parseModName name of
+      Just m  -> showInfo =<< liftModuleCmd (M.getModuleDependencies m)
       Nothing -> rPutStrLn "Invalid module name."
 
   where
-  showInfoEither pref (k,x) =
-    do rPutStrLn (pref ++ show (show (pp k)) ++ ":")
-       let newPref = replicate (length pref + 2) ' '
-       case x of
-         Left a  -> showInfo newPref a
-         Right a -> showInfo newPref a
-
-  showInfo pref lm =
-    do rPutStr (pref ++ "{ \"source\": ")
-       let n = length pref
-           tab x = replicate n ' ' ++ x
-       case M.lmFilePath lm of
-         M.InFile f' ->
-            do f <- io (canonicalizePath f')
-               rPutStrLn (show f)
+  showInfo (p,fi) =
+    do rPutStr "{ \"source\": "
+       case p of
+         M.InFile f  -> rPutStrLn (show f)
          M.InMem l _ -> rPutStrLn ("{ \"internal\": " ++ show l ++ " }")
 
-       let fi = M.lmFileInfo lm
-       rPutStrLn (tab (", \"fingerprint\": \"0x" ++
-                       fingerprintHexString (M.fiFingerprint fi) ++ "\""))
-
+       rPutStrLn (", \"fingerprint\": \"0x" ++
+                       fingerprintHexString (M.fiFingerprint fi) ++ "\"")
 
        let depList f x ys =
-             do rPutStr (tab (", " ++ show (x :: String) ++ ":"))
+             do rPutStr (", " ++ show (x :: String) ++ ":")
                 case ys of
                   [] -> rPutStrLn " []"
                   i : is ->
                     do rPutStrLn ""
-                       rPutStrLn (tab ("     [ " ++ f i))
-                       mapM_ (\j -> rPutStrLn (tab ("   , " ++ f j))) is
-                       rPutStrLn (tab "     ]")
+                       rPutStrLn ("     [ " ++ f i)
+                       mapM_ (\j -> rPutStrLn ("     , " ++ f j)) is
+                       rPutStrLn "     ]"
 
        depList show               "includes" (Set.toList (M.fiIncludeDeps fi))
        depList (show . show . pp) "imports"  (Set.toList (M.fiImportDeps  fi))
        depList show               "foreign"  (Set.toList (M.fiForeignDeps fi))
 
-       rPutStrLn (tab "}")
+       rPutStrLn "}"
 
 
 


### PR DESCRIPTION
Hopefully this should be faster as we just
parse the module and expand the includes.

We do not rename, typecheck, or evaluate anything.