### PR TITLE
CI: Support Ubuntu 24.04, drop 20.04 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # - cryptol-remote-api/Dockerfile
   # - README.md
   # - dev/dev_setup.sh
-  SOLVER_PKG_VERSION: "snapshot-20250227"
+  SOLVER_PKG_VERSION: "snapshot-20250326"
   # The CACHE_VERSION can be updated to force the use of a new cache if
   # the current cache contents become corrupted/invalid.  This can
   # sometimes happen when (for example) the OS version is changed but
@@ -27,7 +27,7 @@ env:
 
 jobs:
   config:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       name: ${{ steps.config.outputs.name }}
       version: ${{ steps.config.outputs.version }}
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         ghc-version: ["9.4.8", "9.6.5", "9.8.2"]
         cabal: [ '3.10.3.0' ]
         run-tests: [true]
@@ -74,7 +74,7 @@ jobs:
           # We include one job from an older Ubuntu LTS release to increase our
           # coverage of possible Linux configurations. Since we already run the
           # tests with the newest LTS release, we won't bother testing this one.
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             ghc-version: 9.4.8
             run-tests: false
           # Windows and macOS CI runners are more expensive than Linux runners,
@@ -281,16 +281,16 @@ jobs:
       matrix:
         suite: [test-lib]
         target: ${{ fromJson(needs.build.outputs.test-lib-json) }}
-        os: [ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-14, windows-2019]
         continue-on-error: [false]
         include:
           - suite: api-tests
             target: ''
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             continue-on-error: false
           - suite: rpc
             target: ''
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             continue-on-error: false
           #- suite: rpc
           #  target: ''
@@ -419,7 +419,7 @@ jobs:
           ./bin/cryptol-api-tests
 
   build-push-image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [config]
     # Do not run this on forks. It seems that you can't stop scheduled
     # jobs from also running in forks. See

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS build
+FROM ubuntu:24.04 AS build
 
 ARG GHCVER="9.4.8"
 ARG CABALVER="3.10.3.0"
@@ -18,7 +18,7 @@ RUN mkdir -p rootfs/usr/local/bin
 WORKDIR /cryptol/rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BIN_ZIP_FILE in
 # `.github/workflow/ci.yml`, but specialized to x86-64 Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250227/ubuntu-22.04-X64-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 WORKDIR /cryptol
 ENV PATH=/cryptol/rootfs/usr/local/bin:/home/cryptol/.local/bin:/home/cryptol/.ghcup/bin:$PATH
