### PR TITLE
Add `version` command to cryptol-remote-api

### DIFF
--- a/cryptol-remote-api/CHANGELOG.md
+++ b/cryptol-remote-api/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision history for `cryptol-remote-api` and `cryptol-eval-server`
 
-## 3.0.1 -- YYYY-MM-DD
+## 3.0.2 -- YYYY-MM-DD
+
+*  NEW CHANGELOG ENTRIES SINCE 3.0.1 GO HERE
+
+## 3.0.1 -- 2023-07-10
 
 * Add `version` command for fetching Cryptol/`cryptol-remote-api` version
   information

--- a/cryptol-remote-api/CHANGELOG.md
+++ b/cryptol-remote-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for `cryptol-remote-api` and `cryptol-eval-server`
 
+## 3.0.1 -- YYYY-MM-DD
+
+* Add `version` command for fetching Cryptol/`cryptol-remote-api` version
+  information
+
 ## 3.0.0 -- 2023-06-26
 
 * The v3.0.0 release is made in tandem with the Cryptol 3.0.0 release. See the

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                cryptol-remote-api
-version:             3.0.0.99
+version:             3.0.1
 license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Galois, Inc.

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                cryptol-remote-api
-version:             3.0.1
+version:             3.0.1.99
 license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Galois, Inc.

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -85,6 +85,7 @@ library
 
   other-modules:
     CryptolServer.AesonCompat
+    Paths_cryptol_remote_api
 
 executable cryptol-remote-api
   import:              deps, warnings, errors

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -80,6 +80,7 @@ library
     CryptolServer.Names
     CryptolServer.Sat
     CryptolServer.TypeCheck
+    CryptolServer.Version
     CryptolServer.FileDeps
 
   other-modules:

--- a/cryptol-remote-api/cryptol-remote-api/Main.hs
+++ b/cryptol-remote-api/cryptol-remote-api/Main.hs
@@ -33,6 +33,7 @@ import CryptolServer.LoadModule
 import CryptolServer.Names ( visibleNames, visibleNamesDescr )
 import CryptolServer.Sat ( proveSat, proveSatDescr )
 import CryptolServer.TypeCheck ( checkType, checkTypeDescr )
+import CryptolServer.Version ( version, versionDescr )
 import CryptolServer.FileDeps( fileDeps, fileDepsDescr )
 
 main :: IO ()
