### PR TITLE
Add sorting to version/PR on generated documents index.

### DIFF
--- a/.github/gen_html_context.py
+++ b/.github/gen_html_context.py
@@ -9,8 +9,8 @@ d = os.listdir('../../..')
 bldtgt = lambda n: os.path.join('/', sys.argv[1].split('/')[1], n, 'RefMan.html')
 
 html_context={'current_version': sys.argv[2],
-              'versions':[(v, bldtgt(v)) for v in d if not v.startswith('PR_')],
-              'pull_reqs':[(v, bldtgt(v)) for v in d if v.startswith('PR_')]}
+              'versions':sorted([(v, bldtgt(v)) for v in d if not v.startswith('PR_')]),
+              'pull_reqs':sorted([(v, bldtgt(v)) for v in d if v.startswith('PR_')])}
 
 if not os.path.isdir('_templates'):
     # Older versions of the repo do not have this file present as it was only

--- a/docs/RefMan/_templates/versions.html
+++ b/docs/RefMan/_templates/versions.html
@@ -6,13 +6,13 @@
     <div class="rst-other-versions">
       <dl>
         <dt>{{ _('Versions') }}</dt>
-        {% for slug, url in versions %}
+        {% for slug, url in versions|dictsort %}
         <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}
       </dl>
       <dl>
         <dt>{{ _('Pull Requests') }}</dt>
-        {% for slug, url in pull_reqs %}
+        {% for slug, url in pull_reqs|dictsort %}
         <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}
       </dl>

--- a/docs/RefMan/_templates/versions.html
+++ b/docs/RefMan/_templates/versions.html
@@ -6,13 +6,13 @@
     <div class="rst-other-versions">
       <dl>
         <dt>{{ _('Versions') }}</dt>
-        {% for slug, url in versions|dictsort %}
+        {% for slug, url in versions %}
         <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}
       </dl>
       <dl>
         <dt>{{ _('Pull Requests') }}</dt>
-        {% for slug, url in pull_reqs|dictsort %}
+        {% for slug, url in pull_reqs %}
         <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}
       </dl>


### PR DESCRIPTION
This ensures that the versions and pull-requests presented in the online document selection list are in sorted order to make it easier to find the desired version of the documents.