### PR TITLE
Sanitize strings in `to_cryptol_str` in quoting.py

### DIFF
--- a/cryptol-remote-api/python/cryptol/bitvector.py
+++ b/cryptol-remote-api/python/cryptol/bitvector.py
@@ -149,7 +149,7 @@ class BV:
 
     def to_signed_int(self) -> int:
         """Return the signed (i.e., two's complement) integer the ``BV`` represents."""
-        if not self.msb():
+        if self.__size == 0 or not self.msb():
             n = self.__value
         else:
             n = 0 - ((2 ** self.__size) - self.__value)

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -29,7 +29,8 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolJSON]) -> str:
     elif isinstance(val, OpaqueValue):
         return str(val)
     elif isinstance(val, str):
-        return f'"{val}"'
+        val_san = val.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
+        return f'"{val_san}"'
     elif hasattr(val, '__to_cryptol_str__'):
         return parenthesize(val.__to_cryptol_str__())
     else:

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -14,6 +14,8 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolJSON]) -> str:
     if isinstance(val, bool):
         return 'True' if val else 'False'
     elif isinstance(val, tuple):
+        if len(val) == 1:
+            raise TypeError("Unable to convert 1-tuple to Cryptol syntax: " + str(val))
         return '(' + ', '.join(to_cryptol_str(x) for x in val) + ')'
     elif isinstance(val, dict):
         return '{' + ', '.join(f'{k} = {to_cryptol_str(v)}' for k,v in val.items()) + '}'
@@ -22,7 +24,7 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolJSON]) -> str:
     elif isinstance(val, list):
         return '[' + ', '.join(to_cryptol_str(x) for x in val) + ']'
     elif isinstance(val, BV):
-        if val.size() % 4 == 0:
+        if val.size() > 0 and val.size() % 4 == 0:
             return val.hex()
         else:
             return f'({val.to_signed_int()} : [{val.size()}])'

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -29,9 +29,8 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolJSON]) -> str:
     elif isinstance(val, OpaqueValue):
         return str(val)
     elif isinstance(val, str):
-        # Sanitizing strings for Cryptol - see <string> of src/Cryptol/Parser/Lexer.x
-        val_san = val.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
-        return f'"{val_san}"'
+        chars = list(val.encode('latin-1'))
+        return f'({to_cryptol_str(chars)} : [{len(chars)}][8])'
     elif hasattr(val, '__to_cryptol_str__'):
         return parenthesize(val.__to_cryptol_str__())
     else:

--- a/cryptol-remote-api/python/cryptol/quoting.py
+++ b/cryptol-remote-api/python/cryptol/quoting.py
@@ -29,6 +29,7 @@ def to_cryptol_str(val : Union[CryptolValue, str, CryptolJSON]) -> str:
     elif isinstance(val, OpaqueValue):
         return str(val)
     elif isinstance(val, str):
+        # Sanitizing strings for Cryptol - see <string> of src/Cryptol/Parser/Lexer.x
         val_san = val.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
         return f'"{val_san}"'
     elif hasattr(val, '__to_cryptol_str__'):

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -35,6 +35,9 @@ class TestQuoting(unittest.TestCase):
 
         s = '" \n ÿ \\'
         self.assertEqual(cry_f('{s}'), cry('([34, 32, 10, 32, 255, 32, 92] : [7][8])')) # "\" \n ÿ \\"
+        self.assertEqual(cry_eval_f('{s}'), [BV(8,c) for c in [34, 32, 10, 32, 255, 32, 92]])
+        with self.assertRaises(UnicodeEncodeError):
+            cry_f('{"π"}') # 'latin-1' codec can't encode character (960 >= 256)
 
         # Only here to check backwards compatability, the above syntax is preferred
         y = cry('g')(cry_f('{x}'))

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -33,6 +33,9 @@ class TestQuoting(unittest.TestCase):
         self.assertEqual(cry_f('id {5:#x}'),    cry('id "0x5"'))
         self.assertEqual(cry_f('id {BV(4,5)}'), cry('id 0x5'))
 
+        s = '" \ \n'
+        self.assertEqual(cry_f('{s}'), cry('"\\" \\\\ \\n"'))
+
         # Only here to check backwards compatability, the above syntax is preferred
         y = cry('g')(cry_f('{x}'))
         z = cry('h')(cry_f('{y}'))

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -29,12 +29,12 @@ class TestQuoting(unittest.TestCase):
         self.assertEqual(cry_f('{{a = {x}, b = {x}}}'), cry('{a = 0x01, b = 0x01}'))
 
         self.assertEqual(cry_f('id {5}'),       cry('id 5'))
-        self.assertEqual(cry_f('id {5!s}'),     cry('id "5"'))
-        self.assertEqual(cry_f('id {5:#x}'),    cry('id "0x5"'))
+        self.assertEqual(cry_f('id {5!s}'),     cry('id ([53] : [1][8])')) # id "5"
+        self.assertEqual(cry_f('id {5:#x}'),    cry('id ([48, 120, 53] : [3][8])')) # id "0x5"
         self.assertEqual(cry_f('id {BV(4,5)}'), cry('id 0x5'))
 
-        s = '" \ \n'
-        self.assertEqual(cry_f('{s}'), cry('"\\" \\\\ \\n"'))
+        s = '" \n ÿ \\'
+        self.assertEqual(cry_f('{s}'), cry('([34, 32, 10, 32, 255, 32, 92] : [7][8])')) # "\" \n ÿ \\"
 
         # Only here to check backwards compatability, the above syntax is preferred
         y = cry('g')(cry_f('{x}'))

--- a/cryptol-remote-api/python/tests/cryptol/test_quoting.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_quoting.py
@@ -24,9 +24,14 @@ class TestQuoting(unittest.TestCase):
 
         self.assertEqual(cry_f('id {BV(size=7, value=1)}'), cry('id (1 : [7])'))
         self.assertEqual(cry_eval_f('id {BV(size=7, value=1)}'), BV(size=7, value=1))
+        self.assertEqual(cry_f('id {BV(size=0, value=0)}'), cry('id (0 : [0])'))
+        self.assertEqual(cry_eval_f('id {BV(size=0, value=0)}'), BV(size=0, value=0))
 
         self.assertEqual(cry_f('{ {"a": x, "b": x} }'), cry('{a = 0x01, b = 0x01}'))
         self.assertEqual(cry_f('{{a = {x}, b = {x}}}'), cry('{a = 0x01, b = 0x01}'))
+
+        with self.assertRaises(TypeError):
+            cry_f('{(0,)}') # Cryptol does not have 1-tuples
 
         self.assertEqual(cry_f('id {5}'),       cry('id 5'))
         self.assertEqual(cry_f('id {5!s}'),     cry('id ([53] : [1][8])')) # id "5"


### PR DESCRIPTION
This PR updates `to_cryptol_str` to correctly sanitize strings. For example, if `s = '" \ \n'`, then `cry_f('{s}')` now correctly gives `'"\\" \\\\ \\n"'` instead of the unescaped `'"" \\ \n"'`.