### PR TITLE
Add more info to `names()` in Python API

### DIFF
--- a/cryptol-remote-api/CHANGELOG.md
+++ b/cryptol-remote-api/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Revision history for `cryptol-remote-api` and `cryptol-eval-server`
 
-## 2.13.0 -- YYYY-MM-DD
+## 2.13.2 -- YYYY-MM-DD
+
+* Add more fields (such as `pragmas`, `parameter`, `module`, and `infix`) to
+  the response to the RPC `visible names` method.
+* Do not error if `visible names` is called when a parameterized module is
+  loaded (this used to cause the appearance of the server hanging in such a
+  case).
+
+## 2.13.0 -- 2022-05-17
 
 * v2.13.0 release in tandem with the Cryptol 2.13.0 release. See the Cryptol
   2.13.0 release notes for relevant Cryptol changes. No notable changes to the

--- a/cryptol-remote-api/CHANGELOG.md
+++ b/cryptol-remote-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for `cryptol-remote-api` and `cryptol-eval-server`
 
-## 2.13.2 -- YYYY-MM-DD
+## NEXT -- YYYY-MM-DD
 
 * Add more fields (such as `pragmas`, `parameter`, `module`, and `infix`) to
   the response to the RPC `visible names` method.

--- a/cryptol-remote-api/docs/Cryptol.rst
+++ b/cryptol-remote-api/docs/Cryptol.rst
@@ -490,7 +490,7 @@ Return fields
 visible names (command)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-List the currently visible (i.e., in scope) names.
+List the currently visible (i.e., in scope) term names.
 
 Parameter fields
 ++++++++++++++++
@@ -514,6 +514,36 @@ Return fields
 
 ``type``
    A:ref:`JSON Cryptol type <JSONSchema>`
+  
+  
+
+``module``
+  A human-readable representation of the module from which the name originates
+  
+  
+
+``parameter``
+  An optional field which is present and ``True`` iff the name is a module parameter
+  
+  
+
+``infix``
+  An optional field which is present and ``True`` iff the name is an infix operator
+  
+  
+
+``infix associativity``
+  An optional field containing one of the strings ``left-associative``, ``right-associative``, or ``non-associative`` if the name is an infix operator
+  
+  
+
+``infix level``
+  An optional field containing the name's precedence level, if the name is an infix operator
+  
+  
+
+``pragmas``
+  An optional field containing a list of the name's pragmas (e.g. ``property``), if it has any
   
   
 

--- a/cryptol-remote-api/docs/Cryptol.rst
+++ b/cryptol-remote-api/docs/Cryptol.rst
@@ -523,22 +523,12 @@ Return fields
   
 
 ``parameter``
-  An optional field which is present and ``True`` iff the name is a module parameter
+  An optional field which is present iff the name is a module parameter
   
   
 
 ``infix``
-  An optional field which is present and ``True`` iff the name is an infix operator
-  
-  
-
-``infix associativity``
-  An optional field containing one of the strings ``left-associative``, ``right-associative``, or ``non-associative`` if the name is an infix operator
-  
-  
-
-``infix level``
-  An optional field containing the name's precedence level, if the name is an infix operator
+  An optional field which is present iff the name is an infix operator. If present, it contains an object with two fields. One field is ``associativity``, containing one of the strings ``left-associative``, ``right-associative``, or ``non-associative``, and the other is ``level``, containing the name's precedence level.
   
   
 

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for `cryptol` Python package
 
-## 2.13.2 -- YYYY-MM-DD
+## NEXT -- YYYY-MM-DD
 
 * Add `property_names` and `parameter_names` commands, used to get only those
   loaded names which are properties or module parameters, respectively.

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Revision history for `cryptol` Python package
 
+## 2.13.2 -- YYYY-MM-DD
 
-## 2.13.0 -- YYYY-MM-DD
+* Add `property_names` and `parameter_names` commands, used to get only those
+  loaded names which are properties or module parameters, respectively.
+* Add more fields (such as `pragmas`, `parameter`, `module`, and `infix`) to
+  the result of `names` (see `cryptol-remote-api` `CHANGELOG`).
+* Do not hang if `names` is called when a parameterized module is loaded
+  (see `cryptol-remote-api` `CHANGELOG`).
+
+## 2.13.0 -- 2022-05-17
 
 * v2.13.0 release in tandem with the Cryptol 2.13.0 release. See the Cryptol
   2.13.0 release notes for relevant Cryptol changes. No notable changes to the

