### PR TITLE
CI: Don't run `poetry update`

### DIFF
--- a/cryptol-remote-api/run_rpc_tests.sh
+++ b/cryptol-remote-api/run_rpc_tests.sh
@@ -23,7 +23,6 @@ get_server() {
 }
 
 echo "Setting up python environment for remote server clients..."
-poetry update
 poetry install
 
 echo "Typechecking code with mypy..."

--- a/cryptol-remote-api/test_docker.sh
+++ b/cryptol-remote-api/test_docker.sh
@@ -27,7 +27,6 @@ pushd $DIR/python
 NUM_FAILS=0
 
 echo "Setting up python environment for remote server clients..."
-poetry update
 poetry install
 
 export CRYPTOL_SERVER_URL="$PROTO://localhost:8080/"


### PR DESCRIPTION
This causes `poetry` to regenerate the `poetry.lock` file with newer versions of dependencies, which defeats the point of checking in the lock file in the first place.

This mirrors a similar change applied to SAW's CI in https://github.com/GaloisInc/saw-script/commit/67a25a81c4f154fd791188494d739274c7f1a236. The use of `poetry update` isn't actively causing problems with Cryptol's CI yet, but better to be safe than sorry.