### PR TITLE
Apply `apSubst` to `Type` field of `EPropGuards` in `TVars` instance for `Expr`

### DIFF
--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -436,7 +436,7 @@ instance TVars Expr where
         EWhere e ds   -> EWhere !$ (go e) !$ (apSubst su ds)
 
         EPropGuards guards ty -> EPropGuards
-          !$ (\(props, e) -> (apSubst su `fmap'` props, apSubst su e)) `fmap'` guards
+          !$ (\(props, e) -> (apSubst su `fmap'` props, go e)) `fmap'` guards
           !$ apSubst su ty
 
 instance TVars Match where

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -435,7 +435,9 @@ instance TVars Expr where
 
         EWhere e ds   -> EWhere !$ (go e) !$ (apSubst su ds)
 
-        EPropGuards guards ty -> EPropGuards !$ (\(props, e) -> (apSubst su `fmap'` props, apSubst su e)) `fmap'` guards .$ ty
+        EPropGuards guards ty -> EPropGuards
+          !$ (\(props, e) -> (apSubst su `fmap'` props, apSubst su e)) `fmap'` guards
+          !$ apSubst su ty
 
 instance TVars Match where
   apSubst su (From x len t e) = From x !$ (apSubst su len) !$ (apSubst su t) !$ (apSubst su e)


### PR DESCRIPTION
Fixes #1569.

Not really sure how to test this since the `Type` field is not really used within Cryptol itself. GaloisInc/saw-script#1923 does seem to be fixed by this change though.