--- a/cryptol-remote-api/python/cryptol/commands.py
+++ b/cryptol-remote-api/python/cryptol/commands.py
@@ -270,6 +270,11 @@ class CryptolNames(argo.Command):
     def process_result(self, res : Any) -> Any:
         return res
 
+class CryptolParameterNames(CryptolNames):
+    def process_result(self, res : Any) -> Any:
+        res = super(CryptolParameterNames, self).process_result(res)
+        return [ n for n in res if "parameter" in n ]
+
 class CryptolPropertyNames(CryptolNames):
     def process_result(self, res : Any) -> Any:
         res = super(CryptolPropertyNames, self).process_result(res)

--- a/cryptol-remote-api/python/cryptol/commands.py
+++ b/cryptol-remote-api/python/cryptol/commands.py
@@ -270,6 +270,11 @@ class CryptolNames(argo.Command):
     def process_result(self, res : Any) -> Any:
         return res
 
+class CryptolPropertyNames(CryptolNames):
+    def process_result(self, res : Any) -> Any:
+        res = super(CryptolPropertyNames, self).process_result(res)
+        return [ n for n in res if "pragmas" in n and "property" in n["pragmas"] ]
+
 
 class CryptolFocusedModule(argo.Command):
     def __init__(self, connection : HasProtocolState, timeout: Optional[float]) -> None:

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -386,6 +386,15 @@ class CryptolConnection:
         self.most_recent_result = CryptolNames(self, timeout)
         return self.most_recent_result
 
+    def property_names(self, *, timeout:Optional[float] = None) -> argo.Command:
+        """Discover the list of property names currently in scope in the current context.
+        The result is a subset of the list returned by `names`.
+
+        :param timeout: Optional timeout for this request (in seconds)."""
+        timeout = timeout if timeout is not None else self.timeout
+        self.most_recent_result = CryptolPropertyNames(self, timeout)
+        return self.most_recent_result
+
     def focused_module(self, *, timeout:Optional[float] = None) -> argo.Command:
         """Return the name of the currently-focused module.
 

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -379,11 +379,20 @@ class CryptolConnection:
         return self.most_recent_result
 
     def names(self, *, timeout:Optional[float] = None) -> argo.Command:
-        """Discover the list of names currently in scope in the current context.
+        """Discover the list of term names currently in scope in the current context.
 
         :param timeout: Optional timeout for this request (in seconds)."""
         timeout = timeout if timeout is not None else self.timeout
         self.most_recent_result = CryptolNames(self, timeout)
+        return self.most_recent_result
+
+    def parameter_names(self, *, timeout:Optional[float] = None) -> argo.Command:
+        """Discover the list of module parameter names currently in scope in the current context.
+        The result is a subset of the list returned by `names`.
+
+        :param timeout: Optional timeout for this request (in seconds)."""
+        timeout = timeout if timeout is not None else self.timeout
+        self.most_recent_result = CryptolParameterNames(self, timeout)
         return self.most_recent_result
 
     def property_names(self, *, timeout:Optional[float] = None) -> argo.Command:

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -222,6 +222,11 @@ def names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
     """Discover the list of names currently in scope in the current context."""
     return __get_designated_connection().names(timeout=timeout)
 
