### PR TITLE
CI fixes for #1598, #1599

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           poetry-version: 1.4.2
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04 AS build
 
+ARG GHCVER="9.2.8"
+ARG CABALVER="3.10.1.0"
 RUN apt-get update && \
     apt-get install -y \
       # ghcup requirements
@@ -24,15 +26,15 @@ RUN z3 --version
 ARG CRYPTOLPATH="/cryptol/.cryptol"
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
-COPY cabal.GHC-9.2.8.config cabal.project.freeze
+COPY cabal.GHC-${GHCVER}.config cabal.project.freeze
 RUN mkdir -p /home/cryptol/.local/bin && \
     curl -L https://downloads.haskell.org/~ghcup/0.1.19.4/x86_64-linux-ghcup-0.1.19.4 -o /home/cryptol/.local/bin/ghcup && \
     chmod +x /home/cryptol/.local/bin/ghcup
 RUN mkdir -p /home/cryptol/.ghcup && \
     ghcup --version && \
-    ghcup install cabal 3.10.1.0 && \
-    ghcup install ghc 9.2.8 && \
-    ghcup set ghc 9.2.8
+    ghcup install cabal ${CABALVER} && \
+    ghcup install ghc ${GHCVER} && \
+    ghcup set ghc ${GHCVER}
 RUN cabal v2-update && \
     cabal v2-build -j cryptol:exe:cryptol && \
     cp $(cabal v2-exec which cryptol) rootfs/usr/local/bin && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir -p /home/cryptol/.local/bin && \
     chmod +x /home/cryptol/.local/bin/ghcup
 RUN mkdir -p /home/cryptol/.ghcup && \
     ghcup --version && \
-    ghcup install cabal 3.6.2.0 && \
+    ghcup install cabal 3.10.1.0 && \
     ghcup install ghc 9.2.8 && \
     ghcup set ghc 9.2.8
 RUN cabal v2-update && \

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -1,6 +1,16 @@
 ARG GHCVER="9.2.8"
 ARG CABALVER="3.10.1.0"
+# This is the version of GHC that we use as part of the process of building a
+# separate copy of GHC from source. The version of GHC that we build from source
+# is determined by the value of GHCVER.
 ARG GHCVER_BOOTSTRAP="8.10.2"
+# We pin specific versions of alex and happy that are necessary to build
+# GHC. In general, we don't want to build the latest versions of each
+# tool, as GHC may not support them (see, for example,
+# https://github.com/GaloisInc/cryptol/issues/1599). If you update GHCVER, you
+# may need to update ALEXVER and HAPPYVER as well.
+ARG ALEXVER="3.4.0.1"
+ARG HAPPYVER="1.20.1.1"
 FROM ubuntu:22.04 AS toolchain
 ARG PORTABILITY=false
 RUN apt-get update && \
@@ -28,11 +38,7 @@ RUN if ${PORTABILITY}; then \
         ghcup install ghc ${GHCVER_BOOTSTRAP} && \
         ghcup set ghc ${GHCVER_BOOTSTRAP} && \
         cabal v2-update && \
-        # We pin specific versions of alex and happy that are necessary to build
-        # GHC. In general, we don't want to build the latest versions of each
-        # tool, as GHC may not support them (see, for example,
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/24302).
-        cabal v2-install alex-3.4.0.1 happy-1.20.1.1 && \
+        cabal v2-install alex-${ALEXVER} happy-${HAPPYVER} && \
         git clone --recurse-submodules --depth 1 --branch ghc-${GHCVER}-release https://gitlab.haskell.org/ghc/ghc.git && \
         cd ./ghc && \
         git apply ../ghc-portability.patch && \

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -27,7 +27,11 @@ RUN if ${PORTABILITY}; then \
         ghcup install ghc ${GHCVER_BOOTSTRAP} && \
         ghcup set ghc ${GHCVER_BOOTSTRAP} && \
         cabal v2-update && \
-        cabal v2-install alex happy-1.20.1.1 && \
+        # We pin specific versions of alex and happy that are necessary to build
+        # GHC. In general, we don't want to build the latest versions of each
+        # tool, as GHC may not support them (see, for example,
+        # https://gitlab.haskell.org/ghc/ghc/-/issues/24302).
+        cabal v2-install alex-3.4.0.1 happy-1.20.1.1 && \
         git clone --recurse-submodules --depth 1 --branch ghc-${GHCVER}-release https://gitlab.haskell.org/ghc/ghc.git && \
         cd ./ghc && \
         git apply ../ghc-portability.patch && \

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -18,7 +18,7 @@ ENV GHCUP_INSTALL_BASE_PREFIX=/opt \
     PATH=/opt/.ghcup/bin:$PATH
 RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.19.4/x86_64-linux-ghcup-0.1.19.4" && \
     chmod +x /usr/local/bin/ghcup
-RUN ghcup install cabal --set
+RUN ghcup install cabal 3.10.1.0 --set
 ENV PATH=/root/.cabal/bin:$PATH
 ADD ./cryptol-remote-api/ghc-portability.patch .
 ARG GHCVER

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 ENV GHCUP_INSTALL_BASE_PREFIX=/opt \
-    PATH=/opt/.ghcup/bin:$PATH
+    PATH=/opt/.ghcup/bin:/root/.local/bin:$PATH
 RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.19.4/x86_64-linux-ghcup-0.1.19.4" && \
     chmod +x /usr/local/bin/ghcup
 RUN ghcup install cabal 3.10.1.0 --set

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -1,4 +1,5 @@
 ARG GHCVER="9.2.8"
+ARG CABALVER="3.10.1.0"
 ARG GHCVER_BOOTSTRAP="8.10.2"
 FROM ubuntu:22.04 AS toolchain
 ARG PORTABILITY=false
@@ -18,7 +19,7 @@ ENV GHCUP_INSTALL_BASE_PREFIX=/opt \
     PATH=/opt/.ghcup/bin:/root/.local/bin:$PATH
 RUN curl -o /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/0.1.19.4/x86_64-linux-ghcup-0.1.19.4" && \
     chmod +x /usr/local/bin/ghcup
-RUN ghcup install cabal 3.10.1.0 --set
+RUN ghcup install cabal ${CABALVER} --set
 ENV PATH=/root/.cabal/bin:$PATH
 ADD ./cryptol-remote-api/ghc-portability.patch .
 ARG GHCVER


### PR DESCRIPTION
Two CI fixes:

## Switch from `haskell/actions/setup` to `haskell-actions/setup`

Fixes https://github.com/GaloisInc/cryptol/issues/1598.

## Pin `alex` to `3.4.0.1` in `cryptol-remote-api` Dockerfile

Fixes https://github.com/GaloisInc/cryptol/issues/1599.