### PR TITLE
Support building with `sbv-10.*`

### DIFF
--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -73,7 +73,7 @@ library
                        pretty,
                        prettyprinter     >= 1.7.0,
                        process           >= 1.2,
-                       sbv               >= 9.1 && < 9.3,
+                       sbv               >= 9.1 && < 10.2,
                        simple-smt        >= 0.9.7,
                        stm               >= 2.4,
                        strict,


### PR DESCRIPTION
`sbv-10.0` brings in two changes to the SBV internals that affect Cryptol.

1. `sbv-10.0` removes the `generateSMTBenchmark` function in favor of two separate `generateSMTBenchmarkSat` and `generateSMTBenchmarkProof` functions.
2. `sbv-10.0` removes the `allSatHasPrefixExistentials` field of `AllSatResult`.

We now use the appropriate CPP to make Cryptol compile before and after these changes.

Fixes #1513.