### PR TITLE
add special cases to handle setting timeouts for SBV-based solvers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@
 
 ## Bug fixes
 
+* Fix a bug where setting at timeout would cause
+  sbv-yices, sbv-cvc4 and sbc-cvc5 to crash.
+  Uses a deadman timer workaround for yices, due
+  to a [known issue](https://github.com/LeventErkok/sbv/issues/735).
+  ([#1808](https://github.com/GaloisInc/cryptol/issues/1808))
+
+
 * Update Yices build in CI to fix a crash when running
   test `issue_1807.icry` on Mac OS X (ARM64).
   ([what4-solvers #58](https://github.com/GaloisInc/what4-solvers/issues/58))

--- a/tests/issues/issue_1808.icry
+++ b/tests/issues/issue_1808.icry
@@ -1,0 +1,14 @@
+:set proverTimeout=1
+
+:l ../../examples/funstuff/NQueens.cry
+
+:set prover=sbv-z3
+:sat nQueens : (Solution 50)
+
+:set prover=sbv-cvc5
+:sat nQueens : (Solution 50)
+
+// FIXME:
+//   broken due to: https://github.com/LeventErkok/sbv/issues/735
+// :set prover=sbv-yices
+// :sat nQueens : (Solution 50)

--- a/tests/issues/issue_1808.icry
+++ b/tests/issues/issue_1808.icry
@@ -8,7 +8,5 @@
 :set prover=sbv-cvc5
 :sat nQueens : (Solution 50)
 
-// FIXME:
-//   broken due to: https://github.com/LeventErkok/sbv/issues/735
-// :set prover=sbv-yices
-// :sat nQueens : (Solution 50)
+:set prover=sbv-yices
+:sat nQueens : (Solution 50)

--- a/tests/issues/issue_1808.icry.stdout
+++ b/tests/issues/issue_1808.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+Unknown.
+  Reason: timeout
+Unknown.
+  Reason: timeout

--- a/tests/issues/issue_1808.icry.stdout
+++ b/tests/issues/issue_1808.icry.stdout
@@ -5,3 +5,5 @@ Unknown.
   Reason: timeout
 Unknown.
   Reason: timeout
+Unknown.
+  Reason: timeout


### PR DESCRIPTION
fixes #1808

* ~Yices still does not work due to unexpected behavior after a timeout is triggered (see: https://github.com/LeventErkok/sbv/issues/735)~ Workaround using deadman timer

* the special cases for CVC4/5 are addressed in the 11.1.5 release for SBV (which is not compatible with cryptol as it requires GHC 9.8)