### PR TITLE
Add :saw notebook command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@
   section](https://galoisinc.github.io/cryptol/master/FFI.html#the-abstract-calling-convention)
   for more information.
 
+## New Features
+
+* New REPL command `:saw` to run SAW on a SAW file, usable in docstrings.
+  [#1835](https://github.com/GaloisInc/cryptol/issues/1835)
+
 # 3.3.0 -- 2025-03-21
 
 ## Language changes

--- a/cryptol/Main.hs
+++ b/cryptol/Main.hs
@@ -221,6 +221,10 @@ displayHelp errs = do
             , "addition to the default locations"
             ]
           )
+        , ( "CRYPTOL_SAW"
+          , [ "Sets the command to use when running SAW via the `:saw` command"
+            ]
+          )
         , ( "EDITOR"
           , [ "Sets the editor executable to use when opening an editor"
             , "via the `:edit` command"

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1531,8 +1531,8 @@ helpCmd cmd
 runShellCmd :: String -> REPL CommandResult
 runShellCmd cmd
   = io $ do h <- Process.runCommand cmd
-            _ <- waitForProcess h
-            return emptyCommandResult -- This could check for exit code 0
+            e <- waitForProcess h
+            pure emptyCommandResult { crSuccess = e == ExitSuccess }
 
 cdCmd :: FilePath -> REPL CommandResult
 cdCmd f | null f = do rPutStrLn $ "[error] :cd requires a path argument"

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -1099,6 +1099,9 @@ userOptions  = mkOptionMap
 
   , simpleOpt "timeQuiet" ["time-quiet"] (EnvBool False) noCheck
     "Suppress output of :time command and only bind result to `it`."
+
+  , simpleOpt "sawFlags" ["saw-flags"] (EnvString "-v 0") noCheck
+    "Flags for all calls to SAW."
   ]
 
 

--- a/tests/docstrings/T13.cry
+++ b/tests/docstrings/T13.cry
@@ -1,0 +1,8 @@
+/** docstrings can use the :saw repl command
+ *
+ * ```repl
+ * :saw T13.saw
+ * ```
+ */
+module I where
+

--- a/tests/docstrings/T13.icry
+++ b/tests/docstrings/T13.icry
@@ -1,0 +1,1 @@
+:! sh -c 'CRYPTOL_SAW="sh ./mocksaw.sh" ../../dist/bin/cryptol T13.cry -c :check-docstrings'

--- a/tests/docstrings/T13.icry.stdout
+++ b/tests/docstrings/T13.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module I
+Checking module I
+  Docstrings on I
+    :saw T13.saw
+Successes: 1, No fences: 0, Failures: 0

--- a/tests/docstrings/T13.saw
+++ b/tests/docstrings/T13.saw
@@ -1,0 +1,1 @@
+// a syntactically valid saw file

--- a/tests/docstrings/T14.cry
+++ b/tests/docstrings/T14.cry
@@ -1,0 +1,8 @@
+/** :saw fails if the saw call fails
+ *
+ * ```repl
+ * :saw T14.saw
+ * ```
+ */
+module I where
+

--- a/tests/docstrings/T14.icry
+++ b/tests/docstrings/T14.icry
@@ -1,0 +1,1 @@
+:! sh -c 'CRYPTOL_SAW="sh ./mocksaw.sh" ../../dist/bin/cryptol T14.cry -c :check-docstrings'

--- a/tests/docstrings/T14.icry.stdout
+++ b/tests/docstrings/T14.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module I
+Checking module I
+  Docstrings on I
+    :saw T14.saw
+Successes: 0, No fences: 0, Failures: 1

--- a/tests/docstrings/T14.saw
+++ b/tests/docstrings/T14.saw
@@ -1,0 +1,2 @@
+// an invalid saw file
+let

--- a/tests/docstrings/T15.cry
+++ b/tests/docstrings/T15.cry
@@ -1,0 +1,8 @@
+/** :saw fails with a nice message if the file doesn't exist
+ *
+ * ```repl
+ * :saw T15.saw
+ * ```
+ */
+module I where
+

--- a/tests/docstrings/T15.icry
+++ b/tests/docstrings/T15.icry
@@ -1,0 +1,2 @@
+:m T15
+:check-docstrings

--- a/tests/docstrings/T15.icry.stdout
+++ b/tests/docstrings/T15.icry.stdout
@@ -1,0 +1,8 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module I
+Checking module I
+  Docstrings on I
+    :saw T15.saw
+      File `T15.saw' does not exist.
+Successes: 0, No fences: 0, Failures: 1

--- a/tests/docstrings/mocksaw.sh
+++ b/tests/docstrings/mocksaw.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+if [ "$3" = "T13.saw" ] ; then
+    exit 0
+fi
+if [ "$3" = "T14.saw" ] ; then
+    exit 1
+fi
+
+exit 1


### PR DESCRIPTION
The command succeeds when `saw` returns 0. Saw output is suppressed because `saw` adds timestamps and absolute paths to all output.

Saw is launched directly, so there is no concern about shell commands escaping the notebook.

Fixes #1835 