### PR TITLE
Python: Use poetry.core.masonry.api as build-backend

### DIFF
--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -23,4 +23,5 @@ typing-extensions = "^4.1.1"
 mypy = "^0.991"
 
 [build-system]
-requires = ["poetry>=1.1.4", "setuptools>=40.8.0"]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This is motivated by a desire to switch away from `setuptools`, which has some unfortunate interactions with static analysis tools.

This also bumps the `argo` submodule to bring in the changes from https://github.com/GaloisInc/argo/pull/197, which applies similar changes.