+def property_names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+    """Discover the list of property names currently in scope in the current context.
+    The result is a subset of the list returned by `names`."""
+    return __get_designated_connection().property_names(timeout=timeout)
+
 def focused_module(*, timeout:Optional[float] = None) -> Dict[str,Any]:
     """Returns the name and other information about the currently-focused module."""
     return __get_designated_connection().focused_module(timeout=timeout)

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -218,21 +218,21 @@ def safe(expr : Any, solver : Solver = Z3, *, timeout:Optional[float] = None) ->
     """
     return __get_designated_connection().safe(expr, solver, timeout=timeout)
 
-def names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+def names(*, timeout:Optional[float] = None) -> List[cryptoltypes.CryptolNameInfo]:
     """Discover the list of term names currently in scope in the current context."""
     return __get_designated_connection().names(timeout=timeout)
 
-def parameter_names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+def parameter_names(*, timeout:Optional[float] = None) -> List[cryptoltypes.CryptolNameInfo]:
     """Discover the list of module parameter names currently in scope in the current context.
     The result is a subset of the list returned by `names`."""
     return __get_designated_connection().parameter_names(timeout=timeout)
 
-def property_names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+def property_names(*, timeout:Optional[float] = None) -> List[cryptoltypes.CryptolNameInfo]:
     """Discover the list of property names currently in scope in the current context.
     The result is a subset of the list returned by `names`."""
     return __get_designated_connection().property_names(timeout=timeout)
 
-def focused_module(*, timeout:Optional[float] = None) -> Dict[str,Any]:
+def focused_module(*, timeout:Optional[float] = None) -> cryptoltypes.CryptolModuleInfo:
     """Returns the name and other information about the currently-focused module."""
     return __get_designated_connection().focused_module(timeout=timeout)
 

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -219,8 +219,13 @@ def safe(expr : Any, solver : Solver = Z3, *, timeout:Optional[float] = None) ->
     return __get_designated_connection().safe(expr, solver, timeout=timeout)
 
 def names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
-    """Discover the list of names currently in scope in the current context."""
+    """Discover the list of term names currently in scope in the current context."""
     return __get_designated_connection().names(timeout=timeout)
+
+def parameter_names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+    """Discover the list of module parameter names currently in scope in the current context.
+    The result is a subset of the list returned by `names`."""
+    return __get_designated_connection().parameter_names(timeout=timeout)
 
 def property_names(*, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
     """Discover the list of property names currently in scope in the current context.

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -355,6 +355,15 @@ class CryptolSyncConnection:
         else:
             raise ValueError("Panic! Result of `names()` is malformed: " + str(res))
 
+    def property_names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+        """Discover the list of property names currently in scope in the current context.
+        The result is a subset of the list returned by `names`."""
+        res = self.connection.property_names(timeout=timeout).result()
+        if isinstance(res, list) and all(isinstance(d, dict) and all(isinstance(k, str) for k in d.keys()) for d in res):
+            return res
+        else:
+            raise ValueError("Panic! Result of `property_names()` is malformed: " + str(res))
+
     def focused_module(self, *, timeout:Optional[float] = None) -> Dict[str,Any]:
         """Returns the name and other information about the currently-focused module."""
         res = self.connection.focused_module(timeout=timeout).result()

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -347,39 +347,35 @@ class CryptolSyncConnection:
         else:
             raise ValueError("Unknown solver type: " + str(solver))
 
-    def names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+    def names(self, *, timeout:Optional[float] = None) -> List[cryptoltypes.CryptolNameInfo]:
         """Discover the list of term names currently in scope in the current context."""
         res = self.connection.names(timeout=timeout).result()
-        if isinstance(res, list) and all(isinstance(d, dict) and all(isinstance(k, str) for k in d.keys()) for d in res):
-            return res
+        if isinstance(res, list):
+            return [ cryptoltypes.to_cryptol_name_info(entry) for entry in res ]
         else:
-            raise ValueError("Panic! Result of `names()` is malformed: " + str(res))
+            raise ValueError("Result of `names()` is not a list: " + str(res))
 
-    def parameter_names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+    def parameter_names(self, *, timeout:Optional[float] = None) -> List[cryptoltypes.CryptolNameInfo]:
         """Discover the list of module parameter names currently in scope in the current context.
         The result is a subset of the list returned by `names`."""
         res = self.connection.parameter_names(timeout=timeout).result()
-        if isinstance(res, list) and all(isinstance(d, dict) and all(isinstance(k, str) for k in d.keys()) for d in res):
-            return res
+        if isinstance(res, list):
+            return [ cryptoltypes.to_cryptol_name_info(entry) for entry in res ]
         else:
-            raise ValueError("Panic! Result of `parameter_names()` is malformed: " + str(res))
+            raise ValueError("Result of `parameter_names()` is not a list: " + str(res))
 
