### PR TITLE
Make Cryptol.Utils.Types safe

### DIFF
--- a/src/Cryptol/Utils/Types.hs
+++ b/src/Cryptol/Utils/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 -- | Useful information about various types.
 module Cryptol.Utils.Types where
 


### PR DESCRIPTION
This PR fixes the typecheck failure "Cryptol.Utils.Types: Can't be safely imported!".