### PR TITLE
type simplification: improve subtraction cancellation with exponents

### DIFF
--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -60,14 +60,14 @@ tAdd x y
   | Just (n,y1) <- isSumK y = addK n (tAdd x y1)
   | Just v <- matchMaybe (do (a,b) <- (|-|) y
                              ((guard (x == b) >> return a)
-                              <|> (guard (x == a) >> return (tSub (tAdd x a) b)))
+                              <|> (same x a >>= \x2 -> return (tSub x2 b)))
                               ) = v
   | Just v <- matchMaybe (do (a,b) <- (|-|) x
                              ((guard (b == y) >> return a)
-                              <|> (guard (a == y) >> return (tSub (tAdd y a) b)))
+                              <|> (same y a >>= \y2 -> return (tSub y2 b)))
                              ) = v
 
-  | Just v <- matchMaybe (factor <|> same <|> swapVars) = v
+  | Just v <- matchMaybe (factor <|> same x y <|> swapVars) = v
 
   | otherwise           = tf2 TCAdd x y
   where
@@ -103,8 +103,8 @@ tAdd x y
               guard (a == a')
               return (tMul a (tAdd b1 b2))
 
-  same = do guard (x == y)
-            return (tMul (tNum (2 :: Int)) x)
+  same x1 y1 = do guard (x1 == y1)
+                  return (tMul (tNum (2 :: Int)) x1)
 
   swapVars = do a <- aTVar x
                 b <- aTVar y

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -60,6 +60,7 @@ tAdd x y
   | Just (n,y1) <- isSumK y = addK n (tAdd x y1)
   | Just v <- matchMaybe (do (a,b) <- (|-|) y
                              ((guard (x == b) >> return a)
+                              -- added to handle this case: 2 ^^ (1 + h) - 1 == 2 ^^ h - 1 + 2 ^^ h
                               <|> (same x a >>= \x2 -> return (tSub x2 b)))
                               ) = v
   | Just v <- matchMaybe (do (a,b) <- (|-|) x

--- a/src/Cryptol/TypeCheck/SimpType.hs
+++ b/src/Cryptol/TypeCheck/SimpType.hs
@@ -59,11 +59,13 @@ tAdd x y
   | Just (n,x1) <- isSumK x = addK n (tAdd x1 y)
   | Just (n,y1) <- isSumK y = addK n (tAdd x y1)
   | Just v <- matchMaybe (do (a,b) <- (|-|) y
-                             guard (x == b)
-                             return a) = v
+                             ((guard (x == b) >> return a)
+                              <|> (guard (x == a) >> return (tSub (tAdd x a) b)))
+                              ) = v
   | Just v <- matchMaybe (do (a,b) <- (|-|) x
-                             guard (b == y)
-                             return a) = v
+                             ((guard (b == y) >> return a)
+                              <|> (guard (a == y) >> return (tSub (tAdd y a) b)))
+                             ) = v
 
   | Just v <- matchMaybe (factor <|> same <|> swapVars) = v
 
