### PR TITLE
Post-#1739 improvements to `cry-ffi`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 # next -- TBA
 
-Nothing yet.
+## Language changes
+
+* `foreign` function declarations now support an optional calling convention
+  keyword. See the [manual
+  section](https://galoisinc.github.io/cryptol/master/FFI.html#calling-conventions)
+  for more information.
+
+* Add an `abstract` calling convention, where Cryptol values are marshalled
+  using an abstract interface. See the [manual
+  section](https://galoisinc.github.io/cryptol/master/FFI.html#the-abstract-calling-convention)
+  for more information.
 
 # 3.3.0 -- 2025-03-21
 

--- a/rust/cry-ffi/Cargo.toml
+++ b/rust/cry-ffi/Cargo.toml
@@ -2,6 +2,8 @@
 name = "cry_ffi"
 version = "0.1.0"
 edition = "2021"
+license = "BSD-3-Clause"
+license-files = "LICENSE"
 
 [lib]
 crate-type = ["lib"]

--- a/rust/cry-ffi/LICENSE
+++ b/rust/cry-ffi/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2025 Galois Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Galois, Inc. nor the names of its contributors
+    may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Add entries about the new `abstract` calling convention to the changelog. Also add a `LICENSE` file to `cry-ffi`.