### PR TITLE
Simplify `inf - x` to `inf`

### DIFF
--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -113,6 +113,7 @@ tSub :: Type -> Type -> Type
 tSub x y
   | Just t <- tOp TCSub (op2 nSub) [x,y] = t
   | tIsInf y  = tError (tf2 TCSub x y)
+  | tIsInf x = x
   | Just 0 <- yNum = x
   | Just k <- yNum
   , TCon (TF TCAdd) [a,b] <- tNoUser x

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -116,7 +116,7 @@ tSub x y
 
   | tIsInf x = x
     {- This assumes that `y` is finite and not error.  The first should
-       follow from the typing on `tSub`, which asserts that the second argumet
+       follow from the typing on `tSub`, which asserts that the second argument
        is finite and less than the first;  the second should have been handleed
        by the first equation above `tOp`. -}
 

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -117,7 +117,7 @@ tSub x y
   | tIsInf x = x
     {- This assumes that `y` is finite and not error.  The first should
        follow from the typing on `tSub`, which asserts that the second argument
-       is finite and less than the first;  the second should have been handleed
+       is finite and less than the first;  the second should have been handled
        by the first equation above `tOp`. -}
 
   | Just 0 <- yNum = x

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -118,7 +118,7 @@ tSub x y
     {- This assumes that `y` is finite and not error.  The first should
        follow from the typing on `tSub`, which asserts that the second argument
        is finite and less than the first;  the second should have been handled
-       by the first equation above `tOp`. -}
+       by the first equation above, see `tOp`. -}
 
   | Just 0 <- yNum = x
   | Just k <- yNum

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -113,7 +113,13 @@ tSub :: Type -> Type -> Type
 tSub x y
   | Just t <- tOp TCSub (op2 nSub) [x,y] = t
   | tIsInf y  = tError (tf2 TCSub x y)
+
   | tIsInf x = x
+    {- This assumes that `y` is finite and not error.  The first should
+       follow from the typing on `tSub`, which asserts that the second argumet
+       is finite and less than the first;  the second should have been handleed
+       by the first equation above `tOp`. -}
+
   | Just 0 <- yNum = x
   | Just k <- yNum
   , TCon (TF TCAdd) [a,b] <- tNoUser x


### PR DESCRIPTION
This PR fixes issue #1741, adding an extra simplification rule to the type checker.