-    def property_names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+    def property_names(self, *, timeout:Optional[float] = None) -> List[cryptoltypes.CryptolNameInfo]:
         """Discover the list of property names currently in scope in the current context.
         The result is a subset of the list returned by `names`."""
         res = self.connection.property_names(timeout=timeout).result()
-        if isinstance(res, list) and all(isinstance(d, dict) and all(isinstance(k, str) for k in d.keys()) for d in res):
-            return res
+        if isinstance(res, list):
+            return [ cryptoltypes.to_cryptol_name_info(entry) for entry in res ]
         else:
-            raise ValueError("Panic! Result of `property_names()` is malformed: " + str(res))
+            raise ValueError("Result of `property_names()` is not a list: " + str(res))
 
-    def focused_module(self, *, timeout:Optional[float] = None) -> Dict[str,Any]:
+    def focused_module(self, *, timeout:Optional[float] = None) -> cryptoltypes.CryptolModuleInfo:
         """Returns the name and other information about the currently-focused module."""
-        res = self.connection.focused_module(timeout=timeout).result()
-        if isinstance(res, dict) and all(isinstance(k, str) for k in res.keys()):
-            return res
-        else:
-            raise ValueError("Panic! Result of `focused_module()` is malformed: " + str(res))
+        return cryptoltypes.to_cryptol_module_info(self.connection.focused_module(timeout=timeout).result())
 
     def reset(self) -> None:
         """Resets the connection, causing its unique state on the server to be freed (if applicable).

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -348,12 +348,21 @@ class CryptolSyncConnection:
             raise ValueError("Unknown solver type: " + str(solver))
 
     def names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
-        """Discover the list of names currently in scope in the current context."""
+        """Discover the list of term names currently in scope in the current context."""
         res = self.connection.names(timeout=timeout).result()
         if isinstance(res, list) and all(isinstance(d, dict) and all(isinstance(k, str) for k in d.keys()) for d in res):
             return res
         else:
             raise ValueError("Panic! Result of `names()` is malformed: " + str(res))
+
+    def parameter_names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
+        """Discover the list of module parameter names currently in scope in the current context.
+        The result is a subset of the list returned by `names`."""
+        res = self.connection.parameter_names(timeout=timeout).result()
+        if isinstance(res, list) and all(isinstance(d, dict) and all(isinstance(k, str) for k in d.keys()) for d in res):
+            return res
+        else:
+            raise ValueError("Panic! Result of `parameter_names()` is malformed: " + str(res))
 
     def property_names(self, *, timeout:Optional[float] = None) -> List[Dict[str,Any]]:
         """Discover the list of property names currently in scope in the current context.

--- a/cryptol-remote-api/python/tests/cryptol/test-files/Names.cry
+++ b/cryptol-remote-api/python/tests/cryptol/test-files/Names.cry
@@ -1,0 +1,33 @@
+module Names where
+
+// Examples of names included in `names()` (term names)
+
+parameter
+  key : [64]
+
+enc : [64] -> [64]
+enc x = x ^ key
+
+enc_correct : [64] -> Bit
+property enc_correct x =
+  x == enc (enc x)
+
+primitive prim : [64] -> [64]
+
+(-!) : [64] -> [64] -> [64]
+x -! y = if y > x then 0 else x - y
+
+// Examples of names not included in `names()` (type and module names)
+
+parameter
+  type a : #
+
+type b = a
+
+type constraint fin_b = fin b
+
+primitive type c : *
+
+newtype d = { un_d : c }
+
+submodule M where

