### PR TITLE
Always show foreign dependencies in `file-deps`, and whether or not they exist on disk

### DIFF
--- a/cryptol-remote-api/src/CryptolServer/FileDeps.hs
+++ b/cryptol-remote-api/src/CryptolServer/FileDeps.hs
@@ -7,6 +7,7 @@ module CryptolServer.FileDeps
   ) where
 
 import Data.Text (Text)
+import qualified Data.Map as Map
 import qualified Data.Set as Set
 
 import qualified Data.Aeson as JSON
@@ -68,7 +69,7 @@ instance ToJSON FileDeps where
       , "fingerprint" .= fingerprintHexString (fiFingerprint fi)
       , "includes"    .= Set.toList (fiIncludeDeps fi)
       , "imports"     .= map (show . pp) (Set.toList (fiImportDeps fi))
-      , "foreign"     .= Set.toList (fiForeignDeps fi)
+      , "foreign"     .= Map.toList (fiForeignDeps fi)
       ]
     where
     fi = fdInfo fd

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -487,11 +487,11 @@ evalDecl sym renv env d = do
     DForeign _ me -> do
       -- Foreign declarations should have been handled by the previous
       -- Cryptol.Eval.FFI.evalForeignDecls pass already, so they should already
-      -- be in the environment. If not, then either Cryptol was not compiled
-      -- with FFI support enabled, or we are in a non-Concrete backend. In that
-      -- case, we bind the name to the fallback cryptol implementation if
-      -- present, or otherwise to an error computation which will raise an error
-      -- if we try to evaluate it.
+      -- be in the environment. If not, then either the foreign source was
+      -- missing, Cryptol was not compiled with FFI support enabled, or we are
+      -- in a non-Concrete backend. In that case, we bind the name to the
+      -- fallback cryptol implementation if present, or otherwise to an error
+      -- computation which will raise an error if we try to evaluate it.
       case lookupVar (dName d) env of
         Just _  -> pure env
         Nothing -> bindVar sym (dName d) val env

--- a/src/Cryptol/ModuleSystem/Env.hs
+++ b/src/Cryptol/ModuleSystem/Env.hs
@@ -564,7 +564,7 @@ data FileInfo = FileInfo
   { fiFingerprint :: Fingerprint
   , fiIncludeDeps :: Set FilePath
   , fiImportDeps  :: Set ModName
-  , fiForeignDeps :: Set FilePath
+  , fiForeignDeps :: Map FilePath Bool
   } deriving (Show,Generic,NFData)
 
 
@@ -579,9 +579,10 @@ fileInfo fp incDeps impDeps fsrc =
     { fiFingerprint = fp
     , fiIncludeDeps = incDeps
     , fiImportDeps  = impDeps
-    , fiForeignDeps = fromMaybe Set.empty
+    , fiForeignDeps = fromMaybe Map.empty
                       do src <- fsrc
-                         Set.singleton <$> getForeignSrcPath src
+                         fpath <- getForeignSrcPath src
+                         pure $ Map.singleton fpath True
     }
 
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -121,6 +121,7 @@ import Data.Bits (shiftL, (.&.), (.|.))
 import Data.Char (isSpace,isPunctuation,isSymbol,isAlphaNum,isAscii)
 import Data.Function (on)
 import Data.List (intercalate, nub, isPrefixOf)
+import qualified Data.Map as Map
 import Data.Maybe (fromMaybe,mapMaybe,isNothing)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode(ExitSuccess))
@@ -1823,7 +1824,7 @@ moduleInfoCmd isFile name
 
        depList show               "includes" (Set.toList (M.fiIncludeDeps fi))
        depList (show . show . pp) "imports"  (Set.toList (M.fiImportDeps  fi))
-       depList show               "foreign"  (Set.toList (M.fiForeignDeps fi))
+       depList show               "foreign"  (Map.toList (M.fiForeignDeps fi))
 
        rPutStrLn "}"
 


### PR DESCRIPTION
Make the `:file-deps` REPL command and the `file_deps` remote API call always return the path of a foreign dependency (shared library) when it __should__ exist (i.e. if there are `foreign` declarations in the module), instead of only if it currently exists. Furthermore, for each foreign dependency return a pair of a string and a boolean, representing the file path and whether or not the file actually currently exists. (In Python the pair is represented as a length-2 list.)

This addresses one part of #1574.