### PR TITLE
`cryptol-remote-api`: Check for valid evaluation contexts

### DIFF
--- a/cryptol-remote-api/CHANGELOG.md
+++ b/cryptol-remote-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for `cryptol-remote-api` and `cryptol-eval-server`
 
+## next -- TBA
+
+* Fix a bug in which the `check`, `prove or satisfy`, and `evaluate expression`
+  commands would fail to check the validity of the expression supplied as an
+  argument. Among other issues, this could cause the remote API to panic when
+  attempting to check an expression that depends on definitions from a
+  parameterized module.
+
 ## 3.1.0 -- 2024-02-05
 
 * The v3.1.0 release is made in tandem with the Cryptol 3.1.0 release. See the

--- a/cryptol-remote-api/docs/Errors.rst
+++ b/cryptol-remote-api/docs/Errors.rst
@@ -129,7 +129,7 @@ Evaluation errors (``20200``–``20499``)
    where the JSON object for ``type`` is a
    :ref:`JSON Cryptol type <cryptol-json-type>`.
 -  ``20220``: “Can’t evaluate Cryptol in a parameterized module”
-   ``{ modules: [String] }``
+   ``{ "type parameters": [String], "definitions": [String] }``
 -  ``20230``: “Prover error” ``{ error: String }``
 
 Module errors (``20500``–``20699``)

--- a/cryptol-remote-api/python/tests/cryptol/test_cryptol_api.py
+++ b/cryptol-remote-api/python/tests/cryptol/test_cryptol_api.py
@@ -9,6 +9,7 @@ import signal
 from distutils.spawn import find_executable
 import cryptol
 import argo_client.connection as argo
+from argo_client.interaction import ArgoException
 import cryptol.cryptoltypes
 from cryptol.single_connection import *
 from cryptol import solver
@@ -285,6 +286,28 @@ class TLSConnectionTests(unittest.TestCase):
             x_val1 = cry_eval("x")
             x_val2 = cry_eval("Id::id x")
             self.assertEqual(x_val1, x_val2)
+
+
+class CryptolParamModTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        connect(verify=False)
+        load_file(str(Path('tests','cryptol','test-files', 'Param.cry')))
+
+    def test_param_mod(self):
+        with self.assertRaises(ArgoException) as res:
+            check('foo')
+        e = res.exception
+        self.assertEqual(e.data['type parameters'], [])
+        self.assertEqual(e.data['definitions'], ['Param::foo'])
+
+        with self.assertRaises(ArgoException) as res:
+            check('`(w)')
+        e = res.exception
+        self.assertEqual(e.data['type parameters'], ['Param::`parameter` interface of Param::w'])
+        self.assertEqual(e.data['definitions'], [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cryptol-remote-api/src/CryptolServer/Check.hs
+++ b/cryptol-remote-api/src/CryptolServer/Check.hs
@@ -37,6 +37,7 @@ import CryptolServer
     ( getTCSolver,
       getModuleEnv,
       liftModuleCmd,
+      validEvalContext,
       CryptolMethod(raise),
       CryptolCommand )
 import CryptolServer.AesonCompat (KeyCompat)
@@ -56,7 +57,8 @@ check :: CheckParams -> CryptolCommand CheckResult
 check (CheckParams jsonExpr cMode) =
   do e <- getExpr jsonExpr
      (_expr, ty, schema) <- liftModuleCmd (CM.checkExpr e)
-     -- TODO? validEvalContext expr, ty, schema
+     validEvalContext ty
+     validEvalContext schema
      s <- getTCSolver
      perhapsDef <- liftIO (defaultReplExpr s ty schema)
      case perhapsDef of

--- a/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
+++ b/cryptol-remote-api/src/CryptolServer/EvalExpr.hs
@@ -42,9 +42,8 @@ evalExpression (EvalExprParams jsonExpr) =
 evalExpression' :: P.Expr P.PName -> CryptolCommand JSON.Value
 evalExpression' e = do
   (_expr, ty, schema) <- liftModuleCmd (checkExpr e)
-  -- TODO: see Cryptol REPL for how to check whether we
-  -- can actually evaluate things, which we can't do in
-  -- a parameterized module
+  validEvalContext ty
+  validEvalContext schema
   s <- getTCSolver
   perhapsDef <- liftIO (defaultReplExpr s ty schema)
   case perhapsDef of

--- a/cryptol-remote-api/src/CryptolServer/Exceptions.hs
+++ b/cryptol-remote-api/src/CryptolServer/Exceptions.hs
@@ -85,7 +85,7 @@ cryptolError modErr warns =
         (20711, [ ("source", jsonPretty src)
                 , ("errors", jsonPretty err')
                 ])
-        
+
       NoIncludeErrors src errs ->
         -- TODO: structured error here
         (20720, [ ("source", jsonPretty src)
@@ -171,11 +171,12 @@ unwantedDefaults defs =
       [ jsonTypeAndString ty <> fromListKM ["parameter" .= pretty param]
       | (param, ty) <- defs ] ]))
 
-evalInParamMod :: [CM.Name] -> JSONRPCException
-evalInParamMod mods =
+evalInParamMod :: [TC.TParam] -> [CM.Name] -> JSONRPCException
+evalInParamMod tyParams defs =
   makeJSONRPCException
     20220 "Can't evaluate Cryptol in a parameterized module."
-    (Just (JSON.object ["modules" .= map pretty mods]))
+    (Just (JSON.object ["type parameters" .= map pretty tyParams
+                       , "definitions" .= map pretty defs ]))
 
 evalPolyErr ::
   TC.Schema {- ^ the type that was too polymorphic -} ->

--- a/cryptol-remote-api/src/CryptolServer/Exceptions.hs
+++ b/cryptol-remote-api/src/CryptolServer/Exceptions.hs
@@ -81,9 +81,9 @@ cryptolError modErr warns =
         (20710, [ ("source", jsonPretty src)
                 , ("errors", jsonList (map jsonPretty errs))
                 ])
-      ExpandPropGuardsError src err ->
+      ExpandPropGuardsError src err' ->
         (20711, [ ("source", jsonPretty src)
-                , ("errors", jsonPretty err)
+                , ("errors", jsonPretty err')
                 ])
         
       NoIncludeErrors src errs ->

--- a/cryptol-remote-api/src/CryptolServer/Sat.hs
+++ b/cryptol-remote-api/src/CryptolServer/Sat.hs
@@ -55,7 +55,8 @@ proveSat :: ProveSatParams -> CryptolCommand ProveSatResult
 proveSat (ProveSatParams queryType (ProverName proverName) jsonExpr hConsing) = do
   e <- getExpr jsonExpr
   (_expr, ty, schema) <- liftModuleCmd (checkExpr e)
-  -- TODO validEvalContext expr, ty, schema
+  validEvalContext ty
+  validEvalContext schema
   decls <- deDecls . meDynEnv <$> getModuleEnv
   s <- getTCSolver
   perhapsDef <- liftIO (defaultReplExpr s ty schema)

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -560,8 +560,8 @@ asBatch body = do
   modifyRW_ $ (\ rw -> rw { eIsBatch = wasBatch })
   return a
 
--- | Is evaluation enabled.  If the currently focused module is
--- parameterized, then we cannot evalute.
+-- | Is evaluation enabled? If the currently focused module is parameterized,
+-- then we cannot evaluate.
 validEvalContext :: T.FreeVars a => a -> REPL ()
 validEvalContext a =
   do me <- eModuleEnv <$> getRW


### PR DESCRIPTION
The `check`, `prove or satisfy`, and `evaluate expression` commands now check if the type and schema of the supplied expression is valid, which can prevent panics that would arise from evaluating invalid expressions (e.g., ones that depend on definitions in parameterized modules). We do so by defining a `validEvalContext` function (inspired by a function of the same name in the Cryptol REPL) and using it where appropriate.

I discovered that there was an unused error code (see the `evalInParamMod` function) in the remote API for this exact scenario, so I have repurposed the error code for this kind of situation. I've also expanded its payload to include both type parameters and definitions from the parameterized module, much like how the Cryptol REPL's `EvalInParamMod` exception currently works.

Fixes https://github.com/GaloisInc/cryptol/issues/1623.