### PR TITLE
CI: Upgrade Poetry and Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.4.2
 
       - uses: haskell/actions/setup@v1
         id: setup-haskell
@@ -291,7 +291,7 @@ jobs:
       - if: matrix.suite == 'rpc'
         uses: abatilo/actions-poetry@v2.1.2
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.4.2
 
       - uses: actions/download-artifact@v2
         with:
@@ -427,7 +427,7 @@ jobs:
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
         uses: abatilo/actions-poetry@v2.1.2
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.4.2
 
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
         name: Test cryptol-remote-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
       - if: matrix.suite == 'rpc'
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.11'
 
       - if: matrix.suite == 'rpc'
         uses: abatilo/actions-poetry@v2.1.2
@@ -422,7 +422,7 @@ jobs:
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.11'
 
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
         uses: abatilo/actions-poetry@v2.1.2


### PR DESCRIPTION
The version we were previously using (1.1.6) is affected by this bug, causing invocations of Poetry to fail:
https://github.com/ionrock/cachecontrol/issues/292