### PR TITLE
Fix simplification rule for nested type-level exponentiation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@
 * The reference evaluator now evaluates the `toSignedInteger` and `deepseq`
   primitives instead of panicking.
 
+* Fix a bug in which `a ^^ (x ^^ y)` could be incorrectly simplified to
+  `a ^^ (x * y)` at the type level.
+  ([#1799](https://github.com/GaloisInc/cryptol/issues/1799))
+
 ## New features
 
 * REPL command `:dumptests <FILE> <EXPR>` updated to write to stdout when

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -150,7 +150,7 @@ tMul x y
   | Just n <- tIsNum y  = mulK n x
   | Just v <- matchMaybe swapVars = v
   | otherwise = checkExpMul x y
-  
+
   where
   mulK 0 _ = tNum (0 :: Int)
   mulK 1 t = t
@@ -174,7 +174,7 @@ tMul x y
                 b <- aTVar y
                 guard (b < a)
                 return (tf2 TCMul y x)
-  
+
   -- Check if (K^a * K^b) => K^(a + b) otherwise default to standard mul
   checkExpMul s t | TCon (TF TCExp) [a,aExp] <- s
                   , Just a' <- tIsNum a

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -222,7 +222,9 @@ tExp :: Type -> Type -> Type
 tExp x y
   | Just t <- tOp TCExp (total (op2 nExp)) [x,y] = t
   | Just 0 <- tIsNum y = tNum (1 :: Int)
-  | TCon (TF TCExp) [a,b] <- tNoUser y = tExp x (tMul a b)
+    -- If `x = (a ^^ b)`, then `(a ^^ b) ^^ y` simplifies to `a ^^ (b * y)`.
+    -- This even holds if `a == 0`, given that `0 ^^ 0 == 1` in Cryptol.
+  | TCon (TF TCExp) [a,b] <- tNoUser x = tExp a (tMul b y)
   | otherwise = tf2 TCExp x y
 
 

--- a/tests/modsys/T1799.icry
+++ b/tests/modsys/T1799.icry
@@ -1,0 +1,6 @@
+:module T1799::Y
+`b : Integer
+`z : Integer
+:module T1799::Z
+`b : Integer
+`z : Integer

--- a/tests/modsys/T1799.icry.stdout
+++ b/tests/modsys/T1799.icry.stdout
@@ -1,0 +1,12 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module `where` argument of Y
+Loading interface module `parameter` interface of B
+Loading module B
+Loading module Y
+2
+19683
+Loading module Cryptol
+Loading module Z
+2
+19683

--- a/tests/modsys/T1799/B.cry
+++ b/tests/modsys/T1799/B.cry
@@ -1,0 +1,13 @@
+module B where
+
+parameter
+  type a: #
+  type y: #
+
+// 2 ^^ (2 ^^ a)
+type w = 2 ^^ a
+type b = 2 ^^ w
+
+// (3 ^^ y) ^^ 3
+type x = 3 ^^ y
+type z = x ^^ 3

--- a/tests/modsys/T1799/Y.cry
+++ b/tests/modsys/T1799/Y.cry
@@ -1,0 +1,3 @@
+module Y = B where
+type a = 0
+type y = 3

--- a/tests/modsys/T1799/Z.cry
+++ b/tests/modsys/T1799/Z.cry
@@ -1,0 +1,11 @@
+module Z where
+
+// 2 ^^ (2 ^^ 0)
+type a = 0
+type w = 2 ^^ a
+type b = 2 ^^ w
+
+// (3 ^^ 3) ^^ 3
+type y = 3
+type x = 3 ^^ y
+type z = x ^^ 3


### PR DESCRIPTION
Previously, `Cryptol.TypeCheck.SimpType.tExp` would attempt to simplify `a ^^ (x ^^ y)` to `a ^^ (x * y)` at the type level, which was blatantly wrong. I have changed this to a similar (but actually valid) rule that simplified `(a ^^ x) ^^ y` to `a ^^ (x * y)`. (This law is normally stated with the condition that `a != 0`, but this law even works in Cryptol when `a == 0` due to the fact that `0 ^^ 0 == 1` in Cryptol.)

Fixes https://github.com/GaloisInc/cryptol/issues/1799.