--- a/cryptol-remote-api/python/tests/cryptol/test_names.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_names.py
@@ -15,7 +15,7 @@ class TestNames(unittest.TestCase):
         # names()
 
         expected_names = [
-            {'module': 'Names', 'name': 'key', 'parameter': [] },
+            {'module': 'Names', 'name': 'key', 'parameter': () },
             {'module': 'Names', 'name': 'enc' },
             {'module': 'Names', 'name': 'enc_correct', 'pragmas': ['property'] },
             {'module': 'Names', 'name': 'prim' },

--- a/cryptol-remote-api/python/tests/cryptol/test_names.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_names.py
@@ -1,0 +1,56 @@
+import unittest
+from pathlib import Path
+import unittest
+import cryptol
+from cryptol.single_connection import *
+
+def names_dict_to_names(names_dict, *, module):
+    return [ {"module": module, "name": n, **vs} for n,vs in names_dict.items() ]
+
+def filter_names(names, *, module, fields_to_exclude):
+    return [ { k:v for k,v in n.items() if k not in fields_to_exclude } for n in names if n["module"] == module ]
+
+class TestNames(unittest.TestCase):
+    def test_names(self):
+        connect(verify=False)
+        load_file(str(Path('tests','cryptol','test-files', 'Names.cry')))
+
+        # names()
+
+        expected_names_dict = {
+            'key': {'parameter': True},
+            'enc': {},
+            'enc_correct': {'pragmas': ['property']},
+            'prim': {},
+            '(-!)': {'infix': True, 'infix associativity': 'left-associative', 'infix level': 100}
+        }
+        expected_names = names_dict_to_names(expected_names_dict, module="Names")
+
+        names_to_check = filter_names(names(), module="Names", fields_to_exclude=["type", "type string"])
+
+        self.assertCountEqual(expected_names, names_to_check)
+
+        # property_names()
+
+        expected_props_dict = {
+            "enc_correct": expected_names_dict["enc_correct"]
+        }
+        expected_props = names_dict_to_names(expected_props_dict, module="Names")
+
+        props_to_check = filter_names(property_names(), module="Names", fields_to_exclude=["type", "type string"])
+
+        self.assertCountEqual(expected_props, props_to_check)
+
+        # parameter_names()
+
+        expected_params_dict = {
+            "key": expected_names_dict["key"]
+        }
+        expected_params = names_dict_to_names(expected_params_dict, module="Names")
+        
+        params_to_check = filter_names(parameter_names(), module="Names", fields_to_exclude=["type", "type string"])
+
+        self.assertCountEqual(expected_params, params_to_check)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cryptol-remote-api/python/tests/cryptol/test_names.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_names.py
@@ -4,9 +4,6 @@ import unittest
 import cryptol
 from cryptol.single_connection import *
 
-def names_dict_to_names(names_dict, *, module):
-    return [ {"module": module, "name": n, **vs} for n,vs in names_dict.items() ]
-
 def filter_names(names, *, module, fields_to_exclude):
     return [ { k:v for k,v in n.items() if k not in fields_to_exclude } for n in names if n["module"] == module ]
 
@@ -17,14 +14,13 @@ class TestNames(unittest.TestCase):
 
         # names()
 
-        expected_names_dict = {
-            'key': {'parameter': True},
-            'enc': {},
-            'enc_correct': {'pragmas': ['property']},
-            'prim': {},
-            '(-!)': {'infix': True, 'infix associativity': 'left-associative', 'infix level': 100}
-        }
-        expected_names = names_dict_to_names(expected_names_dict, module="Names")
+        expected_names = [
+            {'module': 'Names', 'name': 'key', 'parameter': True },
+            {'module': 'Names', 'name': 'enc' },
+            {'module': 'Names', 'name': 'enc_correct', 'pragmas': ['property'] },
+            {'module': 'Names', 'name': 'prim' },
+            {'module': 'Names', 'name': '(-!)', 'infix': True, 'infix associativity': 'left-associative', 'infix level': 100 }
+        ]
 
         names_to_check = filter_names(names(), module="Names", fields_to_exclude=["type", "type string"])
 
@@ -32,10 +28,8 @@ class TestNames(unittest.TestCase):
 
         # property_names()
 
-        expected_props_dict = {
-            "enc_correct": expected_names_dict["enc_correct"]
-        }
-        expected_props = names_dict_to_names(expected_props_dict, module="Names")
+        prop_names = ['enc_correct']
+        expected_props = [ n for n in expected_names if n['name'] in prop_names ]
 
         props_to_check = filter_names(property_names(), module="Names", fields_to_exclude=["type", "type string"])
 
@@ -43,11 +37,9 @@ class TestNames(unittest.TestCase):
 
         # parameter_names()
 
-        expected_params_dict = {
-            "key": expected_names_dict["key"]
-        }
-        expected_params = names_dict_to_names(expected_params_dict, module="Names")
-        
+        param_names = ['key']
+        expected_params = [ n for n in expected_names if n['name'] in param_names ]
+
         params_to_check = filter_names(parameter_names(), module="Names", fields_to_exclude=["type", "type string"])
 
         self.assertCountEqual(expected_params, params_to_check)

--- a/cryptol-remote-api/python/tests/cryptol/test_names.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_names.py
@@ -15,11 +15,11 @@ class TestNames(unittest.TestCase):
         # names()
 
         expected_names = [
-            {'module': 'Names', 'name': 'key', 'parameter': True },
+            {'module': 'Names', 'name': 'key', 'parameter': [] },
             {'module': 'Names', 'name': 'enc' },
             {'module': 'Names', 'name': 'enc_correct', 'pragmas': ['property'] },
             {'module': 'Names', 'name': 'prim' },
-            {'module': 'Names', 'name': '(-!)', 'infix': True, 'infix associativity': 'left-associative', 'infix level': 100 }
+            {'module': 'Names', 'name': '(-!)', 'infix': {'associativity': 'left-associative', 'level': 100} }
         ]
 
         names_to_check = filter_names(names(), module="Names", fields_to_exclude=["type", "type string"])

--- a/cryptol-remote-api/src/CryptolServer/Data/Type.hs
+++ b/cryptol-remote-api/src/CryptolServer/Data/Type.hs
@@ -106,7 +106,7 @@ instance JSON.ToJSON JSONType where
           (other, otherArgs) ->
             [ "type" .= T.pack "unknown"
             , "constructor" .= show other
-            , "arguments" .= show otherArgs
+            , "arguments" .= map (JSONType ns) otherArgs
             ]
       convert (TCon (TF tf) args) =
         JSON.object
@@ -204,7 +204,7 @@ instance JSON.ToJSON JSONType where
           (pc', args') ->
             [ "prop" .= T.pack "unknown"
             , "constructor" .= show pc'
-            , "arguments" .= show args'
+            , "arguments" .= map (JSONType ns) args'
             ]
       convert (TVar v) =
         JSON.object

--- a/cryptol-remote-api/src/CryptolServer/Names.hs
+++ b/cryptol-remote-api/src/CryptolServer/Names.hs
@@ -55,23 +55,29 @@ instance Doc.DescribedMethod VisibleNamesParams [NameInfo] where
     , ("module",
       Doc.Paragraph [Doc.Text "A human-readable representation of the module from which the name originates"])
     , ("parameter",
-      Doc.Paragraph [Doc.Text "An optional field which is present and True iff the name is a module parameter"])
+      Doc.Paragraph [ Doc.Text "An optional field which is present and ",
+                      Doc.Literal "True", Doc.Text " iff the name is a module parameter" ])
     , ("infix",
-      Doc.Paragraph [Doc.Text "An optional field which is present and True iff the name is an infix operator"])
+      Doc.Paragraph [ Doc.Text "An optional field which is present and ",
+                      Doc.Literal "True", Doc.Text " iff the name is an infix operator" ])
     , ("infix associativity",
-      Doc.Paragraph [ Doc.Text "An optional field containing one of the strings \"left-associative\", "
-                    , Doc.Text "\"right-associative\", or \"non-associative\", if the name is an infix operator"])
+      Doc.Paragraph [ Doc.Text "An optional field containing one of the strings ",
+                      Doc.Literal "left-associative", Doc.Text ", ",
+                      Doc.Literal "right-associative", Doc.Text ", or ",
+                      Doc.Literal "non-associative", Doc.Text " if the name is an infix operator" ])
     , ("infix level",
-      Doc.Paragraph [ Doc.Text "An optional field containing the name's precedence level, if the name is an infix operator"])
+      Doc.Paragraph [ Doc.Text "An optional field containing the name's precedence level, ",
+                      Doc.Text "if the name is an infix operator" ])
     , ("pragmas",
-      Doc.Paragraph [Doc.Text "An optional field containing a list of the name's pragmas (e.g. \"property\"), if it has any"])
+      Doc.Paragraph [ Doc.Text "An optional field containing a list of the name's pragmas (e.g. ",
+                      Doc.Literal "property", Doc.Text "), if it has any"])
     , ("documentation",
       Doc.Paragraph [Doc.Text "An optional field containing documentation string for the name, if it is documented"])
     ]
 
 visibleNamesDescr :: Doc.Block
 visibleNamesDescr =
