### PR TITLE
Implement a smart constructor for EPropGuard

### DIFF
--- a/src/Cryptol/TypeCheck/Infer.hs
+++ b/src/Cryptol/TypeCheck/Infer.hs
@@ -1247,7 +1247,7 @@ checkSigB b (Forall as asmps0 t0, validSchema) =
                , t1
                , foldr ETAbs
                    (foldr EProofAbs
-                     (EPropGuards cases1 t1)
+                     (ePropGuards cases1 t1)
                    asmps1)
                  as
                )

--- a/src/Cryptol/TypeCheck/ModuleBacktickInstance.hs
+++ b/src/Cryptol/TypeCheck/ModuleBacktickInstance.hs
@@ -376,7 +376,7 @@ instance RewVal Expr where
       ELocated r e      -> ELocated r (rew e)
       EProofAbs p e     -> EProofAbs (rewType p) (rew e)
       EWhere e ds       -> EWhere (rew e) (rew ds)
-      EPropGuards gs t  -> EPropGuards gs' (rewType t)
+      EPropGuards gs t  -> ePropGuards gs' (rewType t)
         where gs' = [ (rewType <$> p, rew e) | (p,e) <- gs ]
 
     where

--- a/src/Cryptol/TypeCheck/Subst.hs
+++ b/src/Cryptol/TypeCheck/Subst.hs
@@ -448,7 +448,7 @@ instance TVars Expr where
 
         EWhere e ds   -> EWhere !$ (go e) !$ (apSubst su ds)
 
-        EPropGuards guards ty -> EPropGuards
+        EPropGuards guards ty -> ePropGuards
           !$ (\(props, e) -> (apSubst su `fmap'` props, go e)) `fmap'` guards
           !$ apSubst su ty
 


### PR DESCRIPTION
This allows us to simplify away trivially satisfied type-case in a single place. In particular this helps later compiler passes that work on specialized instances of polymorphic functions.