### PR TITLE
Make names in scope in functors accessible when their instantiations are loaded at the REPL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# UNRELEASED
+
+* Fixed #1556, #1237, and #1561.
+* Fixed #1455, making anything in scope of the functor in scope at the REPL as
+  well when an instantiation of the functor is loaded and focused,
+  design choice (3) on the ticket.  In particular, the prelude will be in scope.
+
+
 # 3.0.0 -- 2023-06-26
 
 ## Language changes

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -141,6 +141,7 @@ library
                        Cryptol.ModuleSystem.Name,
                        Cryptol.ModuleSystem.Names,
                        Cryptol.ModuleSystem.NamingEnv,
+                       Cryptol.ModuleSystem.NamingEnv.Types,
                        Cryptol.ModuleSystem.Binds
                        Cryptol.ModuleSystem.Exports,
                        Cryptol.ModuleSystem.Renamer,

--- a/src/Cryptol/ModuleSystem/Base.hs
+++ b/src/Cryptol/ModuleSystem/Base.hs
@@ -631,7 +631,11 @@ checkModule isrc m = do
   rewMod <- case tcm of
               T.TCTopModule mo -> T.TCTopModule <$> liftSupply (`rewModule` mo)
               T.TCTopSignature {} -> pure tcm
-  pure (R.rmInScope renMod,rewMod)
+  let nameEnv = case tcm of
+                  T.TCTopModule mo -> T.mInScope mo
+                  -- Name env for signatures does not change after typechecking
+                  T.TCTopSignature {} -> mInScope (R.rmModule renMod)
+  pure (nameEnv,rewMod)
 
 data TCLinter o = TCLinter
   { lintCheck ::

--- a/src/Cryptol/ModuleSystem/Binds.hs
+++ b/src/Cryptol/ModuleSystem/Binds.hs
@@ -13,6 +13,7 @@ module Cryptol.ModuleSystem.Binds
   , topModuleDefs
   , topDeclsDefs
   , newModParam
+  , newFunctorInst
   , InModule(..)
   , ifaceToMod
   , ifaceSigToMod
@@ -419,6 +420,13 @@ newLocal ns thing rng = liftSupply (mkLocal ns (getIdent thing) rng)
 -- to the signature.
 newModParam :: FreshM m => ModPath -> Ident -> Range -> Name -> m Name
 newModParam m i rng n = liftSupply (mkModParam m i rng n)
+
+-- | Given a name in a functor, make a fresh name for the corresponding thing in
+-- the instantiation.
+--
+-- The 'ModPath' should be the instantiation not the functor.
+newFunctorInst :: FreshM m => ModPath -> Name -> m Name
+newFunctorInst m n = liftSupply (freshNameFor m n)
 
 
 {- | Do something in the context of a module.

--- a/src/Cryptol/ModuleSystem/Binds.hs
+++ b/src/Cryptol/ModuleSystem/Binds.hs
@@ -125,7 +125,7 @@ ifaceSigToMod ps = Mod
   , modState     = ()
   }
   where
-  env = modParamsNamingEnv ps
+  env = modParamNamesNamingEnv ps
 
 
 

--- a/src/Cryptol/ModuleSystem/Interface.hs
+++ b/src/Cryptol/ModuleSystem/Interface.hs
@@ -42,6 +42,7 @@ import Prelude ()
 import Prelude.Compat
 
 import Cryptol.ModuleSystem.Name
+import Cryptol.ModuleSystem.NamingEnv.Types
 import Cryptol.Utils.Ident (ModName, OrigName(..))
 import Cryptol.Utils.Panic(panic)
 import Cryptol.Utils.Fixity(Fixity)
@@ -74,6 +75,7 @@ data IfaceNames name = IfaceNames
   , ifsNested   :: Set Name   -- ^ Things nested in this module
   , ifsDefines  :: Set Name   -- ^ Things defined in this module
   , ifsPublic   :: Set Name   -- ^ Subset of `ifsDefines` that is public
+  , ifsInScope  :: NamingEnv  -- ^ Things in scope in this module
   , ifsDoc      :: !(Maybe Text) -- ^ Documentation
   } deriving (Show, Generic, NFData)
 
@@ -87,6 +89,7 @@ emptyIface nm = Iface
                            , ifsDefines = mempty
                            , ifsPublic  = mempty
                            , ifsNested  = mempty
+                           , ifsInScope = mempty
                            , ifsDoc     = Nothing
                            }
   , ifParams  = mempty

--- a/src/Cryptol/ModuleSystem/Interface.hs
+++ b/src/Cryptol/ModuleSystem/Interface.hs
@@ -42,7 +42,6 @@ import Prelude ()
 import Prelude.Compat
 
 import Cryptol.ModuleSystem.Name
-import Cryptol.ModuleSystem.NamingEnv.Types
 import Cryptol.Utils.Ident (ModName, OrigName(..))
 import Cryptol.Utils.Panic(panic)
 import Cryptol.Utils.Fixity(Fixity)
@@ -75,7 +74,6 @@ data IfaceNames name = IfaceNames
   , ifsNested   :: Set Name   -- ^ Things nested in this module
   , ifsDefines  :: Set Name   -- ^ Things defined in this module
   , ifsPublic   :: Set Name   -- ^ Subset of `ifsDefines` that is public
-  , ifsInScope  :: NamingEnv  -- ^ Things in scope in this module
   , ifsDoc      :: !(Maybe Text) -- ^ Documentation
   } deriving (Show, Generic, NFData)
 
@@ -89,7 +87,6 @@ emptyIface nm = Iface
                            , ifsDefines = mempty
                            , ifsPublic  = mempty
                            , ifsNested  = mempty
-                           , ifsInScope = mempty
                            , ifsDoc     = Nothing
                            }
   , ifParams  = mempty

