### PR TITLE
Modernize the `README` slightly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2020 Galois Inc.
+Copyright (c) 2013-2023 Galois Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE.rtf
+++ b/LICENSE.rtf
@@ -4,7 +4,7 @@
 \margl1440\margr1440\vieww12600\viewh7800\viewkind0
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
 
-\f0\fs24 \cf0 Copyright (c) 2013-2020 Galois Inc.\
+\f0\fs24 \cf0 Copyright (c) 2013-2023 Galois Inc.\
 All rights reserved.\
 \
 Redistribution and use in source and binary forms, with or without\

--- a/README.md
+++ b/README.md
@@ -205,20 +205,20 @@ and by cryptographers to
 ## Acknowledgements
 
 Cryptol has been under development for over a decade with many people
-contributing to its design and implementation. Those people include (but
-are not limited to) Aaron Tomb, Adam Foltzer, Adam Wick, Alexander
-Bakst, Andrew Kent, Andrei Stefanescu, Andrey Chudnov, Andy Gill,
-Benjamin Barenblat, Ben Jones, Ben Selfridge, Brett Boston, Brian
-Huffman, Brian Ledger, Chris Phifer, Daniel Wagner, David Thrane
-Christiansen, David Lazar, Dylan McNamee, Eddy Westbrook, Edward Yang,
-Eric Mertens, Eric Mullen, Fergus Henderson, Iavor Diatchki, Jared
-Weakly, Jeff Lewis, Jim Teisher, Joe Hendrix, Joe Hurd, Joe Kiniry, Joel
-Stanley, Joey Dodds, John Launchbury, John Matthews, Jonathan Daugherty,
-Kenneth Foner, Kevin Quick, Kyle Carter, Ledah Casburn, Lee Pike, Levent
-Erkök, Lisanna Dettwyler, Magnus Carlsson, Mark Shields, Mark Tullsen,
-Matt Sottile, Nathan Collins, Philip Weaver, Robert Dockins, Ryan Scott,
-Sally Browning, Sam Anklesaria, Sigbjørn Finne, Stephen Magill, Thomas
-Nordin, Trevor Elliott, and Tristan Ravitch.
+contributing to its design and implementation. Those people include (but are
+not limited to) Aaron Tomb, Adam Foltzer, Adam Wick, Alexander Bakst, Andrew
+Kent, Andrei Stefanescu, Andrey Chudnov, Andy Gill, Benjamin Barenblat, Ben
+Jones, Ben Selfridge, Brett Boston, Bretton Chen, Brian Huffman, Brian Ledger,
+Chris Phifer, Daniel Wagner, David Thrane Christiansen, David Lazar, Dylan
+McNamee, Eddy Westbrook, Edward Yang, Eric Mertens, Eric Mullen, Fergus
+Henderson, Hazel Weakly, Henry Blanchette, Iavor Diatchki, Jeff Lewis, Jim
+Teisher, Joe Hendrix, Joe Hurd, Joe Kiniry, Joel Stanley, Joey Dodds, John
+Launchbury, John Matthews, Jonathan Daugherty, Kenneth Foner, Kevin Quick, Kyle
+Carter, Ledah Casburn, Lee Pike, Levent Erkök, Lisanna Dettwyler, Magnus
+Carlsson, Mark Shields, Mark Tullsen, Matt Sottile, Matthew Yacavone, Nathan
+Collins, Philip Weaver, Robert Dockins, Ryan Scott, Sally Browning, Sam
+Anklesaria, Sigbjørn Finne, Stephen Magill, Thomas Nordin, Trevor Elliott, and
+Tristan Ravitch.
 
 Much of the work on Cryptol has been funded by, and lots of design input
 was provided by, the team at the [NSA's Laboratory for Advanced Cybersecurity

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/GaloisInc/cryptol)
 
 
-# Cryptol, version 2
+# Cryptol, version 3
 
     This version of Cryptol is (C) 2013-2020 Galois, Inc., and
     distributed under a standard, three-clause BSD license. Please see
@@ -19,7 +19,7 @@ Unlike current specification mechanisms, Cryptol is fully executable,
 allowing designers to experiment with their programs incrementally as
 their designs evolve.
 
-This release is an interpreter for version 2 of the Cryptol
+This release is an interpreter for version 3 of the Cryptol
 language. The interpreter includes a `:check` command, which tests
 predicates written in Cryptol against randomly-generated test vectors
 (in the style of

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Cryptol, version 3
 
-    This version of Cryptol is (C) 2013-2020 Galois, Inc., and
+    This version of Cryptol is (C) 2013-2023 Galois, Inc., and
     distributed under a standard, three-clause BSD license. Please see
     the file LICENSE, distributed with this software, for specific
     terms and conditions.

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "cryptol"
 version = "3.0.0.99"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
-description = "Cryptol client for the Cryptol 2.13 RPC server"
+description = "Cryptol client for the Cryptol RPC server"
 authors = ["Galois, Inc. <cryptol-team@galois.com>"]
 
 license = "BSD License"


### PR DESCRIPTION
* Mention version 3, not 2, of Cryptol. This fixes #1542
* Modernize the copyright years slightly
* Mention significant contributions from @qsctr, @Riib11, and @m-yac 