### PR TITLE
`cryptol-remote-api`: Restore the ability to build with `vector-0.12.*`

### DIFF
--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -55,7 +55,7 @@ common deps
     text                 >= 1.2.3 && < 2.1,
     tf-random,
     unordered-containers ^>= 0.2,
-    vector               ^>= 0.13,
+    vector               >= 0.12 && < 0.14,
 
   default-language:    Haskell2010
 


### PR DESCRIPTION
The downstream `saw-remote-api` library doesn't quite support `vector-0.13.*` yet, but GaloisInc/cryptol#1499 accidentally restricted `cryptol-remote-api`'s build plan to only allow `vector-0.13.*`. This restores the ability to build `cryptol-remote-api` with `vector-0.12.*` for `saw-remote-api`'s sake.