### PR TITLE
Fix `roundAway` implementation in reference evaluator

### DIFF
--- a/src/Cryptol/Eval/Reference.lhs
+++ b/src/Cryptol/Eval/Reference.lhs
@@ -726,7 +726,7 @@ by corresponding type classes:
 >                      (eitherToE . FP.floatToInteger "trunc" FP.ToZero))
 >
 >   , "roundAway"  ~> unary (roundUnary roundAwayRat
->                      (eitherToE . FP.floatToInteger "roundAway" FP.Away))
+>                      (eitherToE . FP.floatToInteger "roundAway" FP.NearAway))
 >
 >   , "roundToEven"~> unary (roundUnary round
 >                      (eitherToE . FP.floatToInteger "roundToEven" FP.NearEven))

--- a/tests/issues/issue1663.icry
+++ b/tests/issues/issue1663.icry
@@ -1,0 +1,12 @@
+:module Float
+let x = 3.5 : Float32
+:eval floor x
+floor x
+:eval ceiling x
+ceiling x
+:eval trunc x
+trunc x
+:eval roundToEven x
+roundToEven x
+:eval roundAway x
+roundAway x

--- a/tests/issues/issue1663.icry.stdout
+++ b/tests/issues/issue1663.icry.stdout
@@ -1,0 +1,13 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Float
+3
+3
+4
+4
+3
+3
+4
+4
+4
+4


### PR DESCRIPTION
This synchronizes the implementation of `roundAway` in the reference evaluator with the implementation of `Cryptol.Backend.FloatHelpers.floatToInteger`, which expects `NearAway` rather than `Away`.

Fixes #1663.