### PR TITLE
Apply functor instantiation map to types

### DIFF
--- a/src/Cryptol/TypeCheck/Module.hs
+++ b/src/Cryptol/TypeCheck/Module.hs
@@ -53,8 +53,8 @@ doFunctorInst m f as instMap0 enclosingInScope doc =
               let (tySus,paramTySyns,decls,paramInstMaps) =
                     unzip4 [ (su,ts,ds,im) | DefinedInst su ts ds im <- as2 ]
               instMap <- addMissingTySyns mpath mf instMap0
-              let ?tSu = mergeDistinctSubst tySus
-                  ?vSu = instMap <> mconcat paramInstMaps
+              let ?tVarSu = mergeDistinctSubst tySus
+                  ?nameSu = instMap <> mconcat paramInstMaps
               let m1   = moduleInstance mf
                   m2   = m1 { mName             = m
                             , mDoc              = Nothing

--- a/src/Cryptol/TypeCheck/ModuleInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleInstance.hs
@@ -82,7 +82,7 @@ instance ModuleInstance (ModuleG name) where
            }
 
 instance ModuleInstance Type where
-  moduleInstance = doTInst
+  moduleInstance = doTVInst
 
 instance ModuleInstance Schema where
   moduleInstance = doTInst

--- a/src/Cryptol/TypeCheck/ModuleInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleInstance.hs
@@ -85,7 +85,7 @@ instance ModuleInstance Type where
   moduleInstance = doTVInst
 
 instance ModuleInstance Schema where
-  moduleInstance = doTInst
+  moduleInstance = doTVInst
 
 instance ModuleInstance TySyn where
   moduleInstance ts =

--- a/tests/issues/issue1590.cry
+++ b/tests/issues/issue1590.cry
@@ -1,0 +1,14 @@
+module Main where
+
+submodule F where
+  parameter
+    x : Bit
+  newtype T = { bit : Bit }
+  type U = T
+
+submodule M = submodule F where x = False
+
+import submodule M
+
+foo : U
+foo = T { bit = True }

--- a/tests/issues/issue1590.icry
+++ b/tests/issues/issue1590.icry
@@ -1,0 +1,1 @@
+:l issue1590.cry

--- a/tests/issues/issue1590.icry.stdout
+++ b/tests/issues/issue1590.icry.stdout
@@ -1,0 +1,3 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main


### PR DESCRIPTION
If a functor contains both a newtype and a type synonym referring to the newtype, then during instantiation we must apply the instantiation map to the types in the functor, so that the type synonym now refers to the instantiated newtype instead. Previously, we only applied type substitutions to the types in the functor, which would replace type variables with concrete types defined in the functor arguments, but would not replace any actual names.

Confusingly, the code referred to the instantiation map as "value substitutions" even though it can contain names in the type namespace. The "type substitutions" and "value substitutions" are better thought of as "`TVar -> Type` mappings" and "`Name -> Name` mappings". I have renamed them to better reflect this.

Fixes #1590.