### PR TITLE
Modify the copyright to avoid sphinx auto-correction based on SOURCE_DATE_EPOCH

### DIFF
--- a/docs/RefMan/conf.py
+++ b/docs/RefMan/conf.py
@@ -22,7 +22,15 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = 'Cryptol'
-copyright = '2024, The Cryptol Team'
+
+# n.b. do not use a space or comma after the year in the copyright message:
+# Sphinx + SOURCE_DATE_EPOCH settings (likely to occur in CI docker runners) will
+# cause undocumented replacement of the year; see
+# https://github.com/sphinx-doc/sphinx/blob/74ec2204795481402322e75752547571a553cc4e/sphinx/config.py#L721
+# and
+# https://github.com/sphinx-doc/sphinx/blob/74ec2204795481402322e75752547571a553cc4e/sphinx/config.py#L765-L766
+copyright = '2024: The Cryptol Team'
+
 author = 'The Cryptol Team'
 
 # The short X.Y version


### PR DESCRIPTION
If `SOURCE_DATE_EPOCH` is set (which seems to be the case in the CI runner), then there's undocumented Sphinx adjustment of the date in the copyright string.  Avoid this by using a syntax that Sphinx will not recognize and change.

See https://github.com/sphinx-doc/sphinx/blob/74ec2204795481402322e75752547571a553cc4e/sphinx/config.py#L721 and https://github.com/sphinx-doc/sphinx/blob/74ec2204795481402322e75752547571a553cc4e/sphinx/config.py#L765-L766

Fixes #1575 