### PR TITLE
`cryptol-remote-api` `Dockerfile`: Properly declare `ARG`s in toolchain stage

### DIFF
--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -33,7 +33,10 @@ RUN ghcup install cabal ${CABALVER} --set
 ENV PATH=/root/.cabal/bin:$PATH
 ADD ./cryptol-remote-api/ghc-portability.patch .
 ARG GHCVER
+ARG CABALVER
 ARG GHCVER_BOOTSTRAP
+ARG ALEXVER
+ARG HAPPYVER
 RUN if ${PORTABILITY}; then \
         ghcup install ghc ${GHCVER_BOOTSTRAP} && \
         ghcup set ghc ${GHCVER_BOOTSTRAP} && \


### PR DESCRIPTION
Addresses the issue identified in https://github.com/GaloisInc/cryptol/pull/1600#issuecomment-1878893019.