@@ -54,7 +54,7 @@ RUN mkdir -p rootfs/"${CRYPTOLPATH}" \
 USER root
 RUN chown -R root:root /cryptol/rootfs
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update \
     && apt-get install -y libgmp10 libgomp1 libffi8 libncurses6 libtinfo6 libreadline8 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cryptol currently uses Microsoft Research's [Z3 SMT
 solver](https://github.com/Z3Prover/z3) by default to solve constraints
 during type checking, and as the default solver for the `:sat` and
 `:prove` commands.  Cryptol generally requires the most recent version
-of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20250227).
+of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20250326).
 
 You can download Z3 binaries for a variety of platforms from their
 [releases page](https://github.com/Z3Prover/z3/releases). If you
@@ -76,8 +76,8 @@ Windows. We regularly build and test it in the following environments:
 
 - macOS 13 (x86-64)
 - macOS 14 (ARM64)
-- Ubuntu 20.04 (x86-64)
 - Ubuntu 22.04 (x86-64)
+- Ubuntu 24.04 (x86-64)
 - Windows Server 2019 (x86-64)
 
 ## Prerequisites

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -11,7 +11,7 @@ ARG GHCVER_BOOTSTRAP="9.0.2"
 # may need to update ALEXVER and HAPPYVER as well.
 ARG ALEXVER="3.4.0.1"
 ARG HAPPYVER="1.20.1.1"
-FROM ubuntu:22.04 AS toolchain
+FROM ubuntu:24.04 AS toolchain
 ARG PORTABILITY=false
 RUN apt-get update && \
     apt-get install -y \
@@ -82,12 +82,12 @@ RUN mkdir -p rootfs/"${CRYPTOLPATH}" \
 WORKDIR /cryptol/rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BIN_ZIP_FILE in
 # `.github/workflow/ci.yml`, but specialized to x86-64 Ubuntu.
-RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250227/ubuntu-22.04-X64-bin.zip" && \
+RUN curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-X64-bin.zip" && \
     unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /cryptol/rootfs
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update \
     && apt-get install -y libgmp10 libgomp1 libffi8 libncurses6 libtinfo6 libreadline8 libnuma-dev openssl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -59,7 +59,7 @@ RUN if ${PORTABILITY}; then \
 
 FROM toolchain AS build
 
-RUN useradd -u 1000 -m cryptol
+RUN useradd -m cryptol
 COPY --chown=cryptol:cryptol . /cryptol
 USER cryptol
 WORKDIR /cryptol

--- a/dev/dev_setup.sh
+++ b/dev/dev_setup.sh
@@ -4,8 +4,8 @@
 #
 # Supported distribution(s):
 #  * macOS 14 (AArch64)
-#  * Ubuntu 20.04 (x86_64)
 #  * Ubuntu 22.04 (x86_64)
+#  * Ubuntu 24.04 (x86_64)
 #
 # This script installs everything needed to get a working development
 # environment for cryptol. Any new environment requirements should be
@@ -37,12 +37,12 @@ GHCUP_URL="https://downloads.haskell.org/~ghcup"
 GHC_VERSION="9.4.8"
 CABAL_VERSION="3.10.3.0"
 
-WHAT4_SOLVERS_SNAPSHOT="snapshot-20250227"
+WHAT4_SOLVERS_SNAPSHOT="snapshot-20250326"
 WHAT4_SOLVERS_URL="https://github.com/GaloisInc/what4-solvers/releases/download/$WHAT4_SOLVERS_SNAPSHOT"
 WHAT4_SOLVERS_MACOS_13="macos-13-X64-bin.zip"
 WHAT4_SOLVERS_MACOS_14="macos-14-ARM64-bin.zip"
-WHAT4_SOLVERS_UBUNTU_20="ubuntu-20.04-X64-bin.zip"
 WHAT4_SOLVERS_UBUNTU_22="ubuntu-22.04-X64-bin.zip"
+WHAT4_SOLVERS_UBUNTU_24="ubuntu-24.04-X64-bin.zip"
 WHAT4_CVC4_VERSION="version 1.8"
 WHAT4_CVC5_VERSION="version 1.1.1"
 WHAT4_Z3_VERSION="version 4.8.14"
@@ -50,8 +50,8 @@ WHAT4_Z3_VERSION="version 4.8.14"
 # Set of supported platforms:
 MACOS14="macos14"
 MACOS13="macos13" # actually, this isn't supported yet
-UBUNTU20="ubuntu-20.04"
 UBUNTU22="ubuntu-22.04"
+UBUNTU24="ubuntu-24.04"
 
 USED_BREW=false
 
@@ -80,10 +80,10 @@ supported_platform() {
                 fi
                 version_file=$(mktemp)
                 lsb_release -d > $version_file
-                if $(grep -q "Ubuntu 20.04" $version_file); then
-                    echo $UBUNTU20
-                elif $(grep -q "Ubuntu 22.04" $version_file); then
+                if $(grep -q "Ubuntu 22.04" $version_file); then
                     echo $UBUNTU22
+                elif $(grep -q "Ubuntu 24.04" $version_file); then
+                    echo $UBUNTU24
                 else
                     echo ""
                 fi
@@ -129,7 +129,7 @@ update_submodules() {
     if ! is_installed git; then
         notice "Installing git"
         case $CRYPTOL_PLATFORM in
-            $UBUNTU20 | $UBUNTU22) logged apt-get install -y git;;
+            $UBUNTU22 | $UBUNTU24) logged apt-get install -y git;;
             $MACOS12 | $MACOS14) logged brew install git && USED_BREW=true;;
             *) unreachable "Unsupported platform; did not install git"; return;;
         esac
@@ -146,7 +146,7 @@ install_ghcup() {
             $MACOS12 | $MACOS14)
                 notice "Installing GHCup via Homebrew"
                 logged brew install ghcup && USED_BREW=true;;
