### PR TITLE
Bump cryptol-remote-api to 3.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
+          # Ensure pyproject.toml and python/mypy.ini are kept in sync with the Python version here.
           python-version: '3.12'
 
       - uses: abatilo/actions-poetry@v2.0.0
@@ -322,6 +323,7 @@ jobs:
       - if: matrix.suite == 'rpc'
         uses: actions/setup-python@v2
         with:
+          # Ensure cryptol-remote-api/python/{pyproject.toml,mypy.ini} are kept in sync with the Python version here.
           python-version: '3.12'
 
       - if: matrix.suite == 'rpc'
@@ -464,6 +466,7 @@ jobs:
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'
         uses: actions/setup-python@v2
         with:
+          # Ensure cryptol-remote-api/python/{pyproject.toml,mypy.ini} are kept in sync with the Python version here.
           python-version: '3.12'
 
       - if: matrix.image == 'ghcr.io/galoisinc/cryptol-remote-api'

--- a/cryptol-remote-api/python/CHANGELOG.md
+++ b/cryptol-remote-api/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for `cryptol` Python package
 
+## 3.1.1 -- 2024-05-15
+
+* Add support for Python 3.12.
+
 ## 3.1.0 -- 2024-02-05
 
 * The v3.1.0 release is made in tandem with the Cryptol 3.1.0 release. See the

--- a/cryptol-remote-api/python/LICENSE
+++ b/cryptol-remote-api/python/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2021 Galois Inc.
+Copyright (c) 2013-2024 Galois Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cryptol-remote-api/python/mypy.ini
+++ b/cryptol-remote-api/python/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 no_implicit_optional = True
+# Ensure .github/workflows/ci.yml and cryptol-remote-api/python/mypy.ini match the Python version used here.
 python_version = 3.12
 warn_return_any = True
 warn_unused_configs = True

--- a/cryptol-remote-api/python/poetry.lock
+++ b/cryptol-remote-api/python/poetry.lock
@@ -2,18 +2,19 @@
 
 [[package]]
 name = "argo-client"
-version = "0.0.11"
+version = "0.0.12"
 description = "A JSON RPC client library."
 optional = false
-python-versions = ">=3.8.0,<4"
+python-versions = "<4,>=3.8.0"
 files = [
-    {file = "argo-client-0.0.11.tar.gz", hash = "sha256:a4be33fab731d03b8d9fc9d997a5ba611feb66648e978b192ec43e560f916931"},
-    {file = "argo_client-0.0.11-py3-none-any.whl", hash = "sha256:85f54ec3b1303d12b86442ea6d77487e51590a983505a947ebeee48a2546914f"},
+    {file = "argo_client-0.0.12-py3-none-any.whl", hash = "sha256:6986b79f03d6592cdcc87cb228a0829cedf12852134c3af9083a322fa28bdc4a"},
+    {file = "argo_client-0.0.12.tar.gz", hash = "sha256:97f5b2db3caa4598c5cdcb1e9c80b5d330bdc5ecae08e36198e4dab217af4b97"},
 ]
 
 [package.dependencies]
-requests = ">=2.26.0,<3.0.0"
-urllib3 = ">=1.26.5"
+requests = ">=2.31.0"
+types-requests = ">=2.31.0"
+urllib3 = ">=2.2.0"
 
 [[package]]
 name = "bitvector"
@@ -281,4 +282,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<4"
-content-hash = "fa4bc31dd07bcb7d16f5a1d346f2e4fb2db32fd5a50a05b024764be692de210c"
+content-hash = "79eb7e6a2b0a2e765d5b699665389a58e1919bf4f7afe811cfdb60271b2e94d4"

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "3.1.0.99"
+version = "3.1.1"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol RPC server"
@@ -15,7 +15,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.8.0,<4"
 BitVector = "^3.4.9"
-argo-client = "0.0.11"
+argo-client = "0.0.12"
 typing-extensions = "^4.1.1"
 
 requests = ">=2.31.0"

--- a/cryptol-remote-api/python/pyproject.toml
+++ b/cryptol-remote-api/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cryptol"
-version = "3.1.1"
+version = "3.1.1.99"
 readme = "README.md"
 keywords = ["cryptography", "verification"]
 description = "Cryptol client for the Cryptol RPC server"


### PR DESCRIPTION
Preparatory work for bumping cryptol-remote-api to version 3.1.1 for python 3.12 support 