### PR TITLE
Remove bitvectors width from the value tag.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ## Bug fixes
 
   * Fix #1740, removes duplicated width from word values.
-    Note that since thins changes the types, it may require changes to
+    Note that since this changes the types, it may require changes to
     libraries depending on Cryptol.
 
 ## New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ## Bug fixes
 
+  * Fix #1740, removes duplicated width from word values.
+    Note that since thins changes the types, it may require changes to
+    libraries depending on Cryptol.
+
 ## New features
 
 # 3.2.0 -- 2024-08-20

--- a/cryptol-remote-api/src/CryptolServer/Data/Expression.hs
+++ b/cryptol-remote-api/src/CryptolServer/Data/Expression.hs
@@ -566,10 +566,10 @@ readBack ty val =
         _ -> mismatchPanic
     TVSeq len elemTy
       | elemTy == TVBit
-      , VWord width wv <- val -> do
+      , VWord wv <- val -> do
         Concrete.BV w v <- liftEval $ asWordVal Concrete.Concrete wv
         let hexStr = T.pack $ showHex v ""
-        let paddedLen = fromIntegral ((width `quot` 4) + (if width `rem` 4 == 0 then 0 else 1))
+        let paddedLen = fromIntegral ((w `quot` 4) + (if w `rem` 4 == 0 then 0 else 1))
         pure $ Just $  Num Hex (T.justifyRight paddedLen '0' hexStr) w
       | VSeq _l (enumerateSeqMap len -> mVals) <- val -> do
         vals <- liftEval $ sequence mVals

--- a/src/Cryptol/Backend.hs
+++ b/src/Cryptol/Backend.hs
@@ -38,6 +38,7 @@ module Cryptol.Backend
 import qualified Control.Exception as X
 import Control.Monad.IO.Class
 import Data.Kind (Type)
+import Data.Proxy(Proxy(..))
 
 import Cryptol.Backend.FloatHelpers (BF)
 import Cryptol.Backend.Monad
@@ -297,7 +298,7 @@ class MonadIO (SEval sym) => Backend sym where
   bitAsLit :: sym -> SBit sym -> Maybe Bool
 
   -- | The number of bits in a word value.
-  wordLen' :: f sym -> SWord sym -> Integer
+  wordLen' :: proxy sym -> SWord sym -> Integer
 
   -- | Determine if this symbolic word is a literal.
   --   If so, return the bit width and value.
@@ -817,5 +818,5 @@ type FPArith2 sym =
   SEval sym (SFloat sym)
 
 wordLen :: forall sym. Backend sym => sym -> SWord sym -> Integer
-wordLen _ x = wordLen' (Nothing :: Maybe sym) x
+wordLen _ x = wordLen' (Proxy :: Proxy sym) x
 {-# INLINE wordLen #-}

--- a/src/Cryptol/Backend.hs
+++ b/src/Cryptol/Backend.hs
@@ -1,7 +1,9 @@
 {-# Language FlexibleContexts #-}
 {-# Language TypeFamilies #-}
+{-# Language ScopedTypeVariables #-}
 module Cryptol.Backend
   ( Backend(..)
+  , wordLen
   , sDelay
   , invalidIndex
   , cryUserError
@@ -295,7 +297,7 @@ class MonadIO (SEval sym) => Backend sym where
   bitAsLit :: sym -> SBit sym -> Maybe Bool
 
   -- | The number of bits in a word value.
-  wordLen :: sym -> SWord sym -> Integer
+  wordLen' :: f sym -> SWord sym -> Integer
 
   -- | Determine if this symbolic word is a literal.
   --   If so, return the bit width and value.
@@ -813,3 +815,7 @@ type FPArith2 sym =
   SFloat sym ->
   SFloat sym ->
   SEval sym (SFloat sym)
+
+wordLen :: forall sym. Backend sym => sym -> SWord sym -> Integer
+wordLen _ x = wordLen' (Nothing :: Maybe sym) x
+{-# INLINE wordLen #-}

--- a/src/Cryptol/Backend/Concrete.hs
+++ b/src/Cryptol/Backend/Concrete.hs
@@ -144,7 +144,9 @@ instance Backend Concrete where
   assertSideCondition _ True _ = return ()
   assertSideCondition sym False err = raiseError sym err
 
-  wordLen _ (BV w _) = w
+  wordLen' _ (BV w _) = w
+  {-# INLINE wordLen' #-}
+  
   wordAsChar _ (BV _ x) = Just $! integerToChar x
 
   wordBit _ (BV w x) idx = pure $! testBit x (fromInteger (w - 1 - idx))

--- a/src/Cryptol/Backend/SBV.hs
+++ b/src/Cryptol/Backend/SBV.hs
@@ -201,7 +201,8 @@ instance Backend SBV where
                 SBVResult pz z ->
                   pure $ SBVResult (svAnd (svIte c px py) pz) z
 
-  wordLen _ v = toInteger (intSizeOf v)
+  wordLen' _ v = toInteger (intSizeOf v)
+  {-# INLINE wordLen' #-}
   wordAsChar _ v = integerToChar <$> svAsInteger v
 
   iteBit _ b x y = pure $! svSymbolicMerge KBool True b x y

--- a/src/Cryptol/Backend/What4.hs
+++ b/src/Cryptol/Backend/What4.hs
@@ -273,7 +273,8 @@ instance W4.IsSymExprBuilder sym => Backend (What4 sym) where
     | SW.bvWidth bv == 8 = toEnum . fromInteger <$> SW.bvAsUnsignedInteger bv
     | otherwise = Nothing
 
-  wordLen _ bv = SW.bvWidth bv
+  wordLen' _ bv = SW.bvWidth bv
+  {-# INLINE wordLen' #-}
 
   bitLit sym b = W4.backendPred (w4 sym) b
   bitAsLit _ v = W4.asConstantPred v

--- a/src/Cryptol/Backend/WordValue.hs
+++ b/src/Cryptol/Backend/WordValue.hs
@@ -60,6 +60,7 @@ module Cryptol.Backend.WordValue
 
 import Control.Monad (unless)
 import Data.Bits
+import Data.Proxy(Proxy(..))
 import GHC.Generics (Generic)
 
 import Cryptol.Backend
@@ -102,7 +103,7 @@ wordValWidth :: forall sym. Backend sym => WordValue sym -> Integer
 wordValWidth val =
   case val of
     ThunkWordVal n _ -> n
-    WordVal sv -> wordLen' (Nothing :: Maybe sym) sv
+    WordVal sv -> wordLen' (Proxy :: Proxy sym) sv
     BitmapVal n _ _ -> n
 {-# INLINE wordValWidth #-}
 

--- a/src/Cryptol/Backend/WordValue.hs
+++ b/src/Cryptol/Backend/WordValue.hs
@@ -25,6 +25,7 @@ module Cryptol.Backend.WordValue
   ( -- * WordValue
     WordValue
   , wordVal
+  , wordValWidth
   , bitmapWordVal
   , asWordList
   , asWordVal
@@ -96,6 +97,14 @@ data WordValue sym
        !(SEval sym (SWord sym)) -- ^ Thunk for packing the word
        !(SeqMap sym (SBit sym)) -- ^
  deriving (Generic)
+
+wordValWidth :: forall sym. Backend sym => WordValue sym -> Integer
+wordValWidth val =
+  case val of
+    ThunkWordVal n _ -> n
+    WordVal sv -> wordLen' (Nothing :: Maybe sym) sv
+    BitmapVal n _ _ -> n
+{-# INLINE wordValWidth #-}
 
 wordVal :: SWord sym -> WordValue sym
 wordVal = WordVal

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -134,7 +134,7 @@ toExpr prims t0 v0 = findOne (go t0 v0)
       (TVSeq _ b, VSeq n svs) ->
         do ses <- traverse (go b) =<< lift (sequence (enumerateSeqMap n svs))
            pure $ EList ses (tValTy b)
-      (TVSeq n TVBit, VWord _ wval) ->
+      (TVSeq n TVBit, VWord wval) ->
         do BV _ v <- lift (asWordVal Concrete wval)
            pure $ ETApp (ETApp (prim "number") (tNum v)) (tWord (tNum n))
 
@@ -206,7 +206,7 @@ primTable getEOpts = let sym = Concrete in
                       F2.pmult (fromInteger (u+1)) x y
                     else
                       F2.pmult (fromInteger (v+1)) y x
-             in return . VWord (1+u+v) . wordVal . mkBv (1+u+v) $! z)
+             in return . VWord . wordVal . mkBv (1+u+v) $! z)
 
    , ("pmod",
         PFinPoly \_u ->
@@ -215,7 +215,7 @@ primTable getEOpts = let sym = Concrete in
         PWordFun \(BV _ m) ->
         PPrim
           do assertSideCondition sym (m /= 0) DivideByZero
-             return . VWord v . wordVal . mkBv v $! F2.pmod (fromInteger w) x m)
+             return . VWord . wordVal . mkBv v $! F2.pmod (fromInteger w) x m)
 
   , ("pdiv",
         PFinPoly \_u ->
@@ -224,7 +224,7 @@ primTable getEOpts = let sym = Concrete in
         PWordFun \(BV _ m) ->
         PPrim
           do assertSideCondition sym (m /= 0) DivideByZero
-             return . VWord w . wordVal . mkBv w $! F2.pdiv (fromInteger w) x m)
+             return . VWord . wordVal . mkBv w $! F2.pdiv (fromInteger w) x m)
   ]
 
 
@@ -297,7 +297,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
               foldM (\st blk -> seq st (SHA.processSHA256Block st <$> (toSHA256Block =<< blk)))
                     SHA.initialSHA224State blks
            let f :: Word32 -> Eval Value
-               f = pure . VWord 32 . wordVal . BV 32 . toInteger
+               f = pure . VWord . wordVal . BV 32 . toInteger
                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6])
            seq zs (pure (VSeq 7 zs)))
 
@@ -310,7 +310,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
              foldM (\st blk -> seq st (SHA.processSHA256Block st <$> (toSHA256Block =<< blk)))
                    SHA.initialSHA256State blks
            let f :: Word32 -> Eval Value
-               f = pure . VWord 32 . wordVal . BV 32 . toInteger
+               f = pure . VWord . wordVal . BV 32 . toInteger
                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6,w7])
            seq zs (pure (VSeq 8 zs)))
 
@@ -323,7 +323,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
              foldM (\st blk -> seq st (SHA.processSHA512Block st <$> (toSHA512Block =<< blk)))
                    SHA.initialSHA384State blks
            let f :: Word64 -> Eval Value
-               f = pure . VWord 64 . wordVal . BV 64 . toInteger
+               f = pure . VWord . wordVal . BV 64 . toInteger
                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5])
            seq zs (pure (VSeq 6 zs)))
 
@@ -336,7 +336,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
              foldM (\st blk -> seq st (SHA.processSHA512Block st <$> (toSHA512Block =<< blk)))
                    SHA.initialSHA512State blks
            let f :: Word64 -> Eval Value
-               f = pure . VWord 64 . wordVal . BV 64 . toInteger
+               f = pure . VWord . wordVal . BV 64 . toInteger
                zs = finiteSeqMap Concrete (map f [w0,w1,w2,w3,w4,w5,w6,w7])
            seq zs (pure (VSeq 8 zs)))
 
@@ -348,7 +348,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESInfKeyExpand" =<< lookupSeqMap ss i)
             let fromWord :: Word32 -> Eval Value
-                fromWord = pure . VWord 32 . wordVal . BV 32 . toInteger
+                fromWord = pure . VWord . wordVal . BV 32 . toInteger
             kws <- mapM toWord [0 .. k-1]
             let ws = AES.keyExpansionWords k kws
             let len = 4*(k+7)
@@ -361,7 +361,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESInvMixColumns" =<< lookupSeqMap ss i)
             let fromWord :: Word32 -> Eval Value
-                fromWord = pure . VWord 32 . wordVal . BV 32 . toInteger
+                fromWord = pure . VWord . wordVal . BV 32 . toInteger
             ws <- mapM toWord [0,1,2,3]
             let ws' = AES.invMixColumns ws
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
@@ -373,7 +373,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESEncRound" =<< lookupSeqMap ss i)
             let fromWord :: Word32 -> Eval Value
-                fromWord = pure . VWord 32 . wordVal . BV 32 . toInteger
+                fromWord = pure . VWord . wordVal . BV 32 . toInteger
             ws <- mapM toWord [0,1,2,3]
             let ws' = AES.aesRound ws
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
@@ -385,7 +385,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESEncFinalRound" =<< lookupSeqMap ss i)
             let fromWord :: Word32 -> Eval Value
-                fromWord = pure . VWord 32 . wordVal . BV 32 . toInteger
+                fromWord = pure . VWord . wordVal . BV 32 . toInteger
             ws <- mapM toWord [0,1,2,3]
             let ws' = AES.aesFinalRound ws
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
@@ -397,7 +397,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESDecRound" =<< lookupSeqMap ss i)
             let fromWord :: Word32 -> Eval Value
-                fromWord = pure . VWord 32 . wordVal . BV 32 . toInteger
+                fromWord = pure . VWord . wordVal . BV 32 . toInteger
             ws <- mapM toWord [0,1,2,3]
             let ws' = AES.aesInvRound ws
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')
@@ -409,7 +409,7 @@ suiteBPrims = Map.fromList $ map (\(n, v) -> (suiteBPrim n, v))
             let toWord :: Integer -> Eval Word32
                 toWord i = fromInteger. bvVal <$> (fromVWord Concrete "AESDecFinalRound" =<< lookupSeqMap ss i)
             let fromWord :: Word32 -> Eval Value
-                fromWord = pure . VWord 32 . wordVal . BV 32 . toInteger
+                fromWord = pure . VWord . wordVal . BV 32 . toInteger
             ws <- mapM toWord [0,1,2,3]
             let ws' = AES.aesInvFinalRound ws
             pure . VSeq 4 . finiteSeqMap Concrete . map fromWord $ ws')

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -1734,7 +1734,7 @@ errorV sym _ty msg =
 --   and return the associated character, if it is concrete.
 --   Otherwise, return a '?' character
 valueToChar :: Backend sym => sym -> GenValue sym -> SEval sym Char
-valueToChar sym (VWord wval) =
+valueToChar sym (VWord wval) | wordValWidth wval == 8 =
   do w <- asWordVal sym wval
      pure $! fromMaybe '?' (wordAsChar sym w)
 valueToChar _ _ = evalPanic "valueToChar" ["Not an 8-bit bitvector"]

--- a/src/Cryptol/Eval/SBV.hs
+++ b/src/Cryptol/Eval/SBV.hs
@@ -81,7 +81,7 @@ indexFront sym mblen a xs _ix idx
        asWordList sym wvs >>= \case
          Just ws ->
            do z <- wordLit sym wlen 0
-              return $ VWord wlen $ wordVal $ SBV.svSelect ws z idx
+              return $ VWord $ wordVal $ SBV.svSelect ws z idx
          Nothing -> folded'
 
   | otherwise = folded'

--- a/src/Cryptol/Eval/What4.hs
+++ b/src/Cryptol/Eval/What4.hs
@@ -454,7 +454,7 @@ toWord32 sym nm ss i =
        _ -> panic nm ["Unexpected word size", show (SW.bvWidth x)]
 
 fromWord32 :: W4.IsSymExprBuilder sym => W4.SymBV sym 32 -> SEval (What4 sym) (Value sym)
-fromWord32 = pure . VWord 32 . wordVal . SW.DBV
+fromWord32 = pure . VWord . wordVal . SW.DBV
 
 toWord64 :: W4.IsSymExprBuilder sym =>
   What4 sym -> String -> SeqMap (What4 sym) (GenValue (What4 sym)) -> Integer -> SEval (What4 sym) (W4.SymBV sym 64)
@@ -465,7 +465,7 @@ toWord64 sym nm ss i =
        _ -> panic nm ["Unexpected word size", show (SW.bvWidth x)]
 
 fromWord64 :: W4.IsSymExprBuilder sym => W4.SymBV sym 64 -> SEval (What4 sym) (Value sym)
-fromWord64 = pure . VWord 64 . wordVal . SW.DBV
+fromWord64 = pure . VWord . wordVal . SW.DBV
 
 
 

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -268,7 +268,7 @@ varShapeToValue sym var =
     VarBit b     -> VBit b
     VarInteger i -> VInteger i
     VarRational n d -> VRational (SRational n d)
-    VarWord w    -> VWord (wordLen sym w) (wordVal w)
+    VarWord w    -> VWord (wordVal w)
     VarFloat f   -> VFloat f
     VarFinSeq n vs -> VSeq n (finiteSeqMap sym (map (pure . varShapeToValue sym) vs))
     VarTuple vs  -> VTuple (map (pure . varShapeToValue sym) vs)

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -237,7 +237,7 @@ randomRational sym w g =
 randomWord :: (Backend sym, RandomGen g) => sym -> Integer -> Gen g sym
 randomWord sym w _sz g =
    let (val, g1) = randomR (0,2^w-1) g
-   in (VWord w . wordVal <$> wordLit sym w val, g1)
+   in (VWord . wordVal <$> wordLit sym w val, g1)
 
 {-# INLINE randomStream #-}
 
@@ -493,7 +493,7 @@ typeValues ty =
     TVArray{}   -> []
     TVStream{}  -> []
     TVSeq n TVBit ->
-      [ VWord n (wordVal (BV n x))
+      [ VWord (wordVal (BV n x))
       | x <- [ 0 .. 2^n - 1 ]
       ]
     TVSeq n el ->


### PR DESCRIPTION
Fixes #1740.  We can do this because the values (WordVal) already has its width, so we don't need to store it again.