### PR TITLE
Gracefully skip docstrings on top-level functors

### DIFF
--- a/tests/docstrings/T09.cry
+++ b/tests/docstrings/T09.cry
@@ -1,0 +1,4 @@
+module T09 where
+
+parameter
+  type n : #

--- a/tests/docstrings/T09.icry
+++ b/tests/docstrings/T09.icry
@@ -1,0 +1,2 @@
+:m T09
+:check-docstrings

--- a/tests/docstrings/T09.icry.stdout
+++ b/tests/docstrings/T09.icry.stdout
@@ -1,0 +1,5 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module `parameter` interface of T09
+Loading module T09
+Skipping docstrings on parameterized module


### PR DESCRIPTION
Fixes #1729