### PR TITLE
Fix `splitV` when splitting empty sequence to type `[inf][0]`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,12 @@
 
 ## Bug fixes
 
-  * Fix #1740, removes duplicated width from word values.
-    Note that since this changes the types, it may require changes to
-    libraries depending on Cryptol.
+* Fix #1740, removes duplicated width from word values.
+  Note that since this changes the types, it may require changes to libraries
+  depending on Cryptol.
+
+* Fix a bug in which splitting a `[0]` value into type `[inf][0]` would panic.
+  ([#1749](https://github.com/GaloisInc/cryptol/issues/1749))
 
 ## New features
 

--- a/tests/issues/issue1749.cry
+++ b/tests/issues/issue1749.cry
@@ -1,0 +1,5 @@
+f : [0] -> [inf][0]
+f = split
+
+main : [0]
+main = (f []) @ 0

--- a/tests/issues/issue1749.icry
+++ b/tests/issues/issue1749.icry
@@ -1,0 +1,2 @@
+:load issue1749.cry
+main

--- a/tests/issues/issue1749.icry.stdout
+++ b/tests/issues/issue1749.icry.stdout
@@ -1,0 +1,4 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+0x0


### PR DESCRIPTION
Previously, `splitV` would assume that if you were splitting a value `val` into something of type `[inf][each]`, then `val` must be a stream of type of `[inf * each]` (i.e., of type `[inf]`). This is not true in the corner case where `each` equals `0`, however. In that case, `val` is of type `[0]`, which is a word, not a stream. As such, we need to ensure that we do not call `fromSeq` on `val`, which crashes if `val` is not a stream or sequence.

Fixes https://github.com/GaloisInc/cryptol/issues/1749.