-  Doc.Paragraph [Doc.Text "List the currently visible (i.e., in scope) names."]
+  Doc.Paragraph [Doc.Text "List the currently visible (i.e., in scope) term names."]
 
 visibleNames :: VisibleNamesParams -> CryptolCommand [NameInfo]
 visibleNames _ =

--- a/cryptol-remote-api/src/CryptolServer/Names.hs
+++ b/cryptol-remote-api/src/CryptolServer/Names.hs
@@ -55,19 +55,15 @@ instance Doc.DescribedMethod VisibleNamesParams [NameInfo] where
     , ("module",
       Doc.Paragraph [Doc.Text "A human-readable representation of the module from which the name originates"])
     , ("parameter",
-      Doc.Paragraph [ Doc.Text "An optional field which is present and ",
-                      Doc.Literal "True", Doc.Text " iff the name is a module parameter" ])
+      Doc.Paragraph [ Doc.Text "An optional field which is present iff the name is a module parameter" ])
     , ("infix",
-      Doc.Paragraph [ Doc.Text "An optional field which is present and ",
-                      Doc.Literal "True", Doc.Text " iff the name is an infix operator" ])
-    , ("infix associativity",
-      Doc.Paragraph [ Doc.Text "An optional field containing one of the strings ",
+      Doc.Paragraph [ Doc.Text "An optional field which is present iff the name is an infix operator. ",
+                      Doc.Text "If present, it contains an object with two fields. One field is ",
+                      Doc.Literal "associativity", Doc.Text ", containing one of the strings ",
                       Doc.Literal "left-associative", Doc.Text ", ",
                       Doc.Literal "right-associative", Doc.Text ", or ",
-                      Doc.Literal "non-associative", Doc.Text " if the name is an infix operator" ])
-    , ("infix level",
-      Doc.Paragraph [ Doc.Text "An optional field containing the name's precedence level, ",
-                      Doc.Text "if the name is an infix operator" ])
+                      Doc.Literal "non-associative", Doc.Text ", and the other is ",
+                      Doc.Literal "level", Doc.Text ", containing the name's precedence level." ])
     , ("pragmas",
       Doc.Paragraph [ Doc.Text "An optional field containing a list of the name's pragmas (e.g. ",
                       Doc.Literal "property", Doc.Text "), if it has any"])
