### PR TITLE
Fix doc-gen CI to not fail on the existsence of a non-mergeable PR.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,10 +122,10 @@ jobs:
             prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
             prref=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].merge_commit_sha)
             tgt=${TGTBASE}/PR_${prnum}
-            # if [ "X$prref" == "Xnull" ] ; then
-            #   echo Skipping PR ${X}: probable unresolved merge conflict
-            #   continue
-            # fi
+            if [ "X$prref" == "Xnull" ] ; then
+              echo Skipping PR ${X}: probable unresolved merge conflict
+              continue
+            fi
             echo "Checkout Pull Request ${prnum} at ${prref} into PR_${prnum}"
             mkdir $tgt
             # n.b. the switch here is important to make sure the branch is

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,6 +122,10 @@ jobs:
             prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
             prref=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].merge_commit_sha)
             tgt=${TGTBASE}/PR_${prnum}
+            if [ "X$prref" == "Xnull" ] ; then
+              echo Skipping PR ${X}: probable unresolved merge conflict
+              continue
+            fi
             echo "Checkout Pull Request ${prnum} at ${prref} into PR_${prnum}"
             mkdir $tgt
             # n.b. the switch here is important to make sure the branch is

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,10 +122,10 @@ jobs:
             prnum=$(cat pulls.json | nix run nixpkgs#jq -- .[${X}].number)
             prref=$(cat pulls.json | nix run nixpkgs#jq -- -r .[${X}].merge_commit_sha)
             tgt=${TGTBASE}/PR_${prnum}
-            if [ "X$prref" == "Xnull" ] ; then
-              echo Skipping PR ${X}: probable unresolved merge conflict
-              continue
-            fi
+            # if [ "X$prref" == "Xnull" ] ; then
+            #   echo Skipping PR ${X}: probable unresolved merge conflict
+            #   continue
+            # fi
             echo "Checkout Pull Request ${prnum} at ${prref} into PR_${prnum}"
             mkdir $tgt
             # n.b. the switch here is important to make sure the branch is


### PR DESCRIPTION
The doc generation run as part of CI attempts to build and deploy a version of the docs for each PR (which allows inspection of doc updates for a PR before it lands).  The docs build is done for the expected marge result (`merge_commit_sha`) of the PR, but if the PR has a merge conflict with the main branch, then the value for this field will be `null`, and thus this CI script will fail.

This change modifies the doc generation CI process to skip PR's that are in this state.