@@ -69,6 +70,10 @@ getSearchPaths =
 cryptolMethods :: [AppMethod ServerState]
 cryptolMethods =
   [ command
+    "version"
+    versionDescr
+    version
+  , command
     "check"
     checkDescr
     check

--- a/cryptol-remote-api/docs/Cryptol.rst
+++ b/cryptol-remote-api/docs/Cryptol.rst
@@ -237,6 +237,52 @@ JSON representations of types are type schemas. A type schema has three fields:
 Methods
 -------
 
+version (command)
+~~~~~~~~~~~~~~~~~
+
+Version information about this Cryptol server.
+
+Parameter fields
+++++++++++++++++
+
+No parameters
+
+
+Return fields
++++++++++++++
+
+
+``RPC server version``
+  The cryptol-remote-api version string.
+  
+  
+
+``version``
+  The Cryptol version string.
+  
+  
+
+``commit hash``
+  The string of the git commit hash during the build of Cryptol.
+  
+  
+
+``commit branch``
+  The string of the git commit branch during the build of Cryptol.
+  
+  
+
+``commit dirty``
+  True iff non-committed files were present during the build of Cryptol.
+  
+  
+
+``FFI enabled``
+  True iff the FFI is enabled.
+  
+  
+
+
 check (command)
 ~~~~~~~~~~~~~~~
 

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision history for `cryptol` Python package
 
-## 3.0.1 -- YYYY-MM-DD
+## 3.0.2 -- YYYY-MM-DD
+
+*  NEW CHANGELOG ENTRIES SINCE 3.0.1 GO HERE
+
+## 3.0.1 -- 2023-07-10
 
 * Update `cry_f` to property handle strings, length-0 `BV`s, and 1-tuples
 * Add `version` command for fetching Cryptol/`cryptol-remote-api` version

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for `cryptol` Python package
 
+## 3.0.1 -- YYYY-MM-DD
+
+* Update `cry_f` to property handle strings, length-0 `BV`s, and 1-tuples
+* Add `version` command for fetching Cryptol/`cryptol-remote-api` version
+  information
+
 ## 3.0.0 -- 2023-06-26
 
 * The v3.0.0 release is made in tandem with the Cryptol 3.0.0 release. See the

--- a/cryptol-remote-api/python/cryptol/commands.py
+++ b/cryptol-remote-api/python/cryptol/commands.py
@@ -311,6 +311,18 @@ class CryptolFocusedModule(argo.Command):
         return res
 
 
+class CryptolVersion(argo.Command):
+    def __init__(self, connection : HasProtocolState, timeout: Optional[float]) -> None:
+        super(CryptolVersion, self).__init__(
+            'version',
+            {},
+            connection,
+            timeout=timeout)
+
+    def process_result(self, res : Any) -> Any:
+        return res
+
+
 class CryptolReset(argo.Notification):
     def __init__(self, connection : HasProtocolState) -> None:
         super(CryptolReset, self).__init__(

--- a/cryptol-remote-api/python/cryptol/connection.py
+++ b/cryptol-remote-api/python/cryptol/connection.py
@@ -421,6 +421,14 @@ class CryptolConnection:
         self.most_recent_result = CryptolFocusedModule(self, timeout)
         return self.most_recent_result
 
+    def version(self, *, timeout:Optional[float] = None) -> argo.Command:
+        """Returns version information about the Cryptol server.
+
+        :param timeout: Optional timeout for this request (in seconds)."""
+        timeout = timeout if timeout is not None else self.timeout
+        self.most_recent_result = CryptolVersion(self, timeout)
+        return self.most_recent_result
+
     def reset(self) -> None:
         """Resets the connection, causing its unique state on the server to be freed (if applicable).
 

--- a/cryptol-remote-api/python/cryptol/single_connection.py
+++ b/cryptol-remote-api/python/cryptol/single_connection.py
@@ -11,7 +11,7 @@ from .quoting import *
 from .solver import OfflineSmtQuery, Solver, OnlineSolver, OfflineSolver, Z3
 from .connection import CryptolValue, CheckReport
 from . import synchronous
-from .synchronous import Qed, Safe, Counterexample, Satisfiable, Unsatisfiable
+from .synchronous import Qed, Safe, Counterexample, Satisfiable, Unsatisfiable, CryptolVersionInfo
 from . import cryptoltypes
 
 
@@ -235,6 +235,10 @@ def property_names(*, timeout:Optional[float] = None) -> List[cryptoltypes.Crypt
 def focused_module(*, timeout:Optional[float] = None) -> cryptoltypes.CryptolModuleInfo:
     """Returns the name and other information about the currently-focused module."""
     return __get_designated_connection().focused_module(timeout=timeout)
+
+def version(*, timeout:Optional[float] = None) -> CryptolVersionInfo:
+    """Returns version information about the Cryptol server."""
+    return __get_designated_connection().version(timeout=timeout)
 
 def reset() -> None:
     """Resets the connection, causing its unique state on the server to be freed (if applicable).

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -78,6 +78,15 @@ class Unsatisfiable:
     def __nonzero__(self) -> Literal[False]:
         return False
 
+@dataclass
+class CryptolVersionInfo:
+    """Class containing version information about the Cryptol server."""
+    version: str
+    commit_hash: str
+    commit_branch: str
+    commit_dirty: bool
+    ffi_enabled: bool 
+
 
 def connect(command : Optional[str]=None,
             *,
@@ -376,6 +385,17 @@ class CryptolSyncConnection:
     def focused_module(self, *, timeout:Optional[float] = None) -> cryptoltypes.CryptolModuleInfo:
         """Returns the name and other information about the currently-focused module."""
         return cryptoltypes.to_cryptol_module_info(self.connection.focused_module(timeout=timeout).result())
+
+    def version(self, *, timeout:Optional[float] = None) -> CryptolVersionInfo:
+        """Returns version information about the Cryptol server."""
+        res = self.connection.version(timeout=timeout).result()
+        return CryptolVersionInfo(
+                version       = res['version'],
+                commit_hash   = res['commit hash'],
+                commit_branch = res['commit branch'],
+                commit_dirty  = res['commit dirty'],
+                ffi_enabled   = res['FFI enabled']
+                )
 
     def reset(self) -> None:
         """Resets the connection, causing its unique state on the server to be freed (if applicable).

--- a/cryptol-remote-api/python/cryptol/synchronous.py
+++ b/cryptol-remote-api/python/cryptol/synchronous.py
@@ -80,7 +80,17 @@ class Unsatisfiable:
 
 @dataclass
 class CryptolVersionInfo:
-    """Class containing version information about the Cryptol server."""
+    """
+    Class containing version information about the Cryptol server.
+
+    :param rpc_version: The cryptol-remote-api version string.
+    :param version: The Cryptol version string.
+    :param commit_hash: The string of the git commit hash during the build of Cryptol.
+    :param commit_branch: The string of the git commit branch during the build of Cryptol.
+    :param commit_dirty: True iff non-committed files were present during the build of Cryptol.
+    :param ffi_enabled: True iff the FFI is enabled.
+    """
+    rpc_version: str
     version: str
     commit_hash: str
     commit_branch: str
@@ -390,6 +400,7 @@ class CryptolSyncConnection:
         """Returns version information about the Cryptol server."""
         res = self.connection.version(timeout=timeout).result()
         return CryptolVersionInfo(
+                rpc_version   = res['RPC server version'],
                 version       = res['version'],
                 commit_hash   = res['commit hash'],
                 commit_branch = res['commit branch'],

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "3.0.0.99"
+version = "3.0.1"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol 2.13 RPC server"

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "3.0.1"
+version = "3.0.1.99"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol 2.13 RPC server"

--- a/cryptol-remote-api/src/CryptolServer/Version.hs
+++ b/cryptol-remote-api/src/CryptolServer/Version.hs
@@ -9,6 +9,7 @@ module CryptolServer.Version
 import qualified Argo.Doc as Doc
 import Data.Aeson as JSON
 
+import qualified Paths_cryptol_remote_api as RPC
 import qualified Cryptol.Version as Cry
 import Data.Version (showVersion)
 
@@ -21,11 +22,12 @@ versionDescr =
 
 version :: VersionParams -> CryptolCommand JSON.Value
 version _ =
-  return $ JSON.object [ "version"       .= showVersion Cry.version
-                       , "commit hash"   .= Cry.commitHash
-                       , "commit branch" .= Cry.commitBranch
-                       , "commit dirty"  .= Cry.commitDirty
-                       , "FFI enabled"   .= Cry.ffiEnabled
+  return $ JSON.object [ "RPC server version" .= showVersion RPC.version
+                       , "version"            .= showVersion Cry.version
+                       , "commit hash"        .= Cry.commitHash
+                       , "commit branch"      .= Cry.commitBranch
+                       , "commit dirty"       .= Cry.commitDirty
+                       , "FFI enabled"        .= Cry.ffiEnabled
                        ]
 
 data VersionParams = VersionParams
@@ -37,17 +39,20 @@ instance Doc.DescribedMethod VersionParams JSON.Value where
   parameterFieldDescription = []
 
   resultFieldDescription =
-    [ ("version",
+    [ ("RPC server version",
+      Doc.Paragraph [ Doc.Text "The cryptol-remote-api version string."
+                    ])
+    , ("version",
       Doc.Paragraph [ Doc.Text "The Cryptol version string."
                     ])
     , ("commit hash",
-      Doc.Paragraph [ Doc.Text "The string of the git commit hash during the build."
+      Doc.Paragraph [ Doc.Text "The string of the git commit hash during the build of Cryptol."
                     ])
     , ("commit branch",
-      Doc.Paragraph [ Doc.Text "The string of the git commit branch during the build."
+      Doc.Paragraph [ Doc.Text "The string of the git commit branch during the build of Cryptol."
                     ])
     , ("commit dirty",
-      Doc.Paragraph [ Doc.Text "True iff non-committed files were present during the build."
+      Doc.Paragraph [ Doc.Text "True iff non-committed files were present during the build of Cryptol."
                     ])
     , ("FFI enabled",
       Doc.Paragraph [ Doc.Text "True iff the FFI is enabled."

--- a/cryptol-remote-api/src/CryptolServer/Version.hs
+++ b/cryptol-remote-api/src/CryptolServer/Version.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+module CryptolServer.Version
+  ( version
+  , versionDescr
+  , VersionParams(..)
+  ) where
+
+import qualified Argo.Doc as Doc
+import Data.Aeson as JSON
+
+import qualified Cryptol.Version as Cry
+import Data.Version (showVersion)
+
+import CryptolServer
+
+versionDescr :: Doc.Block
+versionDescr =
+  Doc.Paragraph
+    [Doc.Text "Version information about this Cryptol server."]
+
+version :: VersionParams -> CryptolCommand JSON.Value
+version _ =
+  return $ JSON.object [ "version"       .= showVersion Cry.version
+                       , "commit hash"   .= Cry.commitHash
+                       , "commit branch" .= Cry.commitBranch
+                       , "commit dirty"  .= Cry.commitDirty
+                       , "FFI enabled"   .= Cry.ffiEnabled
+                       ]
+
+data VersionParams = VersionParams
+
+instance JSON.FromJSON VersionParams where
+  parseJSON _ = pure VersionParams
+
+instance Doc.DescribedMethod VersionParams JSON.Value where
+  parameterFieldDescription = []
+
+  resultFieldDescription =
+    [ ("version",
+      Doc.Paragraph [ Doc.Text "The Cryptol version string."
+                    ])
+    , ("commit hash",
+      Doc.Paragraph [ Doc.Text "The string of the git commit hash during the build."
+                    ])
+    , ("commit branch",
+      Doc.Paragraph [ Doc.Text "The string of the git commit branch during the build."
+                    ])
+    , ("commit dirty",
+      Doc.Paragraph [ Doc.Text "True iff non-committed files were present during the build."
+                    ])
+    , ("FFI enabled",
+      Doc.Paragraph [ Doc.Text "True iff the FFI is enabled."
+                    ])
+    ]

--- a/src/Cryptol/Version.hs
+++ b/src/Cryptol/Version.hs
@@ -21,6 +21,7 @@ module Cryptol.Version (
 import Paths_cryptol
 import qualified GitRev
 import Data.Version (showVersion)
+import Control.Monad (when)
 
 commitHash :: String
 commitHash = GitRev.hash
@@ -47,8 +48,7 @@ displayVersion putLn = do
     putLn ("Cryptol " ++ ver)
     putLn ("Git commit " ++ commitHash)
     putLn ("    branch " ++ commitBranch ++ dirtyLab)
-    if ffiEnabled then putLn "FFI enabled"
-                  else return ()
+    when ffiEnabled $ putLn "FFI enabled"
       where
       dirtyLab | commitDirty = " (non-committed files present during build)"
                | otherwise   = ""

--- a/src/Cryptol/Version.hs
+++ b/src/Cryptol/Version.hs
@@ -13,6 +13,7 @@ module Cryptol.Version (
   , commitShortHash
   , commitBranch
   , commitDirty
+  , ffiEnabled
   , version
   , displayVersion
   ) where
@@ -33,15 +34,21 @@ commitBranch = GitRev.branch
 commitDirty :: Bool
 commitDirty = GitRev.dirty
 
+ffiEnabled :: Bool
+#ifdef FFI_ENABLED
+ffiEnabled = True
+#else
+ffiEnabled = False
+#endif
+
 displayVersion :: Monad m => (String -> m ()) -> m ()
 displayVersion putLn = do
     let ver = showVersion version
     putLn ("Cryptol " ++ ver)
     putLn ("Git commit " ++ commitHash)
     putLn ("    branch " ++ commitBranch ++ dirtyLab)
-#ifdef FFI_ENABLED
-    putLn "FFI enabled"
-#endif
+    if ffiEnabled then putLn "FFI enabled"
+                  else return ()
       where
       dirtyLab | commitDirty = " (non-committed files present during build)"
                | otherwise   = ""


### PR DESCRIPTION
This PR adds a `version` command to the `cryptol-remote-api` and its Python interface. For example:
```python
>>> connection.version()
CryptolVersionInfo(
  rpc_version='3.0.1.99',
  version='3.0.0.99',
  commit_hash='8c811b06a435f5009e8b75b36ecc8fc220e4d6bd',
  commit_branch='version-python-cmd',
  commit_dirty=True,
  ffi_enabled=True)
```
See the [docs for the command in `Version.hs`](https://github.com/GaloisInc/cryptol/blob/3d69f6dc7fe1a00235e3794eb9a26bb011e9bafe/cryptol-remote-api/src/CryptolServer/Version.hs#L41) or the [docstring of `CryptolVersionInfo` in the Python API](https://github.com/GaloisInc/cryptol/blob/3d69f6dc7fe1a00235e3794eb9a26bb011e9bafe/cryptol-remote-api/python/cryptol/synchronous.py#L86) for descriptions of these fields.

Resolves #1544