### PR TITLE
Gracefully skip checking docstrings on interface modules

### DIFF
--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -2192,12 +2192,17 @@ checkDocStringsCmd input
 
 
     checkModName :: P.ModName -> REPL CommandResult
-    checkModName mn = do
-        mb <- M.lookupModule mn <$> getModuleEnv
-        case mb of
-          Nothing -> do
-            rPutStrLn ("Module " ++ show input ++ " is not loaded")
-            pure emptyCommandResult { crSuccess = False }
+    checkModName mn =
+     do env <- getModuleEnv
+        case M.lookupModule mn env of
+          Nothing ->
+            case M.lookupSignature mn env of
+              Nothing ->
+               do rPutStrLn ("Module " ++ show input ++ " is not loaded")
+                  pure emptyCommandResult { crSuccess = False }
+              Just{} ->
+               do rPutStrLn "Skipping docstrings on interface module"
+                  pure emptyCommandResult
 
           Just fe
             | T.isParametrizedModule (M.lmdModule (M.lmData fe)) -> do

--- a/tests/docstrings/T11.cry
+++ b/tests/docstrings/T11.cry
@@ -1,0 +1,11 @@
+interface module I where
+
+/** Interfaces don't contain definitions. We'll need to wait to check
+ * them when they are paired up with a module in the context of a
+ * functor instantiation.
+ *
+ * ```repl
+ * :check \x y z -> add x (add y z) == add (add x y) z
+ * ```
+ */
+add : [8] -> [8] -> [8]

--- a/tests/docstrings/T11.icry
+++ b/tests/docstrings/T11.icry
@@ -1,0 +1,2 @@
+:m T11
+:check-docstrings

--- a/tests/docstrings/T11.icry.stdout
+++ b/tests/docstrings/T11.icry.stdout
@@ -1,0 +1,4 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module I
+Skipping docstrings on interface module


### PR DESCRIPTION
We can't currently check docstrings on interfaces or (uninstantiated) functors. This change ensures we gracefully handle docstring-checking being called on these kinds of modules.

While I'd like to give docstrings on interfaces a better story we need to work through what that story should be. This PR allows us to gracefully check all the .cry files in a project without having to know which ones are regular modules and which are interfaces and which are functors.