### PR TITLE
Fix `freeVars` calculation for `TNominal`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 * Fix a bug in which splitting a `[0]` value into type `[inf][0]` would panic.
   ([#1749](https://github.com/GaloisInc/cryptol/issues/1749))
 
+* Fix a bug in which the free variables of types mentioning newtypes or enums
+  were incorrectly computed.
+  ([#1773](https://github.com/GaloisInc/cryptol/issues/1773))
+
 ## New features
 
 * REPL command `:dumptests <FILE> <EXPR>` updated to write to stdout when

--- a/src/Cryptol/IR/FreeVars.hs
+++ b/src/Cryptol/IR/FreeVars.hs
@@ -159,7 +159,8 @@ instance FreeVars Type where
 
       TUser _ _ t -> freeVars t
       TRec fs     -> freeVars (recordElements fs)
-      TNominal nt ts -> freeVars nt <> freeVars ts
+      TNominal nt ts -> mempty { tyDeps = Set.singleton (ntName nt) }
+                        <> freeVars ts
 
 instance FreeVars TVar where
   freeVars tv = case tv of


### PR DESCRIPTION
Rather than computing the free variables of a `NominalType` definition, we only include the name of the `NominalType` itself as a free variable.

Fixes #1773.