-            $UBUNTU20 | $UBUNTU22)
+            $UBUNTU22 | $UBUNTU24)
                 notice "Installing any missing GHCup dependencies via apt-get"
                 logged apt-get install -y build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5
 
@@ -179,7 +179,7 @@ install_gmp() {
         $MACOS12 | $MACOS14)
             notice "Installing GMP via Homebrew, if it's not already installed"
             logged brew install gmp && USED_BREW=true;;
-        $UBUNTU20 | $UBUNTU22)
+        $UBUNTU22 | $UBUNTU24)
             notice "Installing GMP via apt-get, if it's not already installed"
             logged apt-get install -y libgmp-dev libgmp10;;
         *) unreachable "Unsupported platform; did not install GMP";;
@@ -191,7 +191,7 @@ install_zlib() {
         $MACOS12 | $MACOS14)
             notice "Installing zlib via Homebrew, if it's not already installed"
             logged brew install zlib && USED_BREW=true;;
-        $UBUNTU20 | $UBUNTU22)
+        $UBUNTU22 | $UBUNTU24)
             notice "Installing zlib via apt-get, if it's not already installed"
             logged apt-get install -y zlib1g-dev;;
         *) unreachable "Unsupported platform; did not install zlib";;
@@ -210,8 +210,8 @@ install_solvers() {
         case $CRYPTOL_PLATFORM in
             $MACOS13) solvers_version=$WHAT4_SOLVERS_MACOS_13;;
             $MACOS14) solvers_version=$WHAT4_SOLVERS_MACOS_14;;
-            $UBUNTU20) solvers_version=$WHAT4_SOLVERS_UBUNTU_20;;
             $UBUNTU22) solvers_version=$WHAT4_SOLVERS_UBUNTU_22;;
+            $UBUNTU24) solvers_version=$WHAT4_SOLVERS_UBUNTU_24;;
             *) unreachable "Unsupported platform; did not install solvers"; return;;
         esac
 
@@ -224,7 +224,7 @@ install_solvers() {
                 $MACOS12 | $MACOS14)
                     notice "Installing unzip via Homebrew"
                     logged brew install unzip && USED_BREW=true;;
-                $UBUNTU20 | $UBUNTU22)
+                $UBUNTU22 | $UBUNTU24)
                     notice "Installing unzip via apt-get"
                     logged apt-get install -y unzip;;
                 *) unreachable "Unsupported platform; did not install unzip"; return;;
@@ -286,7 +286,7 @@ put_brew_packages_in_path() {
 
 set_ubuntu_language_encoding() {
     case $CRYPTOL_PLATFORM in
-        $UBUNTU20 | $UBUNTU22)
+        $UBUNTU22 | $UBUNTU24)
             if $LANG != *"UTF-8"* || $LANG != *"utf-8"*; then
                 notice "Language environment variables are not set as expected."
                 notice "    You may need to set them to UTF-8."
@@ -305,7 +305,7 @@ set_ubuntu_language_encoding() {
 notice "Checking whether platform is supported"
 CRYPTOL_PLATFORM=$(supported_platform)
 if [ -z "$CRYPTOL_PLATFORM" ]; then
-    echo "Unsupported platform; this script supports Ubuntu 20.04, Ubuntu 22.04, and macOS 14"
+    echo "Unsupported platform; this script supports Ubuntu 22.04, Ubuntu 24.04, and macOS 14"
     exit 1
 fi
 

--- a/dev/ubuntu24.04.Dockerfile
+++ b/dev/ubuntu24.04.Dockerfile
@@ -2,9 +2,9 @@
 # Note: If building this container from a machine running non-X86 hardware
 # (like Apple M1 / M2 chips), you'll need to build and run the container
 # specifying the platform e.g.
-# $ docker build --platform linux/amd64 ubuntu20.04.Dockerfile
+# $ docker build --platform linux/amd64 ubuntu24.04.Dockerfile
 #
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 WORKDIR /home/
 
 RUN apt-get -y upgrade \


### PR DESCRIPTION
GitHub Actions is removing its Ubuntu 20.04 runners soon (https://github.com/actions/runner-images/issues/11101), so this patch removes CI support for Ubuntu 20.04 and makes Ubuntu 24.04 the latest supported Ubuntu version.