### PR TITLE
Skip `test_project.py` when running in Docker

### DIFF
--- a/cryptol-remote-api/test_docker.sh
+++ b/cryptol-remote-api/test_docker.sh
@@ -32,6 +32,8 @@ poetry install
 export CRYPTOL_SERVER_URL="$PROTO://localhost:8080/"
 
 echo "Running cryptol-remote-api tests with remote server at $CRYPTOL_SERVER_URL..."
+# Disable a test case that is fragile in Docker (#1823)
+sed -i '/def test_project(self):/i\ \ \ \ @unittest.skip("Test is fragile in Docker (#1823)")' tests/cryptol/test_project.py
 poetry run python -m unittest discover --verbose tests/cryptol
 if [ $? -ne 0 ]; then
     NUM_FAILS=$(($NUM_FAILS+1))


### PR DESCRIPTION
Unfortunately, this test case appears to cause various permission-related headaches (for reasons that are difficult to reproduce outside of GitHub Actions), and what's more, it seems to cause later tests to fail (perhaps due to the presence of a `.cryproject` file?). See #1823 for more details.

For the sake of getting the CI to work again, I am opting to just disable this test case when running the tests via Docker.