### PR TITLE
Check the repository owner in CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       - if: runner.os == 'Windows'
         run: .github/wix.ps1
 
-      - if: runner.os == 'Windows' && github.event.pull_request.head.repo.fork == false
+      - if: runner.os == 'Windows' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -212,7 +212,7 @@ jobs:
           OS_TAG: ${{ matrix.os }}
           ARCH_TAG: ${{ runner.arch }}
 
-      - if: github.event.pull_request.head.repo.fork == false
+      - if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -413,7 +413,7 @@ jobs:
   build-push-image:
     runs-on: ubuntu-22.04
     needs: [config]
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true') && github.repository_owner == 'GaloisInc'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-23.05
       - name: build PDF docs
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
         uses: docker://pandoc/latex:2.9.2
         with:
           args: >-
@@ -48,7 +48,7 @@ jobs:
             --run 'make html'
   build-pages-docs:
     # Do not run this on forks:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
     runs-on: ubuntu-latest
     # The public interface should then allow the user to browse the cryptol
     # documentation at the master branch, but also the documentation associated


### PR DESCRIPTION
I discovered recently after updating a fork I'd had sitting around that its periodic CI runs on master were failing.

Apparently it isn't possible to have scheduled runs that are skipped in forks (see https://github.com/orgs/community/discussions/16109 for an open/ignored feature request) but it is at least possible to have them not break.