### PR TITLE
cryptol-remote-api script shebang fixes

### DIFF
--- a/cryptol-remote-api/check_docs.sh
+++ b/cryptol-remote-api/check_docs.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -7,6 +7,7 @@ cd $DIR/docs
 export CRYPTOL_SERVER=$(cabal v2-exec which cryptol-remote-api)
 if [[ ! -x "$CRYPTOL_SERVER" ]]; then
   echo "could not locate cryptol-remote-api executable - try executing with cabal v2-exec"
+  echo "or try building with 'cabal build cryptol-remote-api'"
   exit 1
 fi
 

--- a/cryptol-remote-api/run_rpc_tests.sh
+++ b/cryptol-remote-api/run_rpc_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/cryptol-remote-api/test_docker.sh
+++ b/cryptol-remote-api/test_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
This is the same as #1525 , but that one was on my fork that I was using to test the online doc generations, and I deleted the fork but forgot to merge 1525. 