--- a/src/Cryptol/ModuleSystem/Name.hs
+++ b/src/Cryptol/ModuleSystem/Name.hs
@@ -29,6 +29,7 @@ module Cryptol.ModuleSystem.Name (
   , nameLoc
   , nameFixity
   , nameNamespace
+  , asPName
   , asPrim
   , asOrigName
   , nameModPath
@@ -70,7 +71,8 @@ import qualified Data.Text as Text
 import           Data.Char(isAlpha,toUpper)
 
 
-
+import           Cryptol.Parser.Name (PName)
+import qualified Cryptol.Parser.Name as PName
 import           Cryptol.Parser.Position (Range,Located(..))
 import           Cryptol.Utils.Fixity
 import           Cryptol.Utils.Ident
@@ -226,6 +228,14 @@ nameLoc  = nLoc
 
 nameFixity :: Name -> Maybe Fixity
 nameFixity = nFixity
+
+-- | We only qualify the 'PName' with the interface name from 'FromModParam' in
+-- 'ogSource', if any. We don't qualify with the 'ModPath'.
+asPName :: Name -> PName
+asPName n =
+  case nInfo n of
+    GlobalName _ og -> PName.fromOrigName og
+    LocalName _ txt -> PName.mkUnqual txt
 
 -- | Primtiives must be in a top level module, at least for now.
 asPrim :: Name -> Maybe PrimIdent

--- a/src/Cryptol/ModuleSystem/Name.hs
+++ b/src/Cryptol/ModuleSystem/Name.hs
@@ -29,7 +29,7 @@ module Cryptol.ModuleSystem.Name (
   , nameLoc
   , nameFixity
   , nameNamespace
-  , asPName
+  , nameToDefPName
   , asPrim
   , asOrigName
   , nameModPath
@@ -229,12 +229,13 @@ nameLoc  = nLoc
 nameFixity :: Name -> Maybe Fixity
 nameFixity = nFixity
 
--- | We only qualify the 'PName' with the interface name from 'ogFromParam'. We
--- don't qualify with the 'ogModule'.
-asPName :: Name -> PName
-asPName n =
+-- | Compute a `PName` for the definition site corresponding to the given
+-- `Name`.   Usually this is an unqualified name, but names that come
+-- from module parameters are qualified with the corresponding parameter name.
+nameToDefPName :: Name -> PName
+nameToDefPName n =
   case nInfo n of
-    GlobalName _ og -> PName.fromOrigName og
+    GlobalName _ og -> PName.origNameToDefPName og
     LocalName _ txt -> PName.mkUnqual txt
 
 -- | Primtiives must be in a top level module, at least for now.

--- a/src/Cryptol/ModuleSystem/NamingEnv.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv.hs
@@ -6,14 +6,14 @@
 -- Stability   :  provisional
 -- Portability :  portable
 
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 -- See Note [-Wincomplete-uni-patterns and irrefutable patterns] in Cryptol.TypeCheck.TypePat
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-module Cryptol.ModuleSystem.NamingEnv where
+module Cryptol.ModuleSystem.NamingEnv
+  ( module Cryptol.ModuleSystem.NamingEnv.Types
+  , module Cryptol.ModuleSystem.NamingEnv
+  ) where
 
 import Data.Maybe (mapMaybe,maybeToList)
 import           Data.Map.Strict (Map)
@@ -21,9 +21,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Foldable(foldl')
-
-import GHC.Generics (Generic)
-import Control.DeepSeq(NFData)
 
 import Cryptol.Utils.PP
 import Cryptol.Utils.Panic (panic)
@@ -34,24 +31,7 @@ import Cryptol.ModuleSystem.Name
 import Cryptol.ModuleSystem.Names
 import Cryptol.ModuleSystem.Interface
 
-
--- | The 'NamingEnv' is used by the renamer to determine what
--- identifiers refer to.
-newtype NamingEnv = NamingEnv (Map Namespace (Map PName Names))
-  deriving (Show,Generic,NFData)
-
-instance Monoid NamingEnv where
-  mempty = NamingEnv Map.empty
-  {-# INLINE mempty #-}
-
-instance Semigroup NamingEnv where
-  NamingEnv l <> NamingEnv r =
-    NamingEnv (Map.unionWith (Map.unionWith (<>)) l r)
-
-instance PP NamingEnv where
-  ppPrec _ (NamingEnv mps)   = vcat $ map ppNS $ Map.toList mps
-    where ppNS (ns,xs) = nest 2 (vcat (pp ns : map ppNm (Map.toList xs)))
-          ppNm (x,as)  = pp x <+> "->" <+> commaSep (map pp (namesToList as))
+import Cryptol.ModuleSystem.NamingEnv.Types
 
 
 {- | This "joins" two naming environments by matching the text name.

--- a/src/Cryptol/ModuleSystem/NamingEnv.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv.hs
@@ -211,8 +211,8 @@ isEmptyNamingEnv (NamingEnv mp) = Map.null mp
 
 -- | Compute an unqualified naming environment, containing the various module
 -- parameters.
-modParamsNamingEnv :: T.ModParamNames -> NamingEnv
-modParamsNamingEnv T.ModParamNames { .. } =
+modParamNamesNamingEnv :: T.ModParamNames -> NamingEnv
+modParamNamesNamingEnv T.ModParamNames { .. } =
   NamingEnv $ Map.fromList
     [ (NSValue, Map.fromList $ map fromFu $ Map.keys mpnFuns)
     , (NSType,  Map.fromList $ map fromTS (Map.elems mpnTySyn) ++
@@ -228,6 +228,11 @@ modParamsNamingEnv T.ModParamNames { .. } =
 
   fromTS ts = (toPName (T.tsName ts), One (T.tsName ts))
 
+-- | Compute a naming environment from a module parameter, qualifying it
+-- according to 'mpQual'.
+modParamNamingEnv :: T.ModParam -> NamingEnv
+modParamNamingEnv mp = maybe id qualify (T.mpQual mp) $
+  modParamNamesNamingEnv (T.mpParameters mp)
 
 -- | Generate a naming environment from a declaration interface, where none of
 -- the names are qualified.

--- a/src/Cryptol/ModuleSystem/NamingEnv.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv.hs
@@ -71,16 +71,16 @@ namingEnvNames (NamingEnv xs) =
     Just (One x) -> Set.singleton x
     Just (Ambig as) -> as
 
--- | Get a naming environment for the given names
---
--- We only qualify the PNames with the interface name from 'ogFromParam'. We
--- don't qualify with the 'ogModule'.
+-- | Get a naming environment for the given names.  The `PName`s correspond
+-- to the definition sites of the corresponding `Name`s, so typically they
+-- will be unqualified.  The exception is for names that comre from parameters,
+-- which are qualified with the relevant parameter.
 namingEnvFromNames :: Set Name -> NamingEnv
 namingEnvFromNames xs = NamingEnv (foldl' add mempty xs)
   where
   add mp x = let ns = nameNamespace x
              in Map.insertWith (Map.unionWith (<>))
-                               ns (Map.singleton (asPName x) (One x))
+                               ns (Map.singleton (nameToDefPName x) (One x))
                                mp
 
 

--- a/src/Cryptol/ModuleSystem/NamingEnv.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv.hs
@@ -73,8 +73,8 @@ namingEnvNames (NamingEnv xs) =
 
 -- | Get a naming environment for the given names
 --
--- We only qualify the PNames with the interface name from 'FromModParam' in
--- 'ogSource', if any. We don't qualify with the 'ModPath'.
+-- We only qualify the PNames with the interface name from 'ogFromParam'. We
+-- don't qualify with the 'ogModule'.
 namingEnvFromNames :: Set Name -> NamingEnv
 namingEnvFromNames xs = NamingEnv (foldl' add mempty xs)
   where

--- a/src/Cryptol/ModuleSystem/NamingEnv.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv.hs
@@ -71,14 +71,16 @@ namingEnvNames (NamingEnv xs) =
     Just (One x) -> Set.singleton x
     Just (Ambig as) -> as
 
--- | Get a unqualified naming environment for the given names
+-- | Get a naming environment for the given names
+--
+-- We only qualify the PNames with the interface name from 'FromModParam' in
+-- 'ogSource', if any. We don't qualify with the 'ModPath'.
 namingEnvFromNames :: Set Name -> NamingEnv
 namingEnvFromNames xs = NamingEnv (foldl' add mempty xs)
   where
   add mp x = let ns = nameNamespace x
-                 txt = nameIdent x
              in Map.insertWith (Map.unionWith (<>))
-                               ns (Map.singleton (mkUnqual txt) (One x))
+                               ns (Map.singleton (asPName x) (One x))
                                mp
 
 

--- a/src/Cryptol/ModuleSystem/NamingEnv/Types.hs
+++ b/src/Cryptol/ModuleSystem/NamingEnv/Types.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cryptol.ModuleSystem.NamingEnv.Types where
+
+import           Data.Map.Strict            (Map)
+import qualified Data.Map.Strict            as Map
+
+import           Control.DeepSeq            (NFData)
+import           GHC.Generics               (Generic)
+
+import           Cryptol.ModuleSystem.Names
+import           Cryptol.Parser.Name
+import           Cryptol.Utils.Ident
+import           Cryptol.Utils.PP
+
+-- | The 'NamingEnv' is used by the renamer to determine what
+-- identifiers refer to.
+newtype NamingEnv = NamingEnv (Map Namespace (Map PName Names))
+  deriving (Show,Generic,NFData)
+
+instance Monoid NamingEnv where
+  mempty = NamingEnv Map.empty
+  {-# INLINE mempty #-}
+
+instance Semigroup NamingEnv where
+  NamingEnv l <> NamingEnv r =
+    NamingEnv (Map.unionWith (Map.unionWith (<>)) l r)
+
+instance PP NamingEnv where
+  ppPrec _ (NamingEnv mps)   = vcat $ map ppNS $ Map.toList mps
+    where ppNS (ns,xs) = nest 2 (vcat (pp ns : map ppNm (Map.toList xs)))
+          ppNm (x,as)  = pp x <+> "->" <+> commaSep (map pp (namesToList as))

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -220,10 +220,7 @@ renameModule' ::
   ModuleG mname PName ->
   RenameM (ModuleG mname Name)
 renameModule' mname m =
-  setCurMod
-    case mname of
-      ImpTop r    -> TopModule r
-      ImpNested r -> Nested (nameModPath r) (nameIdent r)
+  setCurMod (impNameModPath mname)
 
   do resolved <- lookupResolved mname
      shadowNames' CheckNone (rmodImports resolved)

--- a/src/Cryptol/ModuleSystem/Renamer.hs
+++ b/src/Cryptol/ModuleSystem/Renamer.hs
@@ -118,7 +118,6 @@ The Renamer Algorithm
 data RenamedModule = RenamedModule
   { rmModule   :: Module Name     -- ^ The renamed module
   , rmDefines  :: NamingEnv       -- ^ What this module defines
-  , rmInScope  :: NamingEnv       -- ^ What's in scope in this module
   , rmImported :: IfaceDecls
     -- ^ Imported declarations.  This provides the types for external
     -- names (used by the type-checker).
@@ -152,12 +151,11 @@ renameModule m0 =
 
      setResolvedLocals resolvedMods $
        setNestedModule pathToName
-       do (ifs,(inScope,m1)) <- collectIfaceDeps (renameModule' mname m)
+       do (ifs,m1) <- collectIfaceDeps (renameModule' mname m)
           env <- rmodDefines <$> lookupResolved mname
           pure RenamedModule
                  { rmModule = m1
                  , rmDefines = env
-                 , rmInScope = inScope
                  , rmImported = ifs
                   -- XXX: maybe we should keep the nested defines too?
                  }
@@ -220,7 +218,7 @@ class Rename f where
 renameModule' ::
   ImpName Name {- ^ Resolved name for this module -} ->
   ModuleG mname PName ->
-  RenameM (NamingEnv, ModuleG mname Name)
+  RenameM (ModuleG mname Name)
 renameModule' mname m =
   setCurMod
     case mname of
@@ -247,7 +245,7 @@ renameModule' mname m =
                      let exports = exportedDecls ds1
                      mapM_ recordUse (exported NSType exports)
                      inScope <- getNamingEnv
-                     pure (inScope, m { mDef = NormalModule ds1 })
+                     pure m { mDef = NormalModule ds1, mInScope = inScope }
 
          -- The things defined by this module are the *results*
          -- of the instantiation, so we should *not* add them
@@ -260,30 +258,20 @@ renameModule' mname m =
               let l = Just (srcRange f')
               imap <- mkInstMap l mempty (thing f') mname
 
-              {- Now we need to compute what's "in scope" of the instantiated
-              module.  This is used when the module is loaded at the command
-              line and users want to evalute things in the context of the
-              module -}
-              fuEnv <- if isFakeName (thing f')
-                          then pure mempty
-                          else lookupDefines (thing f')
-              let ren x = Map.findWithDefault x x imap
+              -- This inScope is incomplete; it only contains names from the
+              -- enclosing scope, but we also want the names in scope from the
+              -- functor, for ease of testing at the command line. We will fix
+              -- this up in doFunctorInst in the typechecker, because right now
+              -- we don't have access yet to the inScope of the functor.
+              inScope <- getNamingEnv
 
-              -- XXX: This is not quite right as it only considers the things
-              -- defined in the module to be in scope.  It misses things
-              -- that are *imported* by the functor, in particular the Cryptol
-              -- library
-              -- is missing.  See #1455.
-              inScope <- shadowNames' CheckNone (mapNamingEnv ren fuEnv)
-                         getNamingEnv
-
-              pure (inScope, m { mDef = FunctorInstance f' as' imap })
+              pure m { mDef = FunctorInstance f' as' imap, mInScope = inScope }
 
          InterfaceModule s ->
            shadowNames' CheckNone (rmodDefines resolved)
              do d <- InterfaceModule <$> renameIfaceModule mname s
                 inScope <- getNamingEnv
-                pure (inScope, m { mDef = d })
+                pure m { mDef = d, mInScope = inScope }
 
 
 checkFunctorArgs :: ModuleInstanceArgs Name -> RenameM ()
@@ -820,10 +808,8 @@ instance Rename NestedModule where
            nm             = thing lnm
        n   <- resolveName NameBind NSModule nm
        depsOf (NamedThing n)
-         do -- XXX: we should store in scope somewhere if we want to browse
-            -- nested modules properly
-            let m' = m { mName = ImpNested <$> mName m }
-            (_inScope,m1) <- renameModule' (ImpNested n) m'
+         do let m' = m { mName = ImpNested <$> mName m }
+            m1 <- renameModule' (ImpNested n) m'
             pure (NestedModule m1 { mName = lnm { thing = n } })
 
 
@@ -1416,8 +1402,6 @@ instance PP RenamedModule where
     doc =
       vcat [ "// --- Defines -----------------------------"
            , pp (rmDefines rn)
-           , "// --- In scope ----------------------------"
-           , pp (rmInScope rn)
            , "// -- Module -------------------------------"
            , pp (rmModule rn)
            , "// -----------------------------------------"

--- a/src/Cryptol/ModuleSystem/Renamer/Imports.hs
+++ b/src/Cryptol/ModuleSystem/Renamer/Imports.hs
@@ -67,10 +67,11 @@ import Cryptol.Utils.Ident(ModName,ModPath(..),Namespace(..),OrigName(..))
 
 import Cryptol.Parser.AST
   ( ImportG(..),PName, ModuleInstanceArgs(..), ImpName(..) )
-import Cryptol.ModuleSystem.Binds (Mod(..), TopDef(..), modNested, ModKind(..))
+import Cryptol.ModuleSystem.Binds
+          ( Mod(..), TopDef(..), modNested, ModKind(..), newFunctorInst )
 import Cryptol.ModuleSystem.Name
-          ( Name, Supply, SupplyT, runSupplyT, liftSupply, freshNameFor
-          , asOrigName, nameIdent, nameTopModule )
+          ( Name, Supply, SupplyT, runSupplyT, asOrigName, nameIdent
+          , nameTopModule )
 import Cryptol.ModuleSystem.Names(Names(..))
 import Cryptol.ModuleSystem.NamingEnv
           ( NamingEnv(..), lookupNS, shadowing, travNamingEnv
@@ -511,7 +512,7 @@ doInstantiate keepArgs mpath def s = (newDef, Set.foldl' doSub newS nestedToDo)
 
   instName :: Name -> SupplyT (M.StateT (Set (Name,Name)) M.Id) Name
   instName x =
-    do y <- liftSupply (freshNameFor mpath x)
+    do y <- newFunctorInst mpath x
        when (x `Set.member` rmodNested def)
             (M.lift (M.sets_ (Set.insert (x,y))))
        pure y

--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -67,7 +67,7 @@ module Cryptol.Parser.AST
   , Pragma(..)
   , ExportType(..)
   , TopLevel(..)
-  , Import, ImportG(..), ImportSpec(..), ImpName(..)
+  , Import, ImportG(..), ImportSpec(..), ImpName(..), impNameModPath
   , Newtype(..)
   , PrimType(..)
   , ParameterType(..)
@@ -106,6 +106,7 @@ module Cryptol.Parser.AST
   , cppKind, ppSelector
   ) where
 
+import Cryptol.ModuleSystem.Name (Name, nameModPath, nameIdent)
 import Cryptol.ModuleSystem.NamingEnv.Types
 import Cryptol.Parser.Name
 import Cryptol.Parser.Position
@@ -309,6 +310,10 @@ data ImpName name =
     ImpTop    ModName           -- ^ A top-level module
   | ImpNested name              -- ^ The module in scope with the given name
     deriving (Show, Generic, NFData, Eq, Ord)
+
+impNameModPath :: ImpName Name -> ModPath
+impNameModPath (ImpTop mn) = TopModule mn
+impNameModPath (ImpNested n) = Nested (nameModPath n) (nameIdent n)
 
 -- | A simple declaration.  Generally these are things that can appear
 -- both at the top-level of a module and in `where` clauses.

--- a/src/Cryptol/Parser/Name.hs
+++ b/src/Cryptol/Parser/Name.hs
@@ -46,16 +46,15 @@ mkUnqual  = UnQual
 mkQual :: ModName -> Ident -> PName
 mkQual  = Qual
 
--- | We only qualify the 'PName' with the interface name from 'FromModParam' in
--- 'ogSource', if any. We don't qualify with the 'ModPath'.
+-- | We only qualify the 'PName' with the interface name from 'ogFromParam'. We
+-- don't qualify with the 'ogModule'.
 fromOrigName :: OrigName -> PName
 fromOrigName og = toPName (ogName og)
   where
   toPName =
-    case ogSource og of
-      FromDefinition -> UnQual
-      FromFunctorInst -> UnQual
-      FromModParam sig -> Qual (identToModName sig)
+    case ogFromParam og of
+      Nothing -> UnQual
+      Just sig -> Qual (identToModName sig)
 
 getModName :: PName -> Maybe ModName
 getModName (Qual ns _) = Just ns

--- a/src/Cryptol/Parser/Name.hs
+++ b/src/Cryptol/Parser/Name.hs
@@ -46,6 +46,17 @@ mkUnqual  = UnQual
 mkQual :: ModName -> Ident -> PName
 mkQual  = Qual
 
+-- | We only qualify the 'PName' with the interface name from 'FromModParam' in
+-- 'ogSource', if any. We don't qualify with the 'ModPath'.
+fromOrigName :: OrigName -> PName
+fromOrigName og = toPName (ogName og)
+  where
+  toPName =
+    case ogSource og of
+      FromDefinition -> UnQual
+      FromFunctorInst -> UnQual
+      FromModParam sig -> Qual (identToModName sig)
+
 getModName :: PName -> Maybe ModName
 getModName (Qual ns _) = Just ns
 getModName _           = Nothing

--- a/src/Cryptol/Parser/Name.hs
+++ b/src/Cryptol/Parser/Name.hs
@@ -46,10 +46,11 @@ mkUnqual  = UnQual
 mkQual :: ModName -> Ident -> PName
 mkQual  = Qual
 
--- | We only qualify the 'PName' with the interface name from 'ogFromParam'. We
--- don't qualify with the 'ogModule'.
-fromOrigName :: OrigName -> PName
-fromOrigName og = toPName (ogName og)
+-- | Compute a `PName` for the definition site corresponding to the given
+-- `OrigName`.   Usually this is an unqualified name, but names that come
+-- from module parameters are qualified with the corresponding parameter name.
+origNameToDefPName :: OrigName -> PName
+origNameToDefPName og = toPName (ogName og)
   where
   toPName =
     case ogFromParam og of

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -36,6 +36,7 @@ import Cryptol.Utils.Panic(panic)
 import Cryptol.Utils.Ident (Ident,isInfixIdent,ModName,PrimIdent,prelPrim)
 import Cryptol.Parser.Position(Located,Range,HasLoc(..))
 import Cryptol.ModuleSystem.Name
+import Cryptol.ModuleSystem.NamingEnv.Types
 import Cryptol.ModuleSystem.Interface
 import Cryptol.ModuleSystem.Exports(ExportSpec(..)
                                    , isExportedBind, isExportedType, isExported)
@@ -111,6 +112,10 @@ data ModuleG mname =
                      , mDecls            :: [DeclGroup]
                      , mSubmodules       :: Map Name (IfaceNames Name)
                      , mSignatures       :: !(Map Name ModParamNames)
+
+                     , mInScope          :: NamingEnv
+                       -- ^ Things in scope at the top level.
+                       --   Submodule in-scope information is in 'mSubmodules'.
                      } deriving (Show, Generic, NFData)
 
 emptyModule :: mname -> ModuleG mname
@@ -134,6 +139,8 @@ emptyModule nm =
     , mFunctors         = mempty
     , mSubmodules       = mempty
     , mSignatures       = mempty
+
+    , mInScope          = mempty
     }
 
 -- | Find all the foreign declarations in the module and return their names and FFIFunTypes.

--- a/src/Cryptol/TypeCheck/Interface.hs
+++ b/src/Cryptol/TypeCheck/Interface.hs
@@ -32,7 +32,6 @@ genIfaceNames m = IfaceNames
   , ifsNested   = mNested m
   , ifsDefines  = genModDefines m
   , ifsPublic   = allExported (mExports m)
-  , ifsInScope  = mInScope m
   , ifsDoc      = mDoc m
   }
 

--- a/src/Cryptol/TypeCheck/Interface.hs
+++ b/src/Cryptol/TypeCheck/Interface.hs
@@ -32,6 +32,7 @@ genIfaceNames m = IfaceNames
   , ifsNested   = mNested m
   , ifsDefines  = genModDefines m
   , ifsPublic   = allExported (mExports m)
+  , ifsInScope  = mInScope m
   , ifsDoc      = mDoc m
   }
 

--- a/src/Cryptol/TypeCheck/Module.hs
+++ b/src/Cryptol/TypeCheck/Module.hs
@@ -310,7 +310,7 @@ checkParamValue ::
   {- ^ Decl mapping a new name to the actual value,
        and a map from the value param name in the functor to the new name
          (for instantiation) -}
-checkParamValue mpath r paramName vMap mp =
+checkParamValue mpath r modParamName vMap mp =
   let name     = mvpName mp
       i        = nameIdent name
       expectT  = mvpType mp
@@ -320,7 +320,7 @@ checkParamValue mpath r paramName vMap mp =
             pure ([], Map.empty)
        Just actual ->
          do e <- mkParamDef r (name,expectT) actual
-            name' <- newModParam mpath paramName (nameLoc (fst actual)) name
+            name' <- newModParam mpath modParamName (nameLoc (fst actual)) name
             let d = Decl { dName        = name'
                          , dSignature   = expectT
                          , dDefinition  = DExpr e

--- a/src/Cryptol/TypeCheck/Module.hs
+++ b/src/Cryptol/TypeCheck/Module.hs
@@ -76,7 +76,16 @@ doFunctorInst m f as inst enclosingInScope doc =
                                  (Map.unions vps)
                                  m2
 
+     -- An instantiation doesn't really have anything "in scope" per se, but
+     -- here we compute what would be in scope as if you hand wrote the
+     -- instantiation by copy-pasting the functor then substituting the
+     -- parameters. That is, it would be whatever is in scope in the functor,
+     -- together with any names in the enclosing scope if this is a nested
+     -- module, with the functor's names taking precedence. This is used to
+     -- determine what is in scope at the REPL when the instantiation is loaded
+     -- and focused.
      let inScope = mInScope m2 `shadowing` enclosingInScope
+
      case thing m of
        P.ImpTop mn    -> newModuleScope mn (mExports m2) inScope
        P.ImpNested mn -> newSubmoduleScope mn doc (mExports m2) inScope

--- a/src/Cryptol/TypeCheck/ModuleBacktickInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleBacktickInstance.hs
@@ -18,15 +18,15 @@ import Data.List(group,sort)
 import Data.Maybe(mapMaybe)
 import qualified Data.Text as Text
 
-import Cryptol.Utils.Ident(ModPath(..), modPathIsOrContains,Namespace(..)
+import Cryptol.Utils.Ident(modPathIsOrContains,Namespace(..)
                           , Ident, mkIdent, identText
                           , ModName, modNameChunksText )
 import Cryptol.Utils.PP(pp)
 import Cryptol.Utils.Panic(panic)
 import Cryptol.Utils.RecordMap(RecordMap,recordFromFields,recordFromFieldsErr)
+import Cryptol.Parser.AST(impNameModPath)
 import Cryptol.Parser.Position
-import Cryptol.ModuleSystem.Name(
-  nameModPath, nameModPathMaybe, nameIdent, mapNameIdent)
+import Cryptol.ModuleSystem.Name(nameModPathMaybe, nameIdent, mapNameIdent)
 import Cryptol.TypeCheck.AST
 import Cryptol.TypeCheck.Error
 import qualified Cryptol.TypeCheck.Monad as TC
@@ -80,9 +80,7 @@ doBacktickInstance as ps mp m
 
     mkBad sel a = [ (a,k) | k <- Map.keys (sel m) ]
 
-    ourPath = case thing (mName m) of
-                ImpTop mo    -> TopModule mo
-                ImpNested mo -> Nested (nameModPath mo) (nameIdent mo)
+    ourPath = impNameModPath (thing (mName m))
 
     doAddParams nt sel =
       mapReader (\ro -> ro { newNewtypes = nt }) (addParams (sel m))

--- a/src/Cryptol/TypeCheck/ModuleInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleInstance.hs
@@ -8,6 +8,7 @@ import qualified Data.Set as Set
 
 import Cryptol.Parser.Position(Located)
 import Cryptol.ModuleSystem.Interface(IfaceNames(..))
+import Cryptol.ModuleSystem.NamingEnv(NamingEnv,mapNamingEnv)
 import Cryptol.IR.TraverseNames(TraverseNames,mapNames)
 import Cryptol.TypeCheck.AST
 import Cryptol.TypeCheck.Subst(Subst,TVars,apSubst)
@@ -51,6 +52,9 @@ instance ModuleInstance a => ModuleInstance (Located a) where
 instance ModuleInstance Name where
   moduleInstance = doVInst
 
+instance ModuleInstance NamingEnv where
+  moduleInstance = mapNamingEnv doVInst
+
 instance ModuleInstance name => ModuleInstance (ImpName name) where
   moduleInstance x =
     case x of
@@ -74,6 +78,7 @@ instance ModuleInstance (ModuleG name) where
            , mDecls            = moduleInstance (mDecls m)
            , mSubmodules       = doMap (mSubmodules m)
            , mSignatures       = doMap (mSignatures m)
+           , mInScope          = moduleInstance (mInScope m)
            }
 
 instance ModuleInstance Type where
@@ -127,6 +132,7 @@ instance ModuleInstance name => ModuleInstance (IfaceNames name) where
                , ifsNested   = doSet (ifsNested ns)
                , ifsDefines  = doSet (ifsDefines ns)
                , ifsPublic   = doSet (ifsPublic ns)
+               , ifsInScope  = moduleInstance (ifsInScope ns)
                , ifsDoc      = ifsDoc ns
                }
 

--- a/src/Cryptol/TypeCheck/ModuleInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleInstance.hs
@@ -28,7 +28,7 @@ doTInst = apSubst ?tSu
 
 -- | Has both value names and types.
 doTVInst :: (Su, TVars a, TraverseNames a) => a -> a
-doTVInst = apSubst ?tSu . doVInst
+doTVInst = doVInst . doTInst
 
 doMap :: (Su, ModuleInstance a) => Map Name a -> Map Name a
 doMap mp =

--- a/src/Cryptol/TypeCheck/ModuleInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleInstance.hs
@@ -132,7 +132,6 @@ instance ModuleInstance name => ModuleInstance (IfaceNames name) where
                , ifsNested   = doSet (ifsNested ns)
                , ifsDefines  = doSet (ifsDefines ns)
                , ifsPublic   = doSet (ifsPublic ns)
-               , ifsInScope  = moduleInstance (ifsInScope ns)
                , ifsDoc      = ifsDoc ns
                }
 

--- a/src/Cryptol/Utils/Ident.hs
+++ b/src/Cryptol/Utils/Ident.hs
@@ -64,7 +64,7 @@ module Cryptol.Utils.Ident
     -- * Original names
   , OrigName(..)
   , OrigSource(..)
-  , ogFromModParam
+  , ogIsModParam
 
     -- * Identifiers for primitives
   , PrimIdent(..)
@@ -259,19 +259,21 @@ data OrigName = OrigName
   , ogModule    :: ModPath
   , ogSource    :: OrigSource
   , ogName      :: Ident
+  , ogFromParam :: !(Maybe Ident)
+    -- ^ Does this name come from a module parameter
   } deriving (Eq,Ord,Show,Generic,NFData)
 
 -- | Describes where a top-level name came from
 data OrigSource =
     FromDefinition
   | FromFunctorInst
-  | FromModParam Ident
+  | FromModParam
     deriving (Eq,Ord,Show,Generic,NFData)
 
 -- | Returns true iff the 'ogSource' of the given 'OrigName' is 'FromModParam'
-ogFromModParam :: OrigName -> Bool
-ogFromModParam og = case ogSource og of
-                      FromModParam _ -> True
+ogIsModParam :: OrigName -> Bool
+ogIsModParam og = case ogSource og of
+                      FromModParam -> True
                       _ -> False
 
 

--- a/src/Cryptol/Utils/Ident.hs
+++ b/src/Cryptol/Utils/Ident.hs
@@ -26,6 +26,7 @@ module Cryptol.Utils.Ident
   , modNameChunks
   , modNameChunksText
   , packModName
+  , identToModName
   , preludeName
   , preludeReferenceName
   , undefinedModName
@@ -213,6 +214,9 @@ packModName strs = textToModName (T.intercalate modSep (map trim strs))
   where
   -- trim space off of the start and end of the string
   trim str = T.dropWhile isSpace (T.dropWhileEnd isSpace str)
+
+identToModName :: Ident -> ModName
+identToModName (Ident _ anon txt) = ModName txt anon
 
 modSep :: T.Text
 modSep  = "::"

--- a/src/Cryptol/Utils/PP.hs
+++ b/src/Cryptol/Utils/PP.hs
@@ -410,16 +410,16 @@ instance PP OrigName where
         UnQualified -> pp (ogName og)
         Qualified m -> ppQual (TopModule m) (pp (ogName og))
         NotInScope  -> ppQual (ogModule og)
-                       case ogSource og of
-                         FromModParam x -> pp x <.> "::" <.> pp (ogName og)
-                         _ -> pp (ogName og)
+                       case ogFromParam og of
+                         Just x  -> pp x <.> "::" <.> pp (ogName og)
+                         Nothing -> pp (ogName og)
     where
-   ppQual mo x =
-    case mo of
-      TopModule m
-        | m == exprModName -> x
-        | otherwise -> pp m <.> "::" <.> x
-      Nested m y -> ppQual m (pp y <.> "::" <.> x)
+    ppQual mo x =
+      case mo of
+        TopModule m
+          | m == exprModName -> x
+          | otherwise -> pp m <.> "::" <.> x
+        Nested m y -> ppQual m (pp y <.> "::" <.> x)
 
 instance PP Namespace where
   ppPrec _ ns =

--- a/tests/issues/issue1455/F.cry
+++ b/tests/issues/issue1455/F.cry
@@ -1,0 +1,6 @@
+module F where
+
+import interface I
+
+a = x + 1
+b = y + 1

--- a/tests/issues/issue1455/G.cry
+++ b/tests/issues/issue1455/G.cry
@@ -1,0 +1,7 @@
+module G where
+
+import interface I
+
+import F { interface I }
+
+c = y + b

--- a/tests/issues/issue1455/I.cry
+++ b/tests/issues/issue1455/I.cry
@@ -1,0 +1,8 @@
+interface module I where
+
+type n : #
+type m = 2 * n
+type constraint (fin n, n >= 1)
+
+x : [n]
+y : [m]

--- a/tests/issues/issue1455/Inst1.cry
+++ b/tests/issues/issue1455/Inst1.cry
@@ -1,0 +1,1 @@
+module Inst = F { M }

--- a/tests/issues/issue1455/Inst1.cry
+++ b/tests/issues/issue1455/Inst1.cry
@@ -1,1 +1,1 @@
-module Inst = F { M }
+module Inst1 = F { M }

--- a/tests/issues/issue1455/Inst2.cry
+++ b/tests/issues/issue1455/Inst2.cry
@@ -1,0 +1,1 @@
+module Inst2 = F { _ }

--- a/tests/issues/issue1455/Inst3.cry
+++ b/tests/issues/issue1455/Inst3.cry
@@ -1,0 +1,1 @@
+module Inst3 = G { M }

--- a/tests/issues/issue1455/M.cry
+++ b/tests/issues/issue1455/M.cry
@@ -1,0 +1,6 @@
+module M where
+
+type n = 4
+
+x = 3
+y = 5

--- a/tests/issues/issue1455_1.icry
+++ b/tests/issues/issue1455_1.icry
@@ -1,0 +1,13 @@
+:l issue1455/Inst1.cry
+`n : Integer
+`m : Integer
+x
+y
+:t x
+:t y
+a
+b
+:t a
+:t b
+a + 2
+:browse

--- a/tests/issues/issue1455_1.icry.stdout
+++ b/tests/issues/issue1455_1.icry.stdout
@@ -1,0 +1,259 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Loading module F
+Loading module M
+Loading module Inst1
+4
+8
+0x3
+0x05
+x : [4]
+y : [8]
+0x4
+0x06
+a : [4]
+b : [m]
+0x6
+Type Synonyms
+=============
+    
+  From Cryptol
+  ------------
+       
+    type Bool = Bit
+    type Char = [8]
+    type lg2 n = width (max 1 n - 1)
+    type String n = [n]Char
+    type Word n = [n]
+     
+  From Inst1
+  ----------
+       
+    type m = 8
+    type n = 4
+     
+Constraint Synonyms
+===================
+    
+  From Cryptol
+  ------------
+       
+    type constraint i < j = j >= 1 + i
+    type constraint i <= j = j >= i
+    type constraint i > j = i >= 1 + j
+     
+Primitive Types
+===============
+    
+  From Cryptol
+  ------------
+       
+    (!=) : # -> # -> Prop
+    (==) : # -> # -> Prop
+    (>=) : # -> # -> Prop
+    (+) : # -> # -> #
+    (-) : # -> # -> #
+    (%) : # -> # -> #
+    (%^) : # -> # -> #
+    (*) : # -> # -> #
+    (/) : # -> # -> #
+    (/^) : # -> # -> #
+    (^^) : # -> # -> #
+    Bit : *
+    Cmp : * -> Prop
+    Eq : * -> Prop
+    FLiteral : # -> # -> # -> * -> Prop
+    Field : * -> Prop
+    fin : # -> Prop
+    Integer : *
+    Integral : * -> Prop
+    inf : #
+    Literal : # -> * -> Prop
+    LiteralLessThan : # -> * -> Prop
+    Logic : * -> Prop
+    lengthFromThenTo : # -> # -> # -> #
+    max : # -> # -> #
+    min : # -> # -> #
+    prime : # -> Prop
+    Rational : *
+    Ring : * -> Prop
+    Round : * -> Prop
+    SignedCmp : * -> Prop
+    width : # -> #
+    Z : # -> *
+    Zero : * -> Prop
+     
+Symbols
+=======
+    
+  From <interactive>
+  ------------------
+       
+    it : [4]
+     
+  From Cryptol
+  ------------
+       
+    (/.) : {a} (Field a) => a -> a -> a
+    (==>) : Bit -> Bit -> Bit
+    (\/) : Bit -> Bit -> Bit
+    (/\) : Bit -> Bit -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (<) : {a} (Cmp a) => a -> a -> Bit
+    (<$) : {a} (SignedCmp a) => a -> a -> Bit
+    (<=) : {a} (Cmp a) => a -> a -> Bit
+    (<=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>) : {a} (Cmp a) => a -> a -> Bit
+    (>$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>=) : {a} (Cmp a) => a -> a -> Bit
+    (>=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (||) : {a} (Logic a) => a -> a -> a
+    (^) : {a} (Logic a) => a -> a -> a
+    (&&) : {a} (Logic a) => a -> a -> a
+    (#) : {front, back, a} (fin front) => [front]a -> [back]a -> [front + back]a
+    (<<) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (<<<) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (>>) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (>>$) : {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+    (>>>) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (+) : {a} (Ring a) => a -> a -> a
+    (-) : {a} (Ring a) => a -> a -> a
+    (%) : {a} (Integral a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (*) : {a} (Ring a) => a -> a -> a
+    (/) : {a} (Integral a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (^^) : {a, e} (Ring a, Integral e) => a -> e -> a
+    (!) : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+    (!!) : {n, k, ix, a} (fin n, Integral ix) => [n]a -> [k]ix -> [k]a
+    (@) : {n, a, ix} (Integral ix) => [n]a -> ix -> a
+    (@@) : {n, k, ix, a} (Integral ix) => [n]a -> [k]ix -> [k]a
+    abs : {a} (Cmp a, Ring a) => a -> a
+    all : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    and : {n} (fin n) => [n] -> Bit
+    any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    assert : {a, n} (fin n) => Bit -> String n -> a -> a
+    carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : {a} (Round a) => a -> Integer
+    complement : {a} (Logic a) => a -> a
+    curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
+    deepseq : {a, b} (Eq a) => a -> b -> b
+    demote : {val, rep} (Literal val rep) => rep
+    drop : {front, back, a} (fin front) => [front + back]a -> [back]a
+    elem : {n, a} (fin n, Eq a) => a -> [n]a -> Bit
+    error : {a, n} (fin n) => String n -> a
+    False : Bit
+    floor : {a} (Round a) => a -> Integer
+    foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+    foldl' : {n, a, b} (fin n, Eq a) => (a -> b -> a) -> a -> [n]b -> a
+    foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
+    foldr' : {n, a, b} (fin n, Eq b) => (a -> b -> b) -> b -> [n]a -> b
+    fraction : {m, n, r, a} (FLiteral m n r a) => a
+    fromInteger : {a} (Ring a) => Integer -> a
+    fromThenTo :
+      {first, next, last, a, len}
+        (fin first, fin next, fin last, Literal first a, Literal next a,
+         Literal last a, first != next,
+         lengthFromThenTo first next last == len) =>
+        [len]a
+    fromTo :
+      {first, last, a}
+        (fin last, last >= first, Literal last a) =>
+        [1 + (last - first)]a
+    fromToBy :
+      {first, last, stride, a}
+        (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+        [1 + (last - first) / stride]a
+    fromToByLessThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, bound >= first,
+         LiteralLessThan bound a) =>
+        [(bound - first) /^ stride]a
+    fromToDownBy :
+      {first, last, stride, a}
+        (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+        [1 + (first - last) / stride]a
+    fromToDownByGreaterThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+        [(first - bound) /^ stride]a
+    fromToLessThan :
+      {first, bound, a}
+        (fin first, bound >= first, LiteralLessThan bound a) =>
+        [bound - first]a
+    fromZ : {n} (fin n, n >= 1) => Z n -> Integer
+    generate :
+      {n, a, ix} (Integral ix, LiteralLessThan n ix) => (ix -> a) -> [n]a
+    groupBy : {each, parts, a} (fin each) => [each * parts]a -> [parts][each]a
+    head : {n, a} [1 + n]a -> a
+    infFrom : {a} (Integral a) => a -> [inf]a
+    infFromThen : {a} (Integral a) => a -> a -> [inf]a
+    iterate : {a} (a -> a) -> a -> [inf]a
+    join : {parts, each, a} (fin each) => [parts][each]a -> [parts * each]a
+    last : {n, a} (fin n) => [1 + n]a -> a
+    length : {n, a, b} (fin n, Literal n b) => [n]a -> b
+    lg2 : {n} (fin n) => [n] -> [n]
+    map : {n, a, b} (a -> b) -> [n]a -> [n]b
+    max : {a} (Cmp a) => a -> a -> a
+    min : {a} (Cmp a) => a -> a -> a
+    negate : {a} (Ring a) => a -> a
+    number : {val, rep} (Literal val rep) => rep
+    or : {n} (fin n) => [n] -> Bit
+    parmap : {a, b, n} (Eq b, fin n) => (a -> b) -> [n]a -> [n]b
+    pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+    pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+    pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
+    product : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
+    repeat : {n, a} a -> [n]a
+    reverse : {n, a} (fin n) => [n]a -> [n]a
+    rnf : {a} (Eq a) => a -> a
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
+    sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    scanl : {n, a, b} (a -> b -> a) -> a -> [n]b -> [1 + n]a
+    scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b
+    scarry : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    sext : {m, n} (fin m, m >= n, n >= 1) => [n] -> [m]
+    sort : {a, n} (Cmp a, fin n) => [n]a -> [n]a
+    sortBy : {a, n} (fin n) => (a -> a -> Bit) -> [n]a -> [n]a
+    split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
+    splitAt :
+      {front, back, a} (fin front) => [front + back]a -> ([front]a, [back]a)
+    sum : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    True : Bit
+    tail : {n, a} [1 + n]a -> [n]a
+    take : {front, back, a} [front + back]a -> [front]a
+    toInteger : {a} (Integral a) => a -> Integer
+    toSignedInteger : {n} (fin n, n >= 1) => [n] -> Integer
+    trace : {n, a, b} (fin n) => String n -> a -> b -> b
+    traceVal : {n, a} (fin n) => String n -> a -> a
+    transpose : {rows, cols, a} [rows][cols]a -> [cols][rows]a
+    trunc : {a} (Round a) => a -> Integer
+    uncurry : {a, b, c} (a -> b -> c) -> (a, b) -> c
+    undefined : {a} a
+    update : {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+    updateEnd : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+    updates :
+      {n, k, ix, a} (Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    updatesEnd :
+      {n, k, ix, a} (fin n, Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    zero : {a} (Zero a) => a
+    zext : {m, n} (fin m, m >= n) => [n] -> [m]
+    zip : {n, a, b} [n]a -> [n]b -> [n](a, b)
+    zipWith : {n, a, b, c} (a -> b -> c) -> [n]a -> [n]b -> [n]c
+     
+  From Inst1
+  ----------
+       
+    a : [4]
+    b : [m]
+    x : [4]
+    y : [8]
+     

--- a/tests/issues/issue1455_2.icry
+++ b/tests/issues/issue1455_2.icry
@@ -1,0 +1,9 @@
+:l issue1455/Inst2.cry
+`n
+`(m 3) : Integer
+x
+y
+:t a
+:t b
+1 + 1 : Integer
+:browse

--- a/tests/issues/issue1455_2.icry.stdout
+++ b/tests/issues/issue1455_2.icry.stdout
@@ -1,0 +1,257 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Loading module F
+Loading module Inst2
+
+[error] at issue1455_2.icry:2:2--2:3
+    Type not in scope: n
+6
+
+[error] at issue1455_2.icry:4:1--4:2
+    Value not in scope: x
+
+[error] at issue1455_2.icry:5:1--5:2
+    Value not in scope: y
+a : {n} (fin n, n >= 1, fin n, n >= 1) => {x : [n], y : [2 * n]} -> [n]
+b : {n} (fin n, n >= 1, fin n, n >= 1) => {x : [n], y : [2 * n]} -> [m n]
+2
+Type Synonyms
+=============
+    
+  From Cryptol
+  ------------
+       
+    type Bool = Bit
+    type Char = [8]
+    type lg2 n = width (max 1 n - 1)
+    type String n = [n]Char
+    type Word n = [n]
+     
+  From Inst2
+  ----------
+       
+    type m n = 2 * n
+     
+Constraint Synonyms
+===================
+    
+  From Cryptol
+  ------------
+       
+    type constraint i < j = j >= 1 + i
+    type constraint i <= j = j >= i
+    type constraint i > j = i >= 1 + j
+     
+Primitive Types
+===============
+    
+  From Cryptol
+  ------------
+       
+    (!=) : # -> # -> Prop
+    (==) : # -> # -> Prop
+    (>=) : # -> # -> Prop
+    (+) : # -> # -> #
+    (-) : # -> # -> #
+    (%) : # -> # -> #
+    (%^) : # -> # -> #
+    (*) : # -> # -> #
+    (/) : # -> # -> #
+    (/^) : # -> # -> #
+    (^^) : # -> # -> #
+    Bit : *
+    Cmp : * -> Prop
+    Eq : * -> Prop
+    FLiteral : # -> # -> # -> * -> Prop
+    Field : * -> Prop
+    fin : # -> Prop
+    Integer : *
+    Integral : * -> Prop
+    inf : #
+    Literal : # -> * -> Prop
+    LiteralLessThan : # -> * -> Prop
+    Logic : * -> Prop
+    lengthFromThenTo : # -> # -> # -> #
+    max : # -> # -> #
+    min : # -> # -> #
+    prime : # -> Prop
+    Rational : *
+    Ring : * -> Prop
+    Round : * -> Prop
+    SignedCmp : * -> Prop
+    width : # -> #
+    Z : # -> *
+    Zero : * -> Prop
+     
+Symbols
+=======
+    
+  From <interactive>
+  ------------------
+       
+    it : Integer
+     
+  From Cryptol
+  ------------
+       
+    (/.) : {a} (Field a) => a -> a -> a
+    (==>) : Bit -> Bit -> Bit
+    (\/) : Bit -> Bit -> Bit
+    (/\) : Bit -> Bit -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (<) : {a} (Cmp a) => a -> a -> Bit
+    (<$) : {a} (SignedCmp a) => a -> a -> Bit
+    (<=) : {a} (Cmp a) => a -> a -> Bit
+    (<=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>) : {a} (Cmp a) => a -> a -> Bit
+    (>$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>=) : {a} (Cmp a) => a -> a -> Bit
+    (>=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (||) : {a} (Logic a) => a -> a -> a
+    (^) : {a} (Logic a) => a -> a -> a
+    (&&) : {a} (Logic a) => a -> a -> a
+    (#) : {front, back, a} (fin front) => [front]a -> [back]a -> [front + back]a
+    (<<) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (<<<) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (>>) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (>>$) : {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+    (>>>) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (+) : {a} (Ring a) => a -> a -> a
+    (-) : {a} (Ring a) => a -> a -> a
+    (%) : {a} (Integral a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (*) : {a} (Ring a) => a -> a -> a
+    (/) : {a} (Integral a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (^^) : {a, e} (Ring a, Integral e) => a -> e -> a
+    (!) : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+    (!!) : {n, k, ix, a} (fin n, Integral ix) => [n]a -> [k]ix -> [k]a
+    (@) : {n, a, ix} (Integral ix) => [n]a -> ix -> a
+    (@@) : {n, k, ix, a} (Integral ix) => [n]a -> [k]ix -> [k]a
+    abs : {a} (Cmp a, Ring a) => a -> a
+    all : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    and : {n} (fin n) => [n] -> Bit
+    any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    assert : {a, n} (fin n) => Bit -> String n -> a -> a
+    carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : {a} (Round a) => a -> Integer
+    complement : {a} (Logic a) => a -> a
+    curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
+    deepseq : {a, b} (Eq a) => a -> b -> b
+    demote : {val, rep} (Literal val rep) => rep
+    drop : {front, back, a} (fin front) => [front + back]a -> [back]a
+    elem : {n, a} (fin n, Eq a) => a -> [n]a -> Bit
+    error : {a, n} (fin n) => String n -> a
+    False : Bit
+    floor : {a} (Round a) => a -> Integer
+    foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+    foldl' : {n, a, b} (fin n, Eq a) => (a -> b -> a) -> a -> [n]b -> a
+    foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
+    foldr' : {n, a, b} (fin n, Eq b) => (a -> b -> b) -> b -> [n]a -> b
+    fraction : {m, n, r, a} (FLiteral m n r a) => a
+    fromInteger : {a} (Ring a) => Integer -> a
+    fromThenTo :
+      {first, next, last, a, len}
+        (fin first, fin next, fin last, Literal first a, Literal next a,
+         Literal last a, first != next,
+         lengthFromThenTo first next last == len) =>
+        [len]a
+    fromTo :
+      {first, last, a}
+        (fin last, last >= first, Literal last a) =>
+        [1 + (last - first)]a
+    fromToBy :
+      {first, last, stride, a}
+        (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+        [1 + (last - first) / stride]a
+    fromToByLessThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, bound >= first,
+         LiteralLessThan bound a) =>
+        [(bound - first) /^ stride]a
+    fromToDownBy :
+      {first, last, stride, a}
+        (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+        [1 + (first - last) / stride]a
+    fromToDownByGreaterThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+        [(first - bound) /^ stride]a
+    fromToLessThan :
+      {first, bound, a}
+        (fin first, bound >= first, LiteralLessThan bound a) =>
+        [bound - first]a
+    fromZ : {n} (fin n, n >= 1) => Z n -> Integer
+    generate :
+      {n, a, ix} (Integral ix, LiteralLessThan n ix) => (ix -> a) -> [n]a
+    groupBy : {each, parts, a} (fin each) => [each * parts]a -> [parts][each]a
+    head : {n, a} [1 + n]a -> a
+    infFrom : {a} (Integral a) => a -> [inf]a
+    infFromThen : {a} (Integral a) => a -> a -> [inf]a
+    iterate : {a} (a -> a) -> a -> [inf]a
+    join : {parts, each, a} (fin each) => [parts][each]a -> [parts * each]a
+    last : {n, a} (fin n) => [1 + n]a -> a
+    length : {n, a, b} (fin n, Literal n b) => [n]a -> b
+    lg2 : {n} (fin n) => [n] -> [n]
+    map : {n, a, b} (a -> b) -> [n]a -> [n]b
+    max : {a} (Cmp a) => a -> a -> a
+    min : {a} (Cmp a) => a -> a -> a
+    negate : {a} (Ring a) => a -> a
+    number : {val, rep} (Literal val rep) => rep
+    or : {n} (fin n) => [n] -> Bit
+    parmap : {a, b, n} (Eq b, fin n) => (a -> b) -> [n]a -> [n]b
+    pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+    pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+    pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
+    product : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
+    repeat : {n, a} a -> [n]a
+    reverse : {n, a} (fin n) => [n]a -> [n]a
+    rnf : {a} (Eq a) => a -> a
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
+    sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    scanl : {n, a, b} (a -> b -> a) -> a -> [n]b -> [1 + n]a
+    scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b
+    scarry : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    sext : {m, n} (fin m, m >= n, n >= 1) => [n] -> [m]
+    sort : {a, n} (Cmp a, fin n) => [n]a -> [n]a
+    sortBy : {a, n} (fin n) => (a -> a -> Bit) -> [n]a -> [n]a
+    split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
+    splitAt :
+      {front, back, a} (fin front) => [front + back]a -> ([front]a, [back]a)
+    sum : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    True : Bit
+    tail : {n, a} [1 + n]a -> [n]a
+    take : {front, back, a} [front + back]a -> [front]a
+    toInteger : {a} (Integral a) => a -> Integer
+    toSignedInteger : {n} (fin n, n >= 1) => [n] -> Integer
+    trace : {n, a, b} (fin n) => String n -> a -> b -> b
+    traceVal : {n, a} (fin n) => String n -> a -> a
+    transpose : {rows, cols, a} [rows][cols]a -> [cols][rows]a
+    trunc : {a} (Round a) => a -> Integer
+    uncurry : {a, b, c} (a -> b -> c) -> (a, b) -> c
+    undefined : {a} a
+    update : {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+    updateEnd : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+    updates :
+      {n, k, ix, a} (Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    updatesEnd :
+      {n, k, ix, a} (fin n, Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    zero : {a} (Zero a) => a
+    zext : {m, n} (fin m, m >= n) => [n] -> [m]
+    zip : {n, a, b} [n]a -> [n]b -> [n](a, b)
+    zipWith : {n, a, b, c} (a -> b -> c) -> [n]a -> [n]b -> [n]c
+     
+  From Inst2
+  ----------
+       
+    a : {n} (fin n, n >= 1, fin n, n >= 1) => {x : [n], y : [2 * n]} -> [n]
+    b : {n} (fin n, n >= 1, fin n, n >= 1) => {x : [n], y : [2 * n]} -> [m n]
+     

--- a/tests/issues/issue1455_3.icry
+++ b/tests/issues/issue1455_3.icry
@@ -1,0 +1,15 @@
+:l issue1455/Inst3.cry
+`n : Integer
+`m : Integer
+x
+y
+:t x
+:t y
+a
+b
+c
+:t a
+:t b
+:t c
+c + 2
+:browse

--- a/tests/issues/issue1455_3.icry.stdout
+++ b/tests/issues/issue1455_3.icry.stdout
@@ -1,0 +1,275 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Loading module F
+Loading module G
+Loading module M
+Loading module Inst3
+4
+8
+0x3
+0x05
+x : [4]
+y : [8]
+0x4
+0x06
+0x0b
+a : [4]
+b : [8]
+c : [m]
+0x0d
+Submodules
+==========
+    
+  From Inst3
+  ----------
+       
+    import of F at issue1455/G.cry:5:1--5:9
+     
+Type Synonyms
+=============
+    
+  From Cryptol
+  ------------
+       
+    type Bool = Bit
+    type Char = [8]
+    type lg2 n = width (max 1 n - 1)
+    type String n = [n]Char
+    type Word n = [n]
+     
+  From Inst3
+  ----------
+       
+    type m = 8
+    type n = 4
+     
+Constraint Synonyms
+===================
+    
+  From Cryptol
+  ------------
+       
+    type constraint i < j = j >= 1 + i
+    type constraint i <= j = j >= i
+    type constraint i > j = i >= 1 + j
+     
+Primitive Types
+===============
+    
+  From Cryptol
+  ------------
+       
+    (!=) : # -> # -> Prop
+    (==) : # -> # -> Prop
+    (>=) : # -> # -> Prop
+    (+) : # -> # -> #
+    (-) : # -> # -> #
+    (%) : # -> # -> #
+    (%^) : # -> # -> #
+    (*) : # -> # -> #
+    (/) : # -> # -> #
+    (/^) : # -> # -> #
+    (^^) : # -> # -> #
+    Bit : *
+    Cmp : * -> Prop
+    Eq : * -> Prop
+    FLiteral : # -> # -> # -> * -> Prop
+    Field : * -> Prop
+    fin : # -> Prop
+    Integer : *
+    Integral : * -> Prop
+    inf : #
+    Literal : # -> * -> Prop
+    LiteralLessThan : # -> * -> Prop
+    Logic : * -> Prop
+    lengthFromThenTo : # -> # -> # -> #
+    max : # -> # -> #
+    min : # -> # -> #
+    prime : # -> Prop
+    Rational : *
+    Ring : * -> Prop
+    Round : * -> Prop
+    SignedCmp : * -> Prop
+    width : # -> #
+    Z : # -> *
+    Zero : * -> Prop
+     
+Symbols
+=======
+    
+  From <interactive>
+  ------------------
+       
+    it : [8]
+     
+  From Cryptol
+  ------------
+       
+    (/.) : {a} (Field a) => a -> a -> a
+    (==>) : Bit -> Bit -> Bit
+    (\/) : Bit -> Bit -> Bit
+    (/\) : Bit -> Bit -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (<) : {a} (Cmp a) => a -> a -> Bit
+    (<$) : {a} (SignedCmp a) => a -> a -> Bit
+    (<=) : {a} (Cmp a) => a -> a -> Bit
+    (<=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>) : {a} (Cmp a) => a -> a -> Bit
+    (>$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>=) : {a} (Cmp a) => a -> a -> Bit
+    (>=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (||) : {a} (Logic a) => a -> a -> a
+    (^) : {a} (Logic a) => a -> a -> a
+    (&&) : {a} (Logic a) => a -> a -> a
+    (#) : {front, back, a} (fin front) => [front]a -> [back]a -> [front + back]a
+    (<<) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (<<<) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (>>) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (>>$) : {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+    (>>>) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (+) : {a} (Ring a) => a -> a -> a
+    (-) : {a} (Ring a) => a -> a -> a
+    (%) : {a} (Integral a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (*) : {a} (Ring a) => a -> a -> a
+    (/) : {a} (Integral a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (^^) : {a, e} (Ring a, Integral e) => a -> e -> a
+    (!) : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+    (!!) : {n, k, ix, a} (fin n, Integral ix) => [n]a -> [k]ix -> [k]a
+    (@) : {n, a, ix} (Integral ix) => [n]a -> ix -> a
+    (@@) : {n, k, ix, a} (Integral ix) => [n]a -> [k]ix -> [k]a
+    abs : {a} (Cmp a, Ring a) => a -> a
+    all : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    and : {n} (fin n) => [n] -> Bit
+    any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    assert : {a, n} (fin n) => Bit -> String n -> a -> a
+    carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : {a} (Round a) => a -> Integer
+    complement : {a} (Logic a) => a -> a
+    curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
+    deepseq : {a, b} (Eq a) => a -> b -> b
+    demote : {val, rep} (Literal val rep) => rep
+    drop : {front, back, a} (fin front) => [front + back]a -> [back]a
+    elem : {n, a} (fin n, Eq a) => a -> [n]a -> Bit
+    error : {a, n} (fin n) => String n -> a
+    False : Bit
+    floor : {a} (Round a) => a -> Integer
+    foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+    foldl' : {n, a, b} (fin n, Eq a) => (a -> b -> a) -> a -> [n]b -> a
+    foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
+    foldr' : {n, a, b} (fin n, Eq b) => (a -> b -> b) -> b -> [n]a -> b
+    fraction : {m, n, r, a} (FLiteral m n r a) => a
+    fromInteger : {a} (Ring a) => Integer -> a
+    fromThenTo :
+      {first, next, last, a, len}
+        (fin first, fin next, fin last, Literal first a, Literal next a,
+         Literal last a, first != next,
+         lengthFromThenTo first next last == len) =>
+        [len]a
+    fromTo :
+      {first, last, a}
+        (fin last, last >= first, Literal last a) =>
+        [1 + (last - first)]a
+    fromToBy :
+      {first, last, stride, a}
+        (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+        [1 + (last - first) / stride]a
+    fromToByLessThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, bound >= first,
+         LiteralLessThan bound a) =>
+        [(bound - first) /^ stride]a
+    fromToDownBy :
+      {first, last, stride, a}
+        (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+        [1 + (first - last) / stride]a
+    fromToDownByGreaterThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+        [(first - bound) /^ stride]a
+    fromToLessThan :
+      {first, bound, a}
+        (fin first, bound >= first, LiteralLessThan bound a) =>
+        [bound - first]a
+    fromZ : {n} (fin n, n >= 1) => Z n -> Integer
+    generate :
+      {n, a, ix} (Integral ix, LiteralLessThan n ix) => (ix -> a) -> [n]a
+    groupBy : {each, parts, a} (fin each) => [each * parts]a -> [parts][each]a
+    head : {n, a} [1 + n]a -> a
+    infFrom : {a} (Integral a) => a -> [inf]a
+    infFromThen : {a} (Integral a) => a -> a -> [inf]a
+    iterate : {a} (a -> a) -> a -> [inf]a
+    join : {parts, each, a} (fin each) => [parts][each]a -> [parts * each]a
+    last : {n, a} (fin n) => [1 + n]a -> a
+    length : {n, a, b} (fin n, Literal n b) => [n]a -> b
+    lg2 : {n} (fin n) => [n] -> [n]
+    map : {n, a, b} (a -> b) -> [n]a -> [n]b
+    max : {a} (Cmp a) => a -> a -> a
+    min : {a} (Cmp a) => a -> a -> a
+    negate : {a} (Ring a) => a -> a
+    number : {val, rep} (Literal val rep) => rep
+    or : {n} (fin n) => [n] -> Bit
+    parmap : {a, b, n} (Eq b, fin n) => (a -> b) -> [n]a -> [n]b
+    pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+    pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+    pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
+    product : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
+    repeat : {n, a} a -> [n]a
+    reverse : {n, a} (fin n) => [n]a -> [n]a
+    rnf : {a} (Eq a) => a -> a
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
+    sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    scanl : {n, a, b} (a -> b -> a) -> a -> [n]b -> [1 + n]a
+    scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b
+    scarry : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    sext : {m, n} (fin m, m >= n, n >= 1) => [n] -> [m]
+    sort : {a, n} (Cmp a, fin n) => [n]a -> [n]a
+    sortBy : {a, n} (fin n) => (a -> a -> Bit) -> [n]a -> [n]a
+    split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
+    splitAt :
+      {front, back, a} (fin front) => [front + back]a -> ([front]a, [back]a)
+    sum : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    True : Bit
+    tail : {n, a} [1 + n]a -> [n]a
+    take : {front, back, a} [front + back]a -> [front]a
+    toInteger : {a} (Integral a) => a -> Integer
+    toSignedInteger : {n} (fin n, n >= 1) => [n] -> Integer
+    trace : {n, a, b} (fin n) => String n -> a -> b -> b
+    traceVal : {n, a} (fin n) => String n -> a -> a
+    transpose : {rows, cols, a} [rows][cols]a -> [cols][rows]a
+    trunc : {a} (Round a) => a -> Integer
+    uncurry : {a, b, c} (a -> b -> c) -> (a, b) -> c
+    undefined : {a} a
+    update : {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+    updateEnd : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+    updates :
+      {n, k, ix, a} (Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    updatesEnd :
+      {n, k, ix, a} (fin n, Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    zero : {a} (Zero a) => a
+    zext : {m, n} (fin m, m >= n) => [n] -> [m]
+    zip : {n, a, b} [n]a -> [n]b -> [n](a, b)
+    zipWith : {n, a, b, c} (a -> b -> c) -> [n]a -> [n]b -> [n]c
+     
+  From Inst3
+  ----------
+       
+    c : [m]
+    x : [4]
+    y : [8]
+     
+  From Inst3::import of F at issue1455/G.cry:5:1--5:9
+  ---------------------------------------------------
+       
+    a : [4]
+    b : [8]
+     

--- a/tests/issues/issue1455_3.icry.stdout.mingw32
+++ b/tests/issues/issue1455_3.icry.stdout.mingw32
@@ -1,0 +1,275 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Loading module F
+Loading module G
+Loading module M
+Loading module Inst3
+4
+8
+0x3
+0x05
+x : [4]
+y : [8]
+0x4
+0x06
+0x0b
+a : [4]
+b : [8]
+c : [m]
+0x0d
+Submodules
+==========
+    
+  From Inst3
+  ----------
+       
+    import of F at issue1455\G.cry:5:1--5:9
+     
+Type Synonyms
+=============
+    
+  From Cryptol
+  ------------
+       
+    type Bool = Bit
+    type Char = [8]
+    type lg2 n = width (max 1 n - 1)
+    type String n = [n]Char
+    type Word n = [n]
+     
+  From Inst3
+  ----------
+       
+    type m = 8
+    type n = 4
+     
+Constraint Synonyms
+===================
+    
+  From Cryptol
+  ------------
+       
+    type constraint i < j = j >= 1 + i
+    type constraint i <= j = j >= i
+    type constraint i > j = i >= 1 + j
+     
+Primitive Types
+===============
+    
+  From Cryptol
+  ------------
+       
+    (!=) : # -> # -> Prop
+    (==) : # -> # -> Prop
+    (>=) : # -> # -> Prop
+    (+) : # -> # -> #
+    (-) : # -> # -> #
+    (%) : # -> # -> #
+    (%^) : # -> # -> #
+    (*) : # -> # -> #
+    (/) : # -> # -> #
+    (/^) : # -> # -> #
+    (^^) : # -> # -> #
+    Bit : *
+    Cmp : * -> Prop
+    Eq : * -> Prop
+    FLiteral : # -> # -> # -> * -> Prop
+    Field : * -> Prop
+    fin : # -> Prop
+    Integer : *
+    Integral : * -> Prop
+    inf : #
+    Literal : # -> * -> Prop
+    LiteralLessThan : # -> * -> Prop
+    Logic : * -> Prop
+    lengthFromThenTo : # -> # -> # -> #
+    max : # -> # -> #
+    min : # -> # -> #
+    prime : # -> Prop
+    Rational : *
+    Ring : * -> Prop
+    Round : * -> Prop
+    SignedCmp : * -> Prop
+    width : # -> #
+    Z : # -> *
+    Zero : * -> Prop
+     
+Symbols
+=======
+    
+  From <interactive>
+  ------------------
+       
+    it : [8]
+     
+  From Cryptol
+  ------------
+       
+    (/.) : {a} (Field a) => a -> a -> a
+    (==>) : Bit -> Bit -> Bit
+    (\/) : Bit -> Bit -> Bit
+    (/\) : Bit -> Bit -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (<) : {a} (Cmp a) => a -> a -> Bit
+    (<$) : {a} (SignedCmp a) => a -> a -> Bit
+    (<=) : {a} (Cmp a) => a -> a -> Bit
+    (<=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>) : {a} (Cmp a) => a -> a -> Bit
+    (>$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>=) : {a} (Cmp a) => a -> a -> Bit
+    (>=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (||) : {a} (Logic a) => a -> a -> a
+    (^) : {a} (Logic a) => a -> a -> a
+    (&&) : {a} (Logic a) => a -> a -> a
+    (#) : {front, back, a} (fin front) => [front]a -> [back]a -> [front + back]a
+    (<<) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (<<<) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (>>) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (>>$) : {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+    (>>>) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (+) : {a} (Ring a) => a -> a -> a
+    (-) : {a} (Ring a) => a -> a -> a
+    (%) : {a} (Integral a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (*) : {a} (Ring a) => a -> a -> a
+    (/) : {a} (Integral a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (^^) : {a, e} (Ring a, Integral e) => a -> e -> a
+    (!) : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+    (!!) : {n, k, ix, a} (fin n, Integral ix) => [n]a -> [k]ix -> [k]a
+    (@) : {n, a, ix} (Integral ix) => [n]a -> ix -> a
+    (@@) : {n, k, ix, a} (Integral ix) => [n]a -> [k]ix -> [k]a
+    abs : {a} (Cmp a, Ring a) => a -> a
+    all : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    and : {n} (fin n) => [n] -> Bit
+    any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    assert : {a, n} (fin n) => Bit -> String n -> a -> a
+    carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : {a} (Round a) => a -> Integer
+    complement : {a} (Logic a) => a -> a
+    curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
+    deepseq : {a, b} (Eq a) => a -> b -> b
+    demote : {val, rep} (Literal val rep) => rep
+    drop : {front, back, a} (fin front) => [front + back]a -> [back]a
+    elem : {n, a} (fin n, Eq a) => a -> [n]a -> Bit
+    error : {a, n} (fin n) => String n -> a
+    False : Bit
+    floor : {a} (Round a) => a -> Integer
+    foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+    foldl' : {n, a, b} (fin n, Eq a) => (a -> b -> a) -> a -> [n]b -> a
+    foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
+    foldr' : {n, a, b} (fin n, Eq b) => (a -> b -> b) -> b -> [n]a -> b
+    fraction : {m, n, r, a} (FLiteral m n r a) => a
+    fromInteger : {a} (Ring a) => Integer -> a
+    fromThenTo :
+      {first, next, last, a, len}
+        (fin first, fin next, fin last, Literal first a, Literal next a,
+         Literal last a, first != next,
+         lengthFromThenTo first next last == len) =>
+        [len]a
+    fromTo :
+      {first, last, a}
+        (fin last, last >= first, Literal last a) =>
+        [1 + (last - first)]a
+    fromToBy :
+      {first, last, stride, a}
+        (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+        [1 + (last - first) / stride]a
+    fromToByLessThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, bound >= first,
+         LiteralLessThan bound a) =>
+        [(bound - first) /^ stride]a
+    fromToDownBy :
+      {first, last, stride, a}
+        (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+        [1 + (first - last) / stride]a
+    fromToDownByGreaterThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+        [(first - bound) /^ stride]a
+    fromToLessThan :
+      {first, bound, a}
+        (fin first, bound >= first, LiteralLessThan bound a) =>
+        [bound - first]a
+    fromZ : {n} (fin n, n >= 1) => Z n -> Integer
+    generate :
+      {n, a, ix} (Integral ix, LiteralLessThan n ix) => (ix -> a) -> [n]a
+    groupBy : {each, parts, a} (fin each) => [each * parts]a -> [parts][each]a
+    head : {n, a} [1 + n]a -> a
+    infFrom : {a} (Integral a) => a -> [inf]a
+    infFromThen : {a} (Integral a) => a -> a -> [inf]a
+    iterate : {a} (a -> a) -> a -> [inf]a
+    join : {parts, each, a} (fin each) => [parts][each]a -> [parts * each]a
+    last : {n, a} (fin n) => [1 + n]a -> a
+    length : {n, a, b} (fin n, Literal n b) => [n]a -> b
+    lg2 : {n} (fin n) => [n] -> [n]
+    map : {n, a, b} (a -> b) -> [n]a -> [n]b
+    max : {a} (Cmp a) => a -> a -> a
+    min : {a} (Cmp a) => a -> a -> a
+    negate : {a} (Ring a) => a -> a
+    number : {val, rep} (Literal val rep) => rep
+    or : {n} (fin n) => [n] -> Bit
+    parmap : {a, b, n} (Eq b, fin n) => (a -> b) -> [n]a -> [n]b
+    pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+    pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+    pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
+    product : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
+    repeat : {n, a} a -> [n]a
+    reverse : {n, a} (fin n) => [n]a -> [n]a
+    rnf : {a} (Eq a) => a -> a
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
+    sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    scanl : {n, a, b} (a -> b -> a) -> a -> [n]b -> [1 + n]a
+    scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b
+    scarry : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    sext : {m, n} (fin m, m >= n, n >= 1) => [n] -> [m]
+    sort : {a, n} (Cmp a, fin n) => [n]a -> [n]a
+    sortBy : {a, n} (fin n) => (a -> a -> Bit) -> [n]a -> [n]a
+    split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
+    splitAt :
+      {front, back, a} (fin front) => [front + back]a -> ([front]a, [back]a)
+    sum : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    True : Bit
+    tail : {n, a} [1 + n]a -> [n]a
+    take : {front, back, a} [front + back]a -> [front]a
+    toInteger : {a} (Integral a) => a -> Integer
+    toSignedInteger : {n} (fin n, n >= 1) => [n] -> Integer
+    trace : {n, a, b} (fin n) => String n -> a -> b -> b
+    traceVal : {n, a} (fin n) => String n -> a -> a
+    transpose : {rows, cols, a} [rows][cols]a -> [cols][rows]a
+    trunc : {a} (Round a) => a -> Integer
+    uncurry : {a, b, c} (a -> b -> c) -> (a, b) -> c
+    undefined : {a} a
+    update : {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+    updateEnd : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+    updates :
+      {n, k, ix, a} (Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    updatesEnd :
+      {n, k, ix, a} (fin n, Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    zero : {a} (Zero a) => a
+    zext : {m, n} (fin m, m >= n) => [n] -> [m]
+    zip : {n, a, b} [n]a -> [n]b -> [n](a, b)
+    zipWith : {n, a, b, c} (a -> b -> c) -> [n]a -> [n]b -> [n]c
+     
+  From Inst3
+  ----------
+       
+    c : [m]
+    x : [4]
+    y : [8]
+     
+  From Inst3::import of F at issue1455\G.cry:5:1--5:9
+  ---------------------------------------------------
+       
+    a : [4]
+    b : [8]
+     

--- a/tests/issues/issue1561/F.cry
+++ b/tests/issues/issue1561/F.cry
@@ -1,0 +1,10 @@
+module F where
+
+import interface I
+import interface I as J
+
+a = x + 1
+b = y + 2
+
+ja = J::x + 1
+jb = J::y + 2

--- a/tests/issues/issue1561/G.cry
+++ b/tests/issues/issue1561/G.cry
@@ -1,0 +1,10 @@
+module G where
+
+import interface I as J
+import interface I as K
+
+ja = J::x + 1
+jb = J::y + 2
+
+ka = K::x + 1
+kb = K::y + 2

--- a/tests/issues/issue1561/I.cry
+++ b/tests/issues/issue1561/I.cry
@@ -1,0 +1,8 @@
+interface module I where
+
+type n : #
+type m = 2 * n
+type constraint (fin n, n >= 1)
+
+x : [n]
+y : [m]

--- a/tests/issues/issue1561/Inst1.cry
+++ b/tests/issues/issue1561/Inst1.cry
@@ -1,0 +1,1 @@
+module Inst1 = F { I = M, J = N }

--- a/tests/issues/issue1561/Inst2.cry
+++ b/tests/issues/issue1561/Inst2.cry
@@ -1,0 +1,1 @@
+module Inst2 = G { J = M, K = N }

--- a/tests/issues/issue1561/M.cry
+++ b/tests/issues/issue1561/M.cry
@@ -1,0 +1,6 @@
+module M where
+
+type n = 2
+
+x = 3
+y = 15

--- a/tests/issues/issue1561/N.cry
+++ b/tests/issues/issue1561/N.cry
@@ -1,0 +1,6 @@
+module N where
+
+type n = 3
+
+x = 5
+y = 20

--- a/tests/issues/issue1561_1.icry
+++ b/tests/issues/issue1561_1.icry
@@ -1,0 +1,23 @@
+:l issue1561/Inst1.cry
+`n : Integer
+`m : Integer
+`J::n : Integer
+`J::m : Integer
+x
+y
+J::x
+J::y
+:t x
+:t y
+:t J::x
+:t J::y
+a
+b
+ja
+jb
+:t a
+:t b
+:t ja
+:t jb
+a + 2
+:browse

--- a/tests/issues/issue1561_1.icry.stdout
+++ b/tests/issues/issue1561_1.icry.stdout
@@ -1,0 +1,276 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Loading module F
+Loading module N
+Loading module M
+Loading module Inst1
+2
+4
+3
+6
+0x3
+0xf
+0x5
+0x14
+x : [2]
+y : [4]
+J::x : [3]
+J::y : [6]
+0x0
+0x1
+0x6
+0x16
+a : [2]
+b : [m]
+ja : [3]
+jb : [J::m]
+0x2
+Type Synonyms
+=============
+    
+  From Cryptol
+  ------------
+       
+    type Bool = Bit
+    type Char = [8]
+    type lg2 n = width (max 1 n - 1)
+    type String n = [n]Char
+    type Word n = [n]
+     
+  From Inst1
+  ----------
+       
+    type m = 4
+    type n = 2
+    type J::m = 6
+    type J::n = 3
+     
+Constraint Synonyms
+===================
+    
+  From Cryptol
+  ------------
+       
+    type constraint i < j = j >= 1 + i
+    type constraint i <= j = j >= i
+    type constraint i > j = i >= 1 + j
+     
+Primitive Types
+===============
+    
+  From Cryptol
+  ------------
+       
+    (!=) : # -> # -> Prop
+    (==) : # -> # -> Prop
+    (>=) : # -> # -> Prop
+    (+) : # -> # -> #
+    (-) : # -> # -> #
+    (%) : # -> # -> #
+    (%^) : # -> # -> #
+    (*) : # -> # -> #
+    (/) : # -> # -> #
+    (/^) : # -> # -> #
+    (^^) : # -> # -> #
+    Bit : *
+    Cmp : * -> Prop
+    Eq : * -> Prop
+    FLiteral : # -> # -> # -> * -> Prop
+    Field : * -> Prop
+    fin : # -> Prop
+    Integer : *
+    Integral : * -> Prop
+    inf : #
+    Literal : # -> * -> Prop
+    LiteralLessThan : # -> * -> Prop
+    Logic : * -> Prop
+    lengthFromThenTo : # -> # -> # -> #
+    max : # -> # -> #
+    min : # -> # -> #
+    prime : # -> Prop
+    Rational : *
+    Ring : * -> Prop
+    Round : * -> Prop
+    SignedCmp : * -> Prop
+    width : # -> #
+    Z : # -> *
+    Zero : * -> Prop
+     
+Symbols
+=======
+    
+  From <interactive>
+  ------------------
+       
+    it : [2]
+     
+  From Cryptol
+  ------------
+       
+    (/.) : {a} (Field a) => a -> a -> a
+    (==>) : Bit -> Bit -> Bit
+    (\/) : Bit -> Bit -> Bit
+    (/\) : Bit -> Bit -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (<) : {a} (Cmp a) => a -> a -> Bit
+    (<$) : {a} (SignedCmp a) => a -> a -> Bit
+    (<=) : {a} (Cmp a) => a -> a -> Bit
+    (<=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>) : {a} (Cmp a) => a -> a -> Bit
+    (>$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>=) : {a} (Cmp a) => a -> a -> Bit
+    (>=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (||) : {a} (Logic a) => a -> a -> a
+    (^) : {a} (Logic a) => a -> a -> a
+    (&&) : {a} (Logic a) => a -> a -> a
+    (#) : {front, back, a} (fin front) => [front]a -> [back]a -> [front + back]a
+    (<<) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (<<<) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (>>) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (>>$) : {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+    (>>>) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (+) : {a} (Ring a) => a -> a -> a
+    (-) : {a} (Ring a) => a -> a -> a
+    (%) : {a} (Integral a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (*) : {a} (Ring a) => a -> a -> a
+    (/) : {a} (Integral a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (^^) : {a, e} (Ring a, Integral e) => a -> e -> a
+    (!) : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+    (!!) : {n, k, ix, a} (fin n, Integral ix) => [n]a -> [k]ix -> [k]a
+    (@) : {n, a, ix} (Integral ix) => [n]a -> ix -> a
+    (@@) : {n, k, ix, a} (Integral ix) => [n]a -> [k]ix -> [k]a
+    abs : {a} (Cmp a, Ring a) => a -> a
+    all : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    and : {n} (fin n) => [n] -> Bit
+    any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    assert : {a, n} (fin n) => Bit -> String n -> a -> a
+    carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : {a} (Round a) => a -> Integer
+    complement : {a} (Logic a) => a -> a
+    curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
+    deepseq : {a, b} (Eq a) => a -> b -> b
+    demote : {val, rep} (Literal val rep) => rep
+    drop : {front, back, a} (fin front) => [front + back]a -> [back]a
+    elem : {n, a} (fin n, Eq a) => a -> [n]a -> Bit
+    error : {a, n} (fin n) => String n -> a
+    False : Bit
+    floor : {a} (Round a) => a -> Integer
+    foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+    foldl' : {n, a, b} (fin n, Eq a) => (a -> b -> a) -> a -> [n]b -> a
+    foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
+    foldr' : {n, a, b} (fin n, Eq b) => (a -> b -> b) -> b -> [n]a -> b
+    fraction : {m, n, r, a} (FLiteral m n r a) => a
+    fromInteger : {a} (Ring a) => Integer -> a
+    fromThenTo :
+      {first, next, last, a, len}
+        (fin first, fin next, fin last, Literal first a, Literal next a,
+         Literal last a, first != next,
+         lengthFromThenTo first next last == len) =>
+        [len]a
+    fromTo :
+      {first, last, a}
+        (fin last, last >= first, Literal last a) =>
+        [1 + (last - first)]a
+    fromToBy :
+      {first, last, stride, a}
+        (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+        [1 + (last - first) / stride]a
+    fromToByLessThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, bound >= first,
+         LiteralLessThan bound a) =>
+        [(bound - first) /^ stride]a
+    fromToDownBy :
+      {first, last, stride, a}
+        (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+        [1 + (first - last) / stride]a
+    fromToDownByGreaterThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+        [(first - bound) /^ stride]a
+    fromToLessThan :
+      {first, bound, a}
+        (fin first, bound >= first, LiteralLessThan bound a) =>
+        [bound - first]a
+    fromZ : {n} (fin n, n >= 1) => Z n -> Integer
+    generate :
+      {n, a, ix} (Integral ix, LiteralLessThan n ix) => (ix -> a) -> [n]a
+    groupBy : {each, parts, a} (fin each) => [each * parts]a -> [parts][each]a
+    head : {n, a} [1 + n]a -> a
+    infFrom : {a} (Integral a) => a -> [inf]a
+    infFromThen : {a} (Integral a) => a -> a -> [inf]a
+    iterate : {a} (a -> a) -> a -> [inf]a
+    join : {parts, each, a} (fin each) => [parts][each]a -> [parts * each]a
+    last : {n, a} (fin n) => [1 + n]a -> a
+    length : {n, a, b} (fin n, Literal n b) => [n]a -> b
+    lg2 : {n} (fin n) => [n] -> [n]
+    map : {n, a, b} (a -> b) -> [n]a -> [n]b
+    max : {a} (Cmp a) => a -> a -> a
+    min : {a} (Cmp a) => a -> a -> a
+    negate : {a} (Ring a) => a -> a
+    number : {val, rep} (Literal val rep) => rep
+    or : {n} (fin n) => [n] -> Bit
+    parmap : {a, b, n} (Eq b, fin n) => (a -> b) -> [n]a -> [n]b
+    pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+    pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+    pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
+    product : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
+    repeat : {n, a} a -> [n]a
+    reverse : {n, a} (fin n) => [n]a -> [n]a
+    rnf : {a} (Eq a) => a -> a
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
+    sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    scanl : {n, a, b} (a -> b -> a) -> a -> [n]b -> [1 + n]a
+    scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b
+    scarry : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    sext : {m, n} (fin m, m >= n, n >= 1) => [n] -> [m]
+    sort : {a, n} (Cmp a, fin n) => [n]a -> [n]a
+    sortBy : {a, n} (fin n) => (a -> a -> Bit) -> [n]a -> [n]a
+    split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
+    splitAt :
+      {front, back, a} (fin front) => [front + back]a -> ([front]a, [back]a)
+    sum : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    True : Bit
+    tail : {n, a} [1 + n]a -> [n]a
+    take : {front, back, a} [front + back]a -> [front]a
+    toInteger : {a} (Integral a) => a -> Integer
+    toSignedInteger : {n} (fin n, n >= 1) => [n] -> Integer
+    trace : {n, a, b} (fin n) => String n -> a -> b -> b
+    traceVal : {n, a} (fin n) => String n -> a -> a
+    transpose : {rows, cols, a} [rows][cols]a -> [cols][rows]a
+    trunc : {a} (Round a) => a -> Integer
+    uncurry : {a, b, c} (a -> b -> c) -> (a, b) -> c
+    undefined : {a} a
+    update : {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+    updateEnd : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+    updates :
+      {n, k, ix, a} (Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    updatesEnd :
+      {n, k, ix, a} (fin n, Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    zero : {a} (Zero a) => a
+    zext : {m, n} (fin m, m >= n) => [n] -> [m]
+    zip : {n, a, b} [n]a -> [n]b -> [n](a, b)
+    zipWith : {n, a, b, c} (a -> b -> c) -> [n]a -> [n]b -> [n]c
+     
+  From Inst1
+  ----------
+       
+    a : [2]
+    b : [m]
+    ja : [3]
+    jb : [J::m]
+    x : [2]
+    y : [4]
+    J::x : [3]
+    J::y : [6]
+     

--- a/tests/issues/issue1561_2.icry
+++ b/tests/issues/issue1561_2.icry
@@ -1,0 +1,27 @@
+:l issue1561/Inst2.cry
+`J::n : Integer
+`J::m : Integer
+`K::n : Integer
+`K::m : Integer
+J::x
+J::y
+K::x
+K::y
+:t J::x
+:t J::y
+:t K::x
+:t K::y
+`n
+`m
+x
+y
+ja
+jb
+ka
+kb
+:t ja
+:t jb
+:t ka
+:t kb
+ja + 2
+:browse

--- a/tests/issues/issue1561_2.icry.stdout
+++ b/tests/issues/issue1561_2.icry.stdout
@@ -1,0 +1,288 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Loading module G
+Loading module N
+Loading module M
+Loading module Inst2
+2
+4
+3
+6
+0x3
+0xf
+0x5
+0x14
+J::x : [2]
+J::y : [4]
+K::x : [3]
+K::y : [6]
+
+[error] at issue1561_2.icry:14:2--14:3
+    Type not in scope: n
+
+[error] at issue1561_2.icry:15:2--15:3
+    Type not in scope: m
+
+[error] at issue1561_2.icry:16:1--16:2
+    Value not in scope: x
+
+[error] at issue1561_2.icry:17:1--17:2
+    Value not in scope: y
+0x0
+0x1
+0x6
+0x16
+ja : [2]
+jb : [J::m]
+ka : [3]
+kb : [K::m]
+0x2
+Type Synonyms
+=============
+    
+  From Cryptol
+  ------------
+       
+    type Bool = Bit
+    type Char = [8]
+    type lg2 n = width (max 1 n - 1)
+    type String n = [n]Char
+    type Word n = [n]
+     
+  From Inst2
+  ----------
+       
+    type J::m = 4
+    type J::n = 2
+    type K::m = 6
+    type K::n = 3
+     
+Constraint Synonyms
+===================
+    
+  From Cryptol
+  ------------
+       
+    type constraint i < j = j >= 1 + i
+    type constraint i <= j = j >= i
+    type constraint i > j = i >= 1 + j
+     
+Primitive Types
+===============
+    
+  From Cryptol
+  ------------
+       
+    (!=) : # -> # -> Prop
+    (==) : # -> # -> Prop
+    (>=) : # -> # -> Prop
+    (+) : # -> # -> #
+    (-) : # -> # -> #
+    (%) : # -> # -> #
+    (%^) : # -> # -> #
+    (*) : # -> # -> #
+    (/) : # -> # -> #
+    (/^) : # -> # -> #
+    (^^) : # -> # -> #
+    Bit : *
+    Cmp : * -> Prop
+    Eq : * -> Prop
+    FLiteral : # -> # -> # -> * -> Prop
+    Field : * -> Prop
+    fin : # -> Prop
+    Integer : *
+    Integral : * -> Prop
+    inf : #
+    Literal : # -> * -> Prop
+    LiteralLessThan : # -> * -> Prop
+    Logic : * -> Prop
+    lengthFromThenTo : # -> # -> # -> #
+    max : # -> # -> #
+    min : # -> # -> #
+    prime : # -> Prop
+    Rational : *
+    Ring : * -> Prop
+    Round : * -> Prop
+    SignedCmp : * -> Prop
+    width : # -> #
+    Z : # -> *
+    Zero : * -> Prop
+     
+Symbols
+=======
+    
+  From <interactive>
+  ------------------
+       
+    it : [2]
+     
+  From Cryptol
+  ------------
+       
+    (/.) : {a} (Field a) => a -> a -> a
+    (==>) : Bit -> Bit -> Bit
+    (\/) : Bit -> Bit -> Bit
+    (/\) : Bit -> Bit -> Bit
+    (!=) : {a} (Eq a) => a -> a -> Bit
+    (!==) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (==) : {a} (Eq a) => a -> a -> Bit
+    (===) : {a, b} (Eq b) => (a -> b) -> (a -> b) -> a -> Bit
+    (<) : {a} (Cmp a) => a -> a -> Bit
+    (<$) : {a} (SignedCmp a) => a -> a -> Bit
+    (<=) : {a} (Cmp a) => a -> a -> Bit
+    (<=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>) : {a} (Cmp a) => a -> a -> Bit
+    (>$) : {a} (SignedCmp a) => a -> a -> Bit
+    (>=) : {a} (Cmp a) => a -> a -> Bit
+    (>=$) : {a} (SignedCmp a) => a -> a -> Bit
+    (||) : {a} (Logic a) => a -> a -> a
+    (^) : {a} (Logic a) => a -> a -> a
+    (&&) : {a} (Logic a) => a -> a -> a
+    (#) : {front, back, a} (fin front) => [front]a -> [back]a -> [front + back]a
+    (<<) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (<<<) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (>>) : {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+    (>>$) : {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+    (>>>) : {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+    (+) : {a} (Ring a) => a -> a -> a
+    (-) : {a} (Ring a) => a -> a -> a
+    (%) : {a} (Integral a) => a -> a -> a
+    (%$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (*) : {a} (Ring a) => a -> a -> a
+    (/) : {a} (Integral a) => a -> a -> a
+    (/$) : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+    (^^) : {a, e} (Ring a, Integral e) => a -> e -> a
+    (!) : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+    (!!) : {n, k, ix, a} (fin n, Integral ix) => [n]a -> [k]ix -> [k]a
+    (@) : {n, a, ix} (Integral ix) => [n]a -> ix -> a
+    (@@) : {n, k, ix, a} (Integral ix) => [n]a -> [k]ix -> [k]a
+    abs : {a} (Cmp a, Ring a) => a -> a
+    all : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    and : {n} (fin n) => [n] -> Bit
+    any : {n, a} (fin n) => (a -> Bit) -> [n]a -> Bit
+    assert : {a, n} (fin n) => Bit -> String n -> a -> a
+    carry : {n} (fin n) => [n] -> [n] -> Bit
+    ceiling : {a} (Round a) => a -> Integer
+    complement : {a} (Logic a) => a -> a
+    curry : {a, b, c} ((a, b) -> c) -> a -> b -> c
+    deepseq : {a, b} (Eq a) => a -> b -> b
+    demote : {val, rep} (Literal val rep) => rep
+    drop : {front, back, a} (fin front) => [front + back]a -> [back]a
+    elem : {n, a} (fin n, Eq a) => a -> [n]a -> Bit
+    error : {a, n} (fin n) => String n -> a
+    False : Bit
+    floor : {a} (Round a) => a -> Integer
+    foldl : {n, a, b} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+    foldl' : {n, a, b} (fin n, Eq a) => (a -> b -> a) -> a -> [n]b -> a
+    foldr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> b
+    foldr' : {n, a, b} (fin n, Eq b) => (a -> b -> b) -> b -> [n]a -> b
+    fraction : {m, n, r, a} (FLiteral m n r a) => a
+    fromInteger : {a} (Ring a) => Integer -> a
+    fromThenTo :
+      {first, next, last, a, len}
+        (fin first, fin next, fin last, Literal first a, Literal next a,
+         Literal last a, first != next,
+         lengthFromThenTo first next last == len) =>
+        [len]a
+    fromTo :
+      {first, last, a}
+        (fin last, last >= first, Literal last a) =>
+        [1 + (last - first)]a
+    fromToBy :
+      {first, last, stride, a}
+        (fin last, fin stride, stride >= 1, last >= first, Literal last a) =>
+        [1 + (last - first) / stride]a
+    fromToByLessThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, bound >= first,
+         LiteralLessThan bound a) =>
+        [(bound - first) /^ stride]a
+    fromToDownBy :
+      {first, last, stride, a}
+        (fin first, fin stride, stride >= 1, first >= last, Literal first a) =>
+        [1 + (first - last) / stride]a
+    fromToDownByGreaterThan :
+      {first, bound, stride, a}
+        (fin first, fin stride, stride >= 1, first >= bound, Literal first a) =>
+        [(first - bound) /^ stride]a
+    fromToLessThan :
+      {first, bound, a}
+        (fin first, bound >= first, LiteralLessThan bound a) =>
+        [bound - first]a
+    fromZ : {n} (fin n, n >= 1) => Z n -> Integer
+    generate :
+      {n, a, ix} (Integral ix, LiteralLessThan n ix) => (ix -> a) -> [n]a
+    groupBy : {each, parts, a} (fin each) => [each * parts]a -> [parts][each]a
+    head : {n, a} [1 + n]a -> a
+    infFrom : {a} (Integral a) => a -> [inf]a
+    infFromThen : {a} (Integral a) => a -> a -> [inf]a
+    iterate : {a} (a -> a) -> a -> [inf]a
+    join : {parts, each, a} (fin each) => [parts][each]a -> [parts * each]a
+    last : {n, a} (fin n) => [1 + n]a -> a
+    length : {n, a, b} (fin n, Literal n b) => [n]a -> b
+    lg2 : {n} (fin n) => [n] -> [n]
+    map : {n, a, b} (a -> b) -> [n]a -> [n]b
+    max : {a} (Cmp a) => a -> a -> a
+    min : {a} (Cmp a) => a -> a -> a
+    negate : {a} (Ring a) => a -> a
+    number : {val, rep} (Literal val rep) => rep
+    or : {n} (fin n) => [n] -> Bit
+    parmap : {a, b, n} (Eq b, fin n) => (a -> b) -> [n]a -> [n]b
+    pdiv : {u, v} (fin u, fin v) => [u] -> [v] -> [u]
+    pmod : {u, v} (fin u, fin v) => [u] -> [1 + v] -> [v]
+    pmult : {u, v} (fin u, fin v) => [1 + u] -> [1 + v] -> [1 + (u + v)]
+    product : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    random : {a} [256] -> a
+    ratio : Integer -> Integer -> Rational
+    recip : {a} (Field a) => a -> a
+    repeat : {n, a} a -> [n]a
+    reverse : {n, a} (fin n) => [n]a -> [n]a
+    rnf : {a} (Eq a) => a -> a
+    roundAway : {a} (Round a) => a -> Integer
+    roundToEven : {a} (Round a) => a -> Integer
+    sborrow : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    scanl : {n, a, b} (a -> b -> a) -> a -> [n]b -> [1 + n]a
+    scanr : {n, a, b} (fin n) => (a -> b -> b) -> b -> [n]a -> [1 + n]b
+    scarry : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+    sext : {m, n} (fin m, m >= n, n >= 1) => [n] -> [m]
+    sort : {a, n} (Cmp a, fin n) => [n]a -> [n]a
+    sortBy : {a, n} (fin n) => (a -> a -> Bit) -> [n]a -> [n]a
+    split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
+    splitAt :
+      {front, back, a} (fin front) => [front + back]a -> ([front]a, [back]a)
+    sum : {n, a} (fin n, Eq a, Ring a) => [n]a -> a
+    True : Bit
+    tail : {n, a} [1 + n]a -> [n]a
+    take : {front, back, a} [front + back]a -> [front]a
+    toInteger : {a} (Integral a) => a -> Integer
+    toSignedInteger : {n} (fin n, n >= 1) => [n] -> Integer
+    trace : {n, a, b} (fin n) => String n -> a -> b -> b
+    traceVal : {n, a} (fin n) => String n -> a -> a
+    transpose : {rows, cols, a} [rows][cols]a -> [cols][rows]a
+    trunc : {a} (Round a) => a -> Integer
+    uncurry : {a, b, c} (a -> b -> c) -> (a, b) -> c
+    undefined : {a} a
+    update : {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+    updateEnd : {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+    updates :
+      {n, k, ix, a} (Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    updatesEnd :
+      {n, k, ix, a} (fin n, Integral ix, fin k) => [n]a -> [k]ix -> [k]a -> [n]a
+    zero : {a} (Zero a) => a
+    zext : {m, n} (fin m, m >= n) => [n] -> [m]
+    zip : {n, a, b} [n]a -> [n]b -> [n](a, b)
+    zipWith : {n, a, b, c} (a -> b -> c) -> [n]a -> [n]b -> [n]c
+     
+  From Inst2
+  ----------
+       
+    ja : [2]
+    jb : [J::m]
+    ka : [3]
+    kb : [K::m]
+    J::x : [2]
+    J::y : [4]
+    K::x : [3]
+    K::y : [6]
+     

--- a/tests/issues/issue1562.cry
+++ b/tests/issues/issue1562.cry
@@ -1,0 +1,13 @@
+interface submodule I where
+  type Zp = [8]
+
+submodule F where
+  import interface submodule I
+
+submodule M where
+  // this is unused, but just here because syntactically we cannot have an empty
+  // module
+  type Empty = Bit
+
+submodule F1 = submodule F { submodule M }
+submodule F2 = submodule F { submodule M }

--- a/tests/issues/issue1562.icry
+++ b/tests/issues/issue1562.icry
@@ -1,0 +1,1 @@
+:l issue1562.cry

--- a/tests/issues/issue1562.icry.stdout
+++ b/tests/issues/issue1562.icry.stdout
@@ -1,0 +1,3 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main


### PR DESCRIPTION
Fixes #1455, making anything in scope of the functor in scope at the REPL as well when an instantiation of the functor is loaded and focused. In particular, the prelude will be in scope. As part of handling functor parameters correctly, this also fixes #1556, fixes #1237, fixes #1561, and fixes #1562.

In addition, this does some work towards implementing #1382, by storing the in-scope information for nested modules into `Cryptol.ModuleSystem.Interface.IFaceNames`.