@@ -122,10 +118,10 @@ instance JSON.ToJSON NameInfo where
     , "type" .= JSONSchema schema
     , "module" .= modl
     ] ++
-    (if isParam then ["parameter" .= isParam] else []) ++
+    (if isParam then ["parameter" .= ()] else []) ++
     maybe [] (\(assoc, lvl) ->
-              [ "infix" .= True
-              , "infix associativity" .= assoc
-              , "infix level" .= lvl ]) fixity ++
+              ["infix" .= JSON.object
+                          [ "associativity" .= assoc
+                          , "level" .= lvl ]]) fixity ++
     (if null pragmas then [] else ["pragmas" .= pragmas]) ++
     maybe [] (\d -> ["documentation" .= d]) nameDocs


### PR DESCRIPTION
As touched upon in #1492, currently the remote API does not provide as much information about names as the `browse` command does in the REPL. This PR expands the result of the `visible names` method (i.e. `names()` in the Python API) to include:
- all the additional information provided by the `browse` command (i.e. what module the name is from, whether or not it is a parameter, and whether or it not it is a property), as well as
- fixity information (i.e. whether or not the name is an infix operator, and if so its associativity and precedence level).

This PR also adds the `property_names` and `parameter_names` functions to the Python API, which return only those names which are properties or parameters, respectively.

Finally, this PR also fixes a bug where `names()` would sometimes hang when a parameterized module is loaded.

See `test_names.py` for an example of this new output of `names` as well as the new the `property_names` and `parameter_names` functions.

Looking ahead: At some point it might also be nice to have `type_names` and `module_names` commands which return similar results to `names`, just for these other two distinct namespaces in Cryptol. It might also be nice to have an easy way to prove a property retrieved from `property_names`.