### PR TITLE
Define `tIsNominal` and use it

### DIFF
--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -739,11 +739,8 @@ expectRec fs tGoal@(WithSource ty src rng) =
 -- an enum, throwing an error if this is not the case.
 expectEnum :: Type -> InferM [EnumCon]
 expectEnum ty =
-  case ty of
-    TUser _ _ ty' ->
-      expectEnum ty'
-
-    TNominal nt _
+  case tIsNominal ty of
+    Just (nt, _)
       |  Enum ecs <- ntDef nt
       -> pure ecs
 

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -599,6 +599,14 @@ tIsRec ty = case tNoUser ty of
               TRec fs -> Just fs
               _       -> Nothing
 
+-- | If the supplied 'Type' is a 'TNominal' type, then return @'Just' (nt, ts)@,
+-- where @nt@ and @ts@ are the underlying 'NominalType' and 'Type' arguments.
+-- Otherwise, return 'Nothing'.
+tIsNominal :: Type -> Maybe (NominalType, [Type])
+tIsNominal ty = case tNoUser ty of
+                  TNominal nm ts -> Just (nm, ts)
+                  _              -> Nothing
+
 tIsBinFun :: TFun -> Type -> Maybe (Type,Type)
 tIsBinFun f ty = case tNoUser ty of
                    TCon (TF g) [a,b] | f == g -> Just (a,b)


### PR DESCRIPTION
This defines a `tIsNominal :: Type -> Maybe (NominalType, [Type])` function. There is one spot in `Cryptol.TypeCheck.Infer` where this can more neatly replace a manual pattern match on `TNominal`, so I went ahead and did this as well.

Fixes #1732.