@@ -137,7 +139,7 @@ tSub x y
     -- ~> (x^^n * x^^h) - x^^h 
     -- ~> ((x^^n - 1) * x^^h
     -- allows subtraction cancelling to occur when
-    -- (x^^h + x^^h) has been rewritten into x^^(1+h)
+    -- (2^^h + 2^^h) has been rewritten into 2^^(1+h)
   | Just v <- matchMaybe $ 
       do (x_base,x_exp) <- (|^|) x
          (y_base,y_exp) <- (|^|) y

--- a/src/Cryptol/TypeCheck/Solver/Numeric.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric.hs
@@ -154,9 +154,14 @@ tryGeqThanSub :: Ctxt -> Type -> Type -> Match Solved
 tryGeqThanSub _ x y =
 
   -- t1 >= t1 - t2
-  do (a,_) <- (|-|) y
-     guard (x == a)
-     return (SolvedIf [])
+  (do (a,_) <- (|-|) y
+      guard (x == a)
+      return (SolvedIf []))
+  <|> do
+    (x1, x2) <- (|-|) x
+    (y1, y2) <- (|-|) y
+    ((guard (x2 == y2) >> return (SolvedIf [x1 >== y1]))
+     <|> (guard (x1 == y1) >> return (SolvedIf [y2 >== x2])))
 
 tryGeqThanVar :: Ctxt -> Type -> TVar -> Match Solved
 tryGeqThanVar _ctxt ty x =

--- a/src/Cryptol/TypeCheck/Solver/Numeric.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric.hs
@@ -151,7 +151,7 @@ tryGeqExp _ x y =
 
 
 tryGeqThanSub :: Ctxt -> Type -> Type -> Match Solved
-tryGeqThanSub _ x y =
+tryGeqThanSub ctxt x y =
 
   -- t1 >= t1 - t2
   (do (a,_) <- (|-|) y
@@ -160,8 +160,12 @@ tryGeqThanSub _ x y =
   <|> do
     (x1, x2) <- (|-|) x
     (y1, y2) <- (|-|) y
+    let x1Fin = iIsFin (typeInterval (intervals ctxt) x1)
+    -- (x - z) >= (y - z)  only if x >= y
     ((guard (x2 == y2) >> return (SolvedIf [x1 >== y1]))
-     <|> (guard (x1 == y1) >> return (SolvedIf [y2 >== x2])))
+     <|>
+    -- (z - x) >= (z - y)  only if y >= x and fin z
+     (guard (x1 == y1 && x1Fin) >> return (SolvedIf [y2 >== x2])))
 
 tryGeqThanVar :: Ctxt -> Type -> TVar -> Match Solved
 tryGeqThanVar _ctxt ty x =

--- a/src/Cryptol/Utils/Patterns.hs
+++ b/src/Cryptol/Utils/Patterns.hs
@@ -88,7 +88,7 @@ matchMaybe (Match m) = m Nothing Just
 
 -- | Attempt matching the given pattern against a tuple, 
 --   making a second attempt with the values swapped if the first fails.
-matchSwap :: (a, a) -> (Pat (a, a) b) -> Match b
+matchSwap :: (a, a) -> Pat (a, a) b -> Match b
 matchSwap (x, y) n = n (x, y) <|> n (y, x)
 
 list :: [Pat a b] -> Pat [a] [b]

--- a/src/Cryptol/Utils/Patterns.hs
+++ b/src/Cryptol/Utils/Patterns.hs
@@ -86,6 +86,10 @@ match m = matchDefault (error "Pattern match failure.") m
 matchMaybe :: Match a -> Maybe a
 matchMaybe (Match m) = m Nothing Just
 
+-- | Attempt matching the given pattern against a tuple, 
+--   making a second attempt with the values swapped if the first fails.
+matchSwap :: (a, a) -> (Pat (a, a) b) -> Match b
+matchSwap (x, y) n = n (x, y) <|> n (y, x)
 
 list :: [Pat a b] -> Pat [a] [b]
 list [] = \a ->

--- a/tests/issues/issue_1812.cry
+++ b/tests/issues/issue_1812.cry
@@ -11,3 +11,9 @@ ff = gg`{h}
 
 gg : {h} (fin h) => [2^^h]
 gg = zero
+
+jj : {h} (fin h) => [2 ^^ (1 + h) - 1]
+jj = kk`{h}
+
+kk : {h} (fin h, 2 ^^ (1 + h) - 1 >= 2 ^^ h - 1) => [2 ^^ h - 1 + 2 ^^ h]
+kk = zero

--- a/tests/issues/issue_1812.cry
+++ b/tests/issues/issue_1812.cry
@@ -1,0 +1,13 @@
+f : {h} (fin h) => [2^^h + (2^^h - 2^^h)]
+f = g`{h}
+
+g : {h} (fin h) => [2^^h]
+g = zero
+
+// See if Cryptol knows that (2^^h + 2^^h) - 2^^h == 2^^h
+
+ff : {h} (fin h) => [(2^^h + 2^^h) - 2^^h]
+ff = gg`{h}
+
+gg : {h} (fin h) => [2^^h]
+gg = zero

--- a/tests/issues/issue_1812.icry.stdout
+++ b/tests/issues/issue_1812.icry.stdout
@@ -1,0 +1,3 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main


### PR DESCRIPTION
this allows for the subtraction cancellation rule
to still apply after some exponent simplification
steps have already occurred

fixes #1812