### PR TITLE
Improve :check-docstrings

### DIFF
--- a/docs/RefMan/BasicSyntax.rst
+++ b/docs/RefMan/BasicSyntax.rst
@@ -122,6 +122,7 @@ end-of-line can be dropped without affecting prefix detection.
 
 .. code-block:: cryptol
   :caption: Examples of docstrings
+
   /** Example documentation for x */
   x = 1
 
@@ -137,17 +138,28 @@ end-of-line can be dropped without affecting prefix detection.
   z = 1
 
 Test cases can be included in docstring comments that will be checked
-by the `:check-docstrings` command in the form of code blocks that are
-unlabeled or labeled with the `repl` language. This cases should be
+by the ``:check-docstrings`` command in the form of code blocks that are
+unlabeled or labeled with the ``repl`` language. This cases should be
 in the form of REPL commands. Success of the test is defined to be the
 success of all the REPL commands.
 
 .. code-block:: cryptol
   :caption: Example docstring with checked test
+
   /** This function 
    *
    * ```repl
    * :check f 10 == 20
+   * ```
+   *
+   * Also checked
+   * ```
+   * :safe f
+   * ```
+   *
+   * Not checked
+   * ```cpp
+   * int main() {}
    * ```
    */
   f : [8] -> [8]

--- a/docs/RefMan/BasicSyntax.rst
+++ b/docs/RefMan/BasicSyntax.rst
@@ -107,9 +107,51 @@ end of the line.  Block comments may be nested arbitrarily.
   // This is a line comment
   /* This is a /* Nested */ block comment */
 
-.. todo::
-  Document ``/** */``
+Documentation Comments
+----------------------
 
+Declarations in Cryptol can have documentation attached to them using special
+*docstring* comments. These attached comments are accessible in the REPL
+using the `:help` command.
+
+Syntactically, docstring comments are block comments that start with exactly
+two `*` characters: `/** ... */`. For lines after the first line a common
+prefix of whitespace and asterisks will be stripped in order to support
+stylistic blocks. Whitespace between the last asterisk on a line and the
+end-of-line can be dropped without affecting prefix detection.
+
+.. code-block:: cryptol
+  :caption: Examples of docstrings
+  /** Example documentation for x */
+  x = 1
+
+  /**
+    Example documentation for y
+   */
+  y = 1
+
+  /**
+   * Example documentation
+   * for z
+   */
+  z = 1
+
+Test cases can be included in docstring comments that will be checked
+by the `:check-docstrings` command in the form of code blocks that are
+unlabeled or labeled with the `repl` language. This cases should be
+in the form of REPL commands. Success of the test is defined to be the
+success of all the REPL commands.
+
+.. code-block:: cryptol
+  :caption: Example docstring with checked test
+  /** This function 
+   *
+   * ```repl
+   * :check f 10 == 20
+   * ```
+   */
+  f : [8] -> [8]
+  f x = 2 * x
 
 Identifiers
 -----------

--- a/docs/RefMan/BasicSyntax.rst
+++ b/docs/RefMan/BasicSyntax.rst
@@ -112,10 +112,10 @@ Documentation Comments
 
 Declarations in Cryptol can have documentation attached to them using special
 *docstring* comments. These attached comments are accessible in the REPL
-using the `:help` command.
+using the ``:help`` command.
 
 Syntactically, docstring comments are block comments that start with exactly
-two `*` characters: `/** ... */`. For lines after the first line a common
+two ``*`` characters: ``/** ... */``. For lines after the first line a common
 prefix of whitespace and asterisks will be stripped in order to support
 stylistic blocks. Whitespace between the last asterisk on a line and the
 end-of-line can be dropped without affecting prefix detection.

--- a/src/Cryptol/Parser/ParserUtils.hs
+++ b/src/Cryptol/Parser/ParserUtils.hs
@@ -19,7 +19,7 @@
 module Cryptol.Parser.ParserUtils where
 
 import qualified Data.Text as Text
-import Data.Char(isAlphaNum)
+import Data.Char(isAlphaNum, isSpace)
 import Data.Maybe(fromMaybe, mapMaybe)
 import Data.Bits(testBit,setBit)
 import Data.List(foldl')
@@ -1014,13 +1014,7 @@ mkDoc ltxt = ltxt { thing = docStr }
          $ thing ltxt
 
   commentChar :: Char -> Bool
-  commentChar x = x `elem` ("/* \t" :: String)
-
-  prefixDroppable :: Char -> Bool
-  prefixDroppable x = x `elem` ("* \t" :: String)
-
-  whitespaceChar :: Char -> Bool
-  whitespaceChar x = x `elem` (" \t" :: String)
+  commentChar x = x `elem` ("/*" :: String) || isSpace x
 
   -- Prefix dropping with a special case for the first line and common
   -- prefix dropping for the following lines. The first line and following
@@ -1049,7 +1043,7 @@ mkDoc ltxt = ltxt { thing = docStr }
     case T.uncons l of
       Nothing -> (l:) <$> searchWhitePrefixChar ls
       Just (c, l')
-        | prefixDroppable c -> (l':) <$> checkPrefixChar c ls
+        | c == '*' || isSpace c -> (l':) <$> checkPrefixChar c ls
         | otherwise -> Nothing
 
   -- So far we've only seen empty lines, so we accept empty
@@ -1060,7 +1054,7 @@ mkDoc ltxt = ltxt { thing = docStr }
     case T.uncons l of
       Nothing -> (l:) <$> searchWhitePrefixChar ls
       Just (c, l')
-        | whitespaceChar c -> (l':) <$> checkPrefixChar c ls
+        | isSpace c -> (l':) <$> checkPrefixChar c ls
         | otherwise -> Nothing
 
   -- So far we've seen a non-empty line and we know what character
@@ -1071,7 +1065,7 @@ mkDoc ltxt = ltxt { thing = docStr }
   checkPrefixChar p (l:ls) =
     case T.uncons l of
       Nothing
-        | whitespaceChar p -> (l:) <$> checkPrefixChar p ls
+        | isSpace p -> (l:) <$> checkPrefixChar p ls
       Just (c,l')
         | c == p -> (l':) <$> checkPrefixChar p ls
       _ -> Nothing

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -2010,7 +2010,7 @@ extractCodeBlocks raw = go [] (T.lines raw)
     go finished (x:xs)
       | (ticks, lang) <- T.span ('`' ==) x
       , 3 <= T.length ticks
-      = if lang `elem` ["", "repl"]
+      = if lang `elem` ["", "repl"] -- supported languages "unlabeled" and repl
         then keep finished ticks [] xs
         else skip finished ticks xs
       | otherwise = go finished xs

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -24,6 +24,7 @@ module Cryptol.REPL.Monad (
   , raise
   , stop
   , catch
+  , try
   , finally
   , rPutStrLn
   , rPutStr
@@ -397,6 +398,9 @@ raise exn = io (X.throwIO exn)
 
 catch :: REPL a -> (REPLException -> REPL a) -> REPL a
 catch m k = REPL (\ ref -> rethrowEvalError (unREPL m ref) `X.catch` \ e -> unREPL (k e) ref)
+
+try :: REPL a -> REPL (Either REPLException a)
+try m = REPL (X.try . rethrowEvalError . unREPL m)
 
 finally :: REPL a -> REPL b -> REPL a
 finally m1 m2 = REPL (\ref -> unREPL m1 ref `X.finally` unREPL m2 ref)

--- a/tests/docstrings/T01.cry
+++ b/tests/docstrings/T01.cry
@@ -8,13 +8,14 @@ module T01 where
  * ```
  */
 submodule Sub where
-  /**
-   * This verifies that pp shadows the outer definition
+  // this docstring starts with some text and that private is OK
+  /** This verifies that pp shadows the outer definition
+   *
    * ```repl
    * :check pp
    * ```
    */
-  pp = True
+  private pp = True
 
 /**
  * ```repl

--- a/tests/docstrings/T02.cry
+++ b/tests/docstrings/T02.cry
@@ -6,26 +6,32 @@ submodule F where
     type n : #
     type constraint (fin n, n >= 2)
 
+  /**
+    * ```
+    * :check c == 1
+    * ```
+    */
   private
     c : Z n
     c = 1
 
+  // this docstring has a less interesting prefix and uses 4 ticks
   /**
-   * Longer code block delimiters are supported
-   * ````repl
-   * :exhaust p
-   * ````
+   Longer code block delimiters are supported
+   ````repl
+   :exhaust p
+   ````
    */
   p x = c + x == x + c
 
 submodule F7 = submodule F where
   type n = 7
 
+// this docstring has an unusual prefix
 /**
- * ```repl
- * let y = 20
- * :check f 10 == 20
- * ```
- */
+ ** ```repl
+ ** let y = 20
+ ** :check f 10 == 20
+ ** ``` */
 f : Integer -> Integer
 f x = x + x

--- a/tests/docstrings/T02.icry.stdout
+++ b/tests/docstrings/T02.icry.stdout
@@ -2,6 +2,11 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module T02
 
+:check c == 1
+Using exhaustive testing.
+Testing... Passed 1 tests.
+Q.E.D.
+
 :exhaust p
 Using exhaustive testing.
 Testing... Passed 7 tests.
@@ -14,4 +19,4 @@ Using exhaustive testing.
 Testing... Passed 1 tests.
 Q.E.D.
 
-Successes: 3, Failures: 0
+Successes: 4, Failures: 0

--- a/tests/docstrings/T03.icry.stdout
+++ b/tests/docstrings/T03.icry.stdout
@@ -2,5 +2,15 @@ Loading module Cryptol
 Loading module Cryptol
 Loading module T03
 
+let x = 1
+
+:check x == 1
+Using exhaustive testing.
+Testing... Passed 1 tests.
+Q.E.D.
+
+:check x == 1
 [error] at <interactive>:0:8--0:9
     Value not in scope: x
+
+Successes: 2, Failures: 1

--- a/tests/docstrings/T04.cry
+++ b/tests/docstrings/T04.cry
@@ -7,9 +7,14 @@ module T03 where
  * :load AFile.cry
  * ```
  *
- * Stuff not marked repl is ignored
+ * Stuff not marked repl is processed
  * ```
  * garbage
+ * ```
+ *
+ * Stuff marked otherwise is ignored
+ * ```cryptol
+ * ignored = 1
  * ```
  */
 a : Bit

--- a/tests/docstrings/T04.icry.stdout
+++ b/tests/docstrings/T04.icry.stdout
@@ -4,4 +4,9 @@ Loading module T03
 
 :load AFile.cry
 Unknown command
-Successes: 0, Failures: 1
+garbage
+
+[error] at <interactive>:0:1--0:8
+    Value not in scope: garbage
+
+Successes: 0, Failures: 2


### PR DESCRIPTION
* Handle more prefix-stripping cases for docstrings
* Catch REPL exceptions when checking docstrings
* Process unlabeled docstring codeblocks in :check-docstrings