### PR TITLE
Typechecker: Simplify `width(2^^n)` to `n + 1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,9 @@
 * Add a REPL option `tcSmtFile` that allows writing typechecker-related SMT
   solver interactions to a file.
 
+* The typechecker can now simplify types of the form `width (2^^n)` to `n + 1`.
+  ([#1802](https://github.com/GaloisInc/cryptol/issues/1802))
+
 # 3.2.0 -- 2024-08-20
 
 ## Language changes

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -320,6 +320,10 @@ tWidth x
   , TCon (TF TCExp) [p,q] <- tNoUser a
   , Just 2 <- tIsNum p = q
 
+  -- width (2^n) = n + 1
+  | TCon (TF TCExp) [m,n] <- tNoUser x
+  , Just 2 <- tIsNum m = tf2 TCAdd n (tNum (1 :: Int))
+
   | otherwise = tf1 TCWidth x
 
 tLenFromThenTo :: Type -> Type -> Type -> Type

--- a/tests/issues/issue1802.cry
+++ b/tests/issues/issue1802.cry
@@ -1,0 +1,12 @@
+// A regression test for #1802.
+module T1802 where
+
+parameter
+  type loglogw : #
+  type constraint (loglogw >= 1, loglogw <= 3)
+
+type logw = 2^^loglogw
+type w = 2^^logw
+
+csum : [32][logw] -> [logw+5]
+csum msg = sum [`w - 1 - zext msgi | msgi <- msg]

--- a/tests/issues/issue1802.icry
+++ b/tests/issues/issue1802.icry
@@ -1,0 +1,1 @@
+:load issue1802.cry

--- a/tests/issues/issue1802.icry.stdout
+++ b/tests/issues/issue1802.icry.stdout
@@ -1,0 +1,4 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading interface module `parameter` interface of T1802
+Loading module T1802


### PR DESCRIPTION
This simplification ends up being critical in order to typecheck the code in the SPHINCS+ spec in `cryptol-specs`, as Cryptol's reasoning about exponentiation is otherwise not complete enough.

Fixes #1802.