### PR TITLE
Fix typechecking of constraint guards with type signature constraints

### DIFF
--- a/src/Cryptol/TypeCheck/Sanity.hs
+++ b/src/Cryptol/TypeCheck/Sanity.hs
@@ -364,8 +364,12 @@ exprSchema expr =
       in go dgs
 
 
-    EPropGuards _guards typ -> 
-      pure Forall {sVars = [], sProps = [], sType = typ}
+    EPropGuards guards typ ->
+      do forM_ guards $ \(prop, e) ->
+           do mapM_ (checkTypeIs KProp) prop
+              eTyp <- exprType e
+              sameTypes "EPropGuards" typ eTyp
+         pure (tMono typ)
 
 
 checkCaseAlt :: CaseAlt -> TcM ([Type], Type)

--- a/tests/constraint-guards/type-sig-constraint.cry
+++ b/tests/constraint-guards/type-sig-constraint.cry
@@ -1,0 +1,3 @@
+bar : {n, a} (Zero a) => [n]a
+bar | n == 1 => zero
+    | n != 1 => zero

--- a/tests/constraint-guards/type-sig-constraint.icry
+++ b/tests/constraint-guards/type-sig-constraint.icry
@@ -3,5 +3,5 @@
 // verifies each guard in the numeric constraint guard definition contains two
 // proof applications, which is a smoke test for testing that the bug is fixed.
 // Full validation of the fix requires SAW, however.
-:set debug=on
+:set coreLint=on
 :l type-sig-constraint.cry

--- a/tests/constraint-guards/type-sig-constraint.icry
+++ b/tests/constraint-guards/type-sig-constraint.icry
@@ -1,0 +1,7 @@
+// This is a "regression test" for
+// https://github.com/GaloisInc/saw-script/issues/2043 in the sense that it
+// verifies each guard in the numeric constraint guard definition contains two
+// proof applications, which is a smoke test for testing that the bug is fixed.
+// Full validation of the fix requires SAW, however.
+:set debug=on
+:l type-sig-constraint.cry

--- a/tests/constraint-guards/type-sig-constraint.icry.stdout
+++ b/tests/constraint-guards/type-sig-constraint.icry.stdout
@@ -1,23 +1,10 @@
 Loading module Cryptol
 Loading module Cryptol
+{n, a, b, c} n == min n n
+{a, n} (fin n) => inf == inf * (1 * (1 * 1))
+{a, n} (fin n) => n / 2 == n - n /^ 2
+{n, a, b} n == min n n
+{n} (n >= 1, fin n) => (fin n, n >= 1)
 Loading module Main
-module Main
-
-/* Not recursive */
-Main::bar(n == 1) : {n, a} (Zero a, n == 1) => [n]a
-Main::bar(n == 1) =
-  \{n, a} (Zero a, n == 1) -> Cryptol::zero ([n]a) <>
-
-/* Not recursive */
-Main::bar(n != 1) : {n, a} (Zero a, n != 1) => [n]a
-Main::bar(n != 1) =
-  \{n, a} (Zero a, n != 1) -> Cryptol::zero ([n]a) <>
-
-/* Not recursive */
-Main::bar : {n, a} (Zero a) => [n]a
-Main::bar =
-  \{n, a} (Zero a) ->
-    (propguards  | n == 1 => Main::bar(n == 1) n a <> <>
-     | n != 1 => Main::bar(n != 1) n a <> <>)
-
-
+{n, a} (Zero a) => n != 1
+{n, a} (Zero a) => n == 1

--- a/tests/constraint-guards/type-sig-constraint.icry.stdout
+++ b/tests/constraint-guards/type-sig-constraint.icry.stdout
@@ -1,0 +1,23 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+module Main
+
+/* Not recursive */
+Main::bar(n == 1) : {n, a} (Zero a, n == 1) => [n]a
+Main::bar(n == 1) =
+  \{n, a} (Zero a, n == 1) -> Cryptol::zero ([n]a) <>
+
+/* Not recursive */
+Main::bar(n != 1) : {n, a} (Zero a, n != 1) => [n]a
+Main::bar(n != 1) =
+  \{n, a} (Zero a, n != 1) -> Cryptol::zero ([n]a) <>
+
+/* Not recursive */
+Main::bar : {n, a} (Zero a) => [n]a
+Main::bar =
+  \{n, a} (Zero a) ->
+    (propguards  | n == 1 => Main::bar(n == 1) n a <> <>
+     | n != 1 => Main::bar(n != 1) n a <> <>)
+
+


### PR DESCRIPTION
Previously, `checkPropGuardCase` would not consider type signature constraints when determining how many proof applications to generate, which ultimately led to the issues observed in https://github.com/GaloisInc/saw-script/issues/2043. This is relatively easy to fix by ensuring that we pass these constraints as an additional argument to `checkPropGuardCase`.

This bug would have been caught if `coreLint` supported numeric constraint guards (#1647), so I have implemented `coreLint` support in a separate commit. As such, this PR fixes #1647.

It is difficult to fully validate that this fix works without SAW, but I have checked in a smoke test that checks if the guards in a numeric constraint guard definition have the expected number of proof applications.