### PR TITLE
Test suite: Accept new output for `ffi-type-errors` and `issue410`

### DIFF
--- a/tests/ffi/c-calling-convention/ffi-type-errors.icry.stdout
+++ b/tests/ffi/c-calling-convention/ffi-type-errors.icry.stdout
@@ -35,8 +35,8 @@ Loading module Main
   When checking the type of 'Main::badFloatSizes'
 [error] at ffi-type-errors.cry:5:9--6:59:
   Type unsupported for FFI:
-    [n`962] -> [n`962]([16], [16]) -> [n`962][4][8]{a : [n`962],
-     b : [2]}
+    [n`962] ->
+    [n`962]([16], [16]) -> [n`962][4][8]{a : [n`962], b : [2]}
     Due to:
       Type unsupported for FFI:
         [n`962]

--- a/tests/issues/issue410.icry.stdout
+++ b/tests/issues/issue410.icry.stdout
@@ -2,11 +2,7 @@ Loading module Cryptol
 {n, a} (Logic a) => n == min (1 + n) n
 (s
  where
-   s x =
-       (bs
-        where
-          bs = [~b | b <- [~x] # bs
-                   | _ <- bs])) :
+   s x = (bs where bs = [~b | b <- [~x] # bs | _ <- bs])) :
   {n, a} (Logic a) => a -> [n]a
 (bs where bs = [b | b <- bs]) : {n, a} [n]a
 [b | b <- [True]] : [1]


### PR DESCRIPTION
The output for these tests are now slightly different due to the recently merged changed from https://github.com/GaloisInc/cryptol/pull/1292. These changes are benign, so let's accept them.

Fixes #1845.