### PR TITLE
CI: Bump what4-solvers snapshot to 20230711

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
   workflow_dispatch:
 
 env:
+  # The solver package snapshot date. If you update this, make sure to also
+  # update it in the following locations:
+  #
+  # - Dockerfile
+  # - cryptol-remote-api/Dockerfile
+  # - README.md
   SOLVER_PKG_VERSION: "snapshot-20230711"
   # The CACHE_VERSION can be updated to force the use of a new cache if
   # the current cache contents become corrupted/invalid.  This can
@@ -121,6 +127,12 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
+          # The full zip file name for a what4-solvers bindist. If you update
+          # this, make sure to also update it in the following locations:
+          #
+          # - The other BIN_ZIP_FILE in the `test` job
+          # - Dockerfile
+          # - cryptol-remote-api/Dockerfile
           BIN_ZIP_FILE: ${{ matrix.os }}-${{ runner.arch }}-bin.zip
 
       - shell: bash
@@ -293,6 +305,12 @@ jobs:
 
       - shell: bash
         env:
+          # The full zip file name for a what4-solvers bindist. If you update
+          # this, make sure to also update it in the following locations:
+          #
+          # - The other BIN_ZIP_FILE in the `build` job
+          # - Dockerfile
+          # - cryptol-remote-api/Dockerfile
           BIN_ZIP_FILE: ${{ matrix.os }}-${{ runner.arch }}-bin.zip
         run: |
           set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  SOLVER_PKG_VERSION: "snapshot-20221212"
+  SOLVER_PKG_VERSION: "snapshot-20230711"
   # The CACHE_VERSION can be updated to force the use of a new cache if
   # the current cache contents become corrupted/invalid.  This can
   # sometimes happen when (for example) the OS version is changed but
@@ -121,7 +121,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          BIN_ZIP_FILE: ${{ matrix.os }}-bin.zip
+          BIN_ZIP_FILE: ${{ matrix.os }}-${{ runner.arch }}-bin.zip
 
       - shell: bash
         env:
@@ -293,7 +293,7 @@ jobs:
 
       - shell: bash
         env:
-          BIN_ZIP_FILE: ${{ matrix.os }}-bin.zip
+          BIN_ZIP_FILE: ${{ matrix.os }}-${{ runner.arch }}-bin.zip
         run: |
           set -x
           chmod +x dist/bin/cryptol

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER cryptol
 WORKDIR /cryptol
 RUN mkdir -p rootfs/usr/local/bin
 WORKDIR /cryptol/rootfs/usr/local/bin
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20221212/ubuntu-22.04-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20230711/ubuntu-22.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 WORKDIR /cryptol
 ENV PATH=/cryptol/rootfs/usr/local/bin:/home/cryptol/.local/bin:/home/cryptol/.ghcup/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ USER cryptol
 WORKDIR /cryptol
 RUN mkdir -p rootfs/usr/local/bin
 WORKDIR /cryptol/rootfs/usr/local/bin
+# The URL here is based on the same logic used to specify BIN_ZIP_FILE in
+# `.github/workflow/ci.yml`, but specialized to x86-64 Ubuntu.
 RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20230711/ubuntu-22.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 WORKDIR /cryptol

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cryptol currently uses Microsoft Research's [Z3 SMT
 solver](https://github.com/Z3Prover/z3) by default to solve constraints
 during type checking, and as the default solver for the `:sat` and
 `:prove` commands.  Cryptol generally requires the most recent version
-of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20221212).
+of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20230711).
 
 You can download Z3 binaries for a variety of platforms from their
 [releases page](https://github.com/Z3Prover/z3/releases). If you

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -64,6 +64,8 @@ ENV PATH=/usr/local/bin:/cryptol/rootfs/usr/local/bin:$PATH
 RUN mkdir -p rootfs/"${CRYPTOLPATH}" \
     && cp -r lib/* rootfs/"${CRYPTOLPATH}"
 WORKDIR /cryptol/rootfs/usr/local/bin
+# The URL here is based on the same logic used to specify BIN_ZIP_FILE in
+# `.github/workflow/ci.yml`, but specialized to x86-64 Ubuntu.
 RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20230711/ubuntu-22.04-X64-bin.zip" && \
     unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -64,7 +64,7 @@ ENV PATH=/usr/local/bin:/cryptol/rootfs/usr/local/bin:$PATH
 RUN mkdir -p rootfs/"${CRYPTOLPATH}" \
     && cp -r lib/* rootfs/"${CRYPTOLPATH}"
 WORKDIR /cryptol/rootfs/usr/local/bin
-RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20221212/ubuntu-22.04-bin.zip" && \
+RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20230711/ubuntu-22.04-X64-bin.zip" && \
     unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /cryptol/rootfs


### PR DESCRIPTION
This includes the following changes:

* The bindist URLs now include the OS architecture, I have tweaked the parts of CI that downloads bindists accordingly.
* This snapshot includes `cvc5-1.0.5`, which has fixed a bug that was responsible for #1548. As such, this fixes #1548.