### PR TITLE
Enable Github CI build of documentation for all tags and PRs.

### DIFF
--- a/.github/gen_html_context.py
+++ b/.github/gen_html_context.py
@@ -1,0 +1,43 @@
+import os, sys
+
+# Run this script from one of the doc checkout dirs RefMan doc dir
+# (e.g. docs/ci_build_out/DIR/docs/RefMan})
+#
+# Arguments: owner/repository current_version
+
+d = os.listdir('../../..')
+bldtgt = lambda n: os.path.join('/', sys.argv[1].split('/')[1], n, 'RefMan.html')
+
+html_context={'current_version': sys.argv[2],
+              'versions':[(v, bldtgt(v)) for v in d if not v.startswith('PR_')],
+              'pull_reqs':[(v, bldtgt(v)) for v in d if v.startswith('PR_')]}
+
+if not os.path.isdir('_templates'):
+    # Older versions of the repo do not have this file present as it was only
+    # added in the global gh_pages support, so manually generate it here.
+    os.mkdir('_templates')
+    open('_templates/versions.html', 'w').write('''
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book">Doc version</span>
+    v: {{ current_version }}
+    <span class="fa fa-caret-down"></span>
+    <div class="rst-other-versions">
+      <dl>
+        <dt>{{ _('Versions') }}</dt>
+        {% for slug, url in versions %}
+        <dd><a href="{{ url }}">{{ slug }}</a></dd>
+        {% endfor %}
+      </dl>
+      <dl>
+        <dt>{{ _('Pull Requests') }}</dt>
+        {% for slug, url in pull_reqs %}
+        <dd><a href="{{ url }}">{{ slug }}</a></dd>
+        {% endfor %}
+      </dl>
+    </div>
+  </span>
+</div>
+''')
+
+print('html_context=',html_context)

--- a/.github/gen_html_context.py
+++ b/.github/gen_html_context.py
@@ -14,7 +14,14 @@ html_context={'current_version': sys.argv[2],
 
 if not os.path.isdir('_templates'):
     # Older versions of the repo do not have this file present as it was only
-    # added in the global gh_pages support, so manually generate it here.
+    # added in the global gh_pages support, so manually generate it here.  This
+    # is a duplicate of the existing _templates/versions.html.  Having it as an
+    # explicit HTML file will be easier to find and work with in the future,
+    # which is why this generator isn't the sole location of this HTML, at the
+    # cost of duplication.
+    #
+    # Once there are no pull requests that originated from before the latter file
+    # was part of master, this duplication here can be removed.
     os.mkdir('_templates')
     open('_templates/versions.html', 'w').write('''
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,18 +138,6 @@ jobs:
         run: .github/ci.sh check_rpc_docs
         if: runner.os != 'Windows'
 
-      - if: runner.os == 'Linux'
-        uses: docker://pandoc/latex:2.9.2
-        with:
-          args: >-
-            sh -c
-            "
-            apk add make &&
-            tlmgr install subfigure lastpage preprint adjustbox nag collectbox sectsty todonotes palatino mathpazo &&
-            cd docs &&
-            make
-            "
-
       - shell: bash
         name: Partition test-lib tests
         id: test-lib

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,8 +59,9 @@ jobs:
     # from those individual builds, but building the docs is relatively fast, so
     # it's simpler to do it here).  A top-level index file is created that allows
     # switching between the various versions of the documentation.  Then the
-    # final results are committed to the gh-pages branch so that the
-    # https://cryptol.github.io/ is useable to browse that documentation.
+    # final results are committed to the gh-pages branch so that
+    # https://galoisinc.github.io/cryptol is useable to browse that
+    # documentation.
     #
     # In order to accomplish the above, various clones of the repository must be
     # created that are switched to different branches/tags.  The github

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,18 +109,30 @@ jobs:
           mkdir ${TGTBASE}
           gh repo clone ${{ github.repositoryURL }} ${REFREPO}
           git -C ${REFREPO} switch --discard-changes master
+          echo local branches
+          git -C ${REFREPO} branch -l
+          echo remote branches
+          git -C ${REFREPO} branch -l -r
           for X in $(seq 0 $(( $(cat pulls.json | nix run nixpkgs#jq -- length) - 1))) ; do
             prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
             prbr=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].head.ref)
             tgt=${TGTBASE}/PR_${prnum}
             echo "Checkout Pull Request ${prbr} into PR_${prnum}"
-            mkdir $tgt
-            git clone ${REFREPO} ${tgt}
-            git -C ${tgt} switch --discard-changes ${prbr}
-            if [ ! -d ${tgt}/docs/RefMan ] ; then
-              echo "Removing ${tgt}: no RefMan docs in this version"
-              rm -rf ${tgt}
-            fi
+            (set -x
+             mkdir $tgt
+             git clone -b ${prbr} --single-branch ${REFREPO} ${tgt}
+             ls -a ${tgt}
+             echo lbr
+             git -C ${tgt} branch -l
+             echo rbr
+             git -C ${tgt} branch -l -r
+             echo switch
+             git -C ${tgt} switch --discard-changes ${prbr}
+             if [ ! -d ${tgt}/docs/RefMan ] ; then
+               echo "Removing ${tgt}: no RefMan docs in this version"
+               rm -rf ${tgt}
+             fi
+            )
           done
           for X in $(seq 0 $(( $(cat tags.json | nix run nixpkgs#jq -- length) - 1))) ; do
             tagname=$(cat tags.json | nix run nixpkgs#jq -- -r .[${X}].name)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -112,15 +112,16 @@ jobs:
           git -C ${REFREPO} fetch --all
           for X in $(seq 0 $(( $(cat pulls.json | nix run nixpkgs#jq -- length) - 1))) ; do
             prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
-            prbr=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].head.ref)
+            prref=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].merge_commit_sha)
             tgt=${TGTBASE}/PR_${prnum}
-            echo "Checkout Pull Request ${prbr} into PR_${prnum}"
+            echo "Checkout Pull Request ${prnum} at ${prref} into PR_${prnum}"
             mkdir $tgt
             # n.b. the switch here is important to make sure the branch is
             # present in the clone.
-            git -C ${REFREPO} switch --discard-changes ${prbr}
+            git -C ${REFREPO} fetch origin ${prref}
+            git -C ${REFREPO} checkout ${prref}
             git clone ${REFREPO} ${tgt}
-            git -C ${tgt} switch --discard-changes ${prbr}
+            git -C ${tgt} checkout ${prref}
             if [ ! -d ${tgt}/docs/RefMan ] ; then
               echo "Removing ${tgt}: no RefMan docs in this version"
               rm -rf ${tgt}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,8 +77,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     env:
-      # GH_TOKEN is used to enable the `gh repo clone` below.
-      GH_TOKEN: ${{ github.token }}
       # TGTBASE is used below as the working location to checkout and generate
       # documentation.  Can be changed for convenience.
       TGTBASE: docs/ci_build_out
@@ -107,44 +105,40 @@ jobs:
         run: |
           rm -rf ${TGTBASE}
           mkdir ${TGTBASE}
-          gh repo clone ${{ github.repositoryURL }} ${REFREPO}
-          git -C ${REFREPO} switch --discard-changes master
-          echo local branches
-          git -C ${REFREPO} branch -l
-          echo remote branches
-          git -C ${REFREPO} branch -l -r
+          # n.b. do not use github.repositoryURL for checkout: it is
+          # git:/github.com/owner/repo but that will fail in the context of
+          # github workflows; use an https reference instead:
+          git -c protocol.version=2 clone ${{ github.server_url }}/${{ github.repository }} ${REFREPO}
+          git -C ${REFREPO} fetch --all
           for X in $(seq 0 $(( $(cat pulls.json | nix run nixpkgs#jq -- length) - 1))) ; do
             prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
             prbr=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].head.ref)
             tgt=${TGTBASE}/PR_${prnum}
             echo "Checkout Pull Request ${prbr} into PR_${prnum}"
-            (set -x
-             mkdir $tgt
-             git clone -b ${prbr} --single-branch ${REFREPO} ${tgt}
-             ls -a ${tgt}
-             echo lbr
-             git -C ${tgt} branch -l
-             echo rbr
-             git -C ${tgt} branch -l -r
-             echo switch
-             git -C ${tgt} switch --discard-changes ${prbr}
-             if [ ! -d ${tgt}/docs/RefMan ] ; then
-               echo "Removing ${tgt}: no RefMan docs in this version"
-               rm -rf ${tgt}
-             fi
-            )
-          done
-          for X in $(seq 0 $(( $(cat tags.json | nix run nixpkgs#jq -- length) - 1))) ; do
-            tagname=$(cat tags.json | nix run nixpkgs#jq -- -r .[${X}].name)
-            tgt=${TGTBASE}/${tagname}
-            echo "Checkout Release Tag ${tagname} into ${tagname}"
+            mkdir $tgt
+            # n.b. the switch here is important to make sure the branch is
+            # present in the clone.
+            git -C ${REFREPO} switch --discard-changes ${prbr}
             git clone ${REFREPO} ${tgt}
-            git -C ${tgt} checkout --detach ${tagname}
+            git -C ${tgt} switch --discard-changes ${prbr}
             if [ ! -d ${tgt}/docs/RefMan ] ; then
               echo "Removing ${tgt}: no RefMan docs in this version"
               rm -rf ${tgt}
             fi
           done
+          for X in $(seq 0 $(( $(cat tags.json | nix run nixpkgs#jq -- length) - 1))) ; do
+            tagname=$(cat tags.json | nix run nixpkgs#jq -- -r .[${X}].name)
+            tgt=${TGTBASE}/${tagname}
+            echo "Checkout Release Tag ${tagname} into ${tagname}"
+            git -C ${REFREPO} checkout ${tagname}
+            git clone ${REFREPO} ${tgt}
+            git -C ${tgt} checkout ${tagname}
+            if [ ! -d ${tgt}/docs/RefMan ] ; then
+              echo "Removing ${tgt}: no RefMan docs in this version"
+              rm -rf ${tgt}
+            fi
+          done
+          git -C ${REFREPO} switch --discard-changes master
       - name: sphinx version config for each doc directory
         shell: bash
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,170 @@
+name: Cryptol Docs
+on:
+  push:
+    tags: ["[0-9]+.[0-9]+(.[0-9]+)?"]
+    branches: [master, "release-**"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Only run one of these at a time because they update the global pages.  Don't
+  # cancel existing runs
+  group: "cryptoldoc"
+  cancel-in-progress: false
+
+jobs:
+  # There are two jobs: building docs for this branch, and then
+  # building a full set of docs for and update the public interface.
+  build-branch-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-23.05
+      - name: build PDF docs
+        if: github.event.pull_request.head.repo.fork == false
+        uses: docker://pandoc/latex:2.9.2
+        with:
+          args: >-
+            sh -c
+            "
+            apk add make;
+            tlmgr install subfigure lastpage preprint adjustbox nag collectbox sectsty todonotes palatino mathpazo;
+            cd docs;
+            make
+            "
+      - name: build HTML docs
+        # This builds the docs for the current checked-out branch to verify they
+        # are buildable.
+        shell: bash
+        run: |
+          cd docs/RefMan
+          nix-shell \
+            -p 'python3.withPackages (pp: [pp.sphinx pp.sphinx_rtd_theme])' \
+            --run 'make html'
+  build-pages-docs:
+    runs-on: ubuntu-latest
+    # The public interface should then allow the user to browse the cryptol
+    # documentation at the master branch, but also the documentation associated
+    # with each pull request and each tag (where a tag typically represents a
+    # released version).
+    #
+    # The general process is to checkout a version of the repository at each
+    # pull-request branch and each tag.  Then the html documentation is generated
+    # for each (a more complicate scheme would access artifacts of the doc builds
+    # from those individual builds, but building the docs is relatively fast, so
+    # it's simpler to do it here).  A top-level index file is created that allows
+    # switching between the various versions of the documentation.  Then the
+    # final results are committed to the gh-pages branch so that the
+    # https://cryptol.github.io/ is useable to browse that documentation.
+    #
+    # In order to accomplish the above, various clones of the repository must be
+    # created that are switched to different branches/tags.  The github
+    # action/checkout unfortunately is not useable for this, and it does not
+    # leave the repository it checked out in a state that it can be used for this
+    # (it removes branch references and authentication).  The solution here then
+    # uses the GH_TOKEN and the `gh` API tool to interact with github to get a
+    # full reference checkout from which it can then create these ref-specific
+    # checkouts.
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      # GH_TOKEN is used to enable the `gh repo clone` below.
+      GH_TOKEN: ${{ github.token }}
+      # TGTBASE is used below as the working location to checkout and generate
+      # documentation.  Can be changed for convenience.
+      TGTBASE: docs/ci_build_out
+      REFREPO: docs/ci_build_out/master
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-23.05
+      - name: tags and pull requests
+        shell: bash
+        run: |
+          curl ${{ github.api_url }}/repos/${{ github.repository }}/pulls > pulls.json
+          curl ${{ github.api_url }}/repos/${{ github.repository }}/tags > tags.json
+      - name: checkout all doc versions
+        shell: bash
+        # Would like to clone from what we've already checked out, but
+        # actions/checkout seems to remove a lot of the critical
+        # references. [Side note: why is actions/checkout so complicated?  There
+        # are some controls, but it's a bunch of typescript that compiles to over
+        # 18,000 lines of JS that gets executed by nodejs to run a couple of
+        # shell commands!]  I think we can make this easier here
+        run: |
+          rm -rf ${TGTBASE}
+          mkdir ${TGTBASE}
+          gh repo clone ${{ github.repositoryURL }} ${REFREPO}
+          git -C ${REFREPO} switch --discard-changes master
+          for X in $(seq 0 $(( $(cat pulls.json | nix run nixpkgs#jq -- length) - 1))) ; do
+            prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
+            prbr=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].head.ref)
+            tgt=${TGTBASE}/PR_${prnum}
+            echo "Checkout Pull Request ${prbr} into PR_${prnum}"
+            mkdir $tgt
+            git clone ${REFREPO} ${tgt}
+            git -C ${tgt} switch --discard-changes ${prbr}
+            if [ ! -d ${tgt}/docs/RefMan ] ; then
+              echo "Removing ${tgt}: no RefMan docs in this version"
+              rm -rf ${tgt}
+            fi
+          done
+          for X in $(seq 0 $(( $(cat tags.json | nix run nixpkgs#jq -- length) - 1))) ; do
+            tagname=$(cat tags.json | nix run nixpkgs#jq -- -r .[${X}].name)
+            tgt=${TGTBASE}/${tagname}
+            echo "Checkout Release Tag ${tagname} into ${tagname}"
+            git clone ${REFREPO} ${tgt}
+            git -C ${tgt} checkout --detach ${tagname}
+            if [ ! -d ${tgt}/docs/RefMan ] ; then
+              echo "Removing ${tgt}: no RefMan docs in this version"
+              rm -rf ${tgt}
+            fi
+          done
+      - name: sphinx version config for each doc directory
+        shell: bash
+        run: |
+          topdir=$(pwd)
+          for tgt in ${TGTBASE}/* ; do
+            echo "Setting RefMan config in ${tgt}"
+            (cd ${tgt}/docs/RefMan
+             nix run nixpkgs#python3 -- ${topdir}/.github/gen_html_context.py ${{ github.repository }} $(basename ${tgt}) >> conf.py
+            )
+          done
+      - name: docs for each tag and pull request
+        shell: bash
+        # Do not fail if a particular set of docs doesn't build, just echo an
+        # error message placeholder for that set.
+        run: |
+          for tgt in ${TGTBASE}/* ; do
+            (cd ${tgt}/docs/RefMan;
+             echo Building HTML docs in ${tgt}/docs/RefMan
+             nix-shell \
+               -p 'python3.withPackages (pp: [pp.sphinx pp.sphinx_rtd_theme])' \
+               --run 'make html'
+            ) || (
+             echo "Unable to generate documentation for this release" > ${tgt}/docs/RefMan/_build/html/RefMan.html
+            )
+            mv ${tgt}/docs/RefMan/_build/html docs/RefMan/_build/$(basename ${tgt})
+          done
+          cp docs/index.html docs/RefMan/_build/index.html
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'docs/RefMan/_build'
+      - name: Deploy to github pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,11 @@
 
 * Declarations may now use *numeric constraint guards*.   This is a feature
   that allows a function to behave differently depending on its numeric
-  type parameters.  See the [manual section](https://galoisinc.github.io/cryptol/RefMan/_build/html/BasicSyntax.html#numeric-constraint-guards))
+  type parameters.  See the [manual section](https://galoisinc.github.io/cryptol/master/BasicSyntax.html#numeric-constraint-guards))
   for more information.
 
 * The foreign function interface (FFI) has been added, which allows Cryptol to
-  call functions written in C. See the [manual section](https://galoisinc.github.io/cryptol/RefMan/_build/html/FFI.html)
+  call functions written in C. See the [manual section](https://galoisinc.github.io/cryptol/master/FFI.html)
   for more information.
 
 * The unary `-` operator now has the same precedence as binary `-`, meaning

--- a/docs/RefMan/_templates/versions.html
+++ b/docs/RefMan/_templates/versions.html
@@ -1,0 +1,21 @@
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book">Doc version</span>
+    v: {{ current_version }}
+    <span class="fa fa-caret-down"></span>
+    <div class="rst-other-versions">
+      <dl>
+        <dt>{{ _('Versions') }}</dt>
+        {% for slug, url in versions %}
+        <dd><a href="{{ url }}">{{ slug }}</a></dd>
+        {% endfor %}
+      </dl>
+      <dl>
+        <dt>{{ _('Pull Requests') }}</dt>
+        {% for slug, url in pull_reqs %}
+        <dd><a href="{{ url }}">{{ slug }}</a></dd>
+        {% endfor %}
+      </dl>
+    </div>
+  </span>
+</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <head>
 <title>Cryptol Documentation</title>
 <meta http-equiv="refresh"
-      content="0; url=https://kquick.github.io/cryptol2/master/RefMan.html">
+      content="0; url=https://galoisinc.github.io/cryptol/master/RefMan.html">
 </head>
 <body>
 <a href="master/RefMan.html">Cryptol Reference Manual</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<title>Crytpol Documentation</title>
+<title>Cryptol Documentation</title>
 <meta http-equiv="refresh"
-      content="0; url=https://galoisinc.github.io/cryptol/RefMan/_build/html/RefMan.html">
+      content="0; url=https://kquick.github.io/cryptol2/master/RefMan.html">
 </head>
 <body>
-<a href="RefMan/_build/html/RefMan.html">Crytpol Reference Manual</a>
+<a href="master/RefMan.html">Cryptol Reference Manual</a>
 </body>
 </html>


### PR DESCRIPTION
Updates Github CI process to publish multiple versions of the documentation to the online documentation (github-pages) site.  Originally, only master documentation was deployed.  This change means that there are alternate versions of the documentation available (via a selector on the documentation page) for every PR and every tagged version (for which documentation is available, starting with v2.12.0).