### PR TITLE
Allow doctests to span multiple lines with a trailing \ like the REPL already supports

### DIFF
--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -2062,7 +2062,7 @@ data SubcommandResult = SubcommandResult
 checkBlock ::
   [T.Text] {- ^ lines of the code block -} ->
   REPL [SubcommandResult]
-checkBlock = isolated . go
+checkBlock = isolated . go . continuedLines
   where
     go [] = pure []
     go (line:block) =
@@ -2103,6 +2103,14 @@ checkBlock = isolated . go
                     }
               subresults <- checkBlock block
               pure (subresult : subresults)
+
+-- | Combine lines ending in a backslash with the next line.
+continuedLines :: [T.Text] -> [T.Text]
+continuedLines xs =
+  case span ("\\" `T.isSuffixOf`) xs of
+    ([], []) -> []
+    (a, []) -> [foldMap T.init a] -- permissive
+    (a, b:bs) -> T.concat (map T.init a ++ [b]) : continuedLines bs
 
 captureLog :: REPL a -> REPL (String, a)
 captureLog m = do

--- a/tests/docstrings/T02.cry
+++ b/tests/docstrings/T02.cry
@@ -31,6 +31,7 @@ submodule F7 = submodule F where
 /**
  ** ```repl
  ** let y = 20
+ **
  ** :check f 10 \
  **          == 20
  ** ``` */

--- a/tests/docstrings/T02.cry
+++ b/tests/docstrings/T02.cry
@@ -31,7 +31,8 @@ submodule F7 = submodule F where
 /**
  ** ```repl
  ** let y = 20
- ** :check f 10 == 20
+ ** :check f 10 \
+ **          == 20
  ** ``` */
 f : Integer -> Integer
 f x = x + x

--- a/tests/docstrings/T02.icry.stdout
+++ b/tests/docstrings/T02.icry.stdout
@@ -23,7 +23,7 @@ Checking T02::f
 
 let y = 20
 
-:check f 10 == 20
+:check f 10          == 20
 Using exhaustive testing.
 Testing... Passed 1 tests.
 Q.E.D.

--- a/tests/docstrings/T02.icry.stdout
+++ b/tests/docstrings/T02.icry.stdout
@@ -23,7 +23,7 @@ Checking T02::f
 
 let y = 20
 
-:check f 10          == 20
+:check f 10 == 20
 Using exhaustive testing.
 Testing... Passed 1 tests.
 Q.E.D.


### PR DESCRIPTION
Additionally this allows empty doctest lines to be skipped without error