### PR TITLE
`test.Dockerfile`: Sync Python, Poetry versions with CI

### DIFF
--- a/cryptol-remote-api/test.Dockerfile
+++ b/cryptol-remote-api/test.Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.7
+FROM python:3.11
 # Intended to be built from the root of the cryptol git repository
 
 COPY cryptol-remote-api/python python
-RUN pip3 install 'poetry==1.1.5'
+RUN pip3 install 'poetry==1.4.2'
 RUN cd python && poetry install
 COPY cryptol-remote-api/test-cryptol-remote-api.py /python/entrypoint.py
 WORKDIR /python


### PR DESCRIPTION
This really ought to have been done at the same time as #1493/#1519, but this was overlooked due to CI-related oversights.

Without these changes, the `cryptol-remote-api` Docker image fails to build. (This was something I noticed when preparing the 3.0.0 release.) Once this lands, I will push these to the `release-3.0.0` branch as well.