### PR TITLE
Generate `:exhaust` for simple properties.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Language changes
 
+* `Bit` properties (e.g. `property p = True`) will be checked with `:exhaust`,
+  unless their docstrings contain code blocks understood by `:check-docstrings`.
+  ([#1842](https://github.com/GaloisInc/cryptol/issues/1842))
+
 * `foreign` function declarations now support an optional calling convention
   keyword. See the [manual
   section](https://galoisinc.github.io/cryptol/master/FFI.html#calling-conventions)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## Language changes
 
-* `Bit` properties (e.g. `property p = True`) will be checked with `:exhaust`,
-  unless their docstrings contain code blocks understood by `:check-docstrings`.
+* When running the `:check-docstrings` command, `Bit` properties (e.g. `property
+  p = True`) will be checked with `:exhaust`, unless their docstrings contain
+  code blocks understood by `:check-docstrings`.
   ([#1842](https://github.com/GaloisInc/cryptol/issues/1842))
 
 * `foreign` function declarations now support an optional calling convention

--- a/cryptol.cabal
+++ b/cryptol.cabal
@@ -161,6 +161,7 @@ library
                        Cryptol.TypeCheck.TypePat,
                        Cryptol.TypeCheck.SimpType,
                        Cryptol.TypeCheck.AST,
+                       Cryptol.TypeCheck.Docstrings,
                        Cryptol.TypeCheck.Parseable,
                        Cryptol.TypeCheck.Monad,
                        Cryptol.TypeCheck.Infer,

--- a/docs/RefMan/BasicSyntax.rst
+++ b/docs/RefMan/BasicSyntax.rst
@@ -165,6 +165,13 @@ success of all the REPL commands.
   f : [8] -> [8]
   f x = 2 * x
 
+When you define a ``property p`` of type ``Bit``, there is special
+behavior for docstring checks.
+
+If no docstring is provided, *or* if the provided docstring contains
+no code blocks that would be checked with ``:check-docstrings``, then
+``:check-docstrings`` will implicitly run ``:exhaust p``.
+
 Identifiers
 -----------
 

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -100,6 +100,7 @@ import Cryptol.Parser
     ,parseModName,parseHelpName,parseImpName)
 import           Cryptol.Parser.Position (Position(..),Range(..),HasLoc(..))
 import qualified Cryptol.TypeCheck.AST as T
+import qualified Cryptol.TypeCheck.Docstrings as T
 import qualified Cryptol.TypeCheck.Error as T
 import qualified Cryptol.TypeCheck.Parseable as T
 import qualified Cryptol.TypeCheck.Subst as T

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -27,13 +27,11 @@ module Cryptol.TypeCheck.AST
   , Fixity(..)
   , PrimMap(..)
   , module Cryptol.TypeCheck.Type
-  , DocFor(..)
   , FFI(..)
   ) where
 
-import Data.Maybe(catMaybes)
 import Cryptol.Utils.Panic(panic)
-import Cryptol.Utils.Ident (Ident,identText,isInfixIdent,ModName,PrimIdent,prelPrim)
+import Cryptol.Utils.Ident (Ident,isInfixIdent,ModName,PrimIdent,prelPrim)
 import Cryptol.Parser.Position(Located, HasLoc(..), Range)
 import Cryptol.ModuleSystem.Name
 import Cryptol.ModuleSystem.NamingEnv.Types
@@ -58,10 +56,9 @@ import Control.DeepSeq
 import qualified Data.IntMap as IntMap
 import           Data.Map    (Map)
 import qualified Data.Map    as Map
-import           Data.Maybe  (mapMaybe, maybeToList, isJust, fromMaybe)
+import           Data.Maybe  (catMaybes, mapMaybe, isJust)
 import           Data.Set    (Set)
 import           Data.Text   (Text)
-import qualified Data.Text   as T
 
 
 data TCTopEntity =
@@ -560,127 +557,3 @@ instance PP (WithNames TCTopEntity) where
      TCTopModule m -> ppWithNames nm m
      TCTopSignature n ps ->
         hang ("interface module" <+> pp n <+> "where") 2 (pp ps)
-
-data DocItem = DocItem
-  { docModContext :: ImpName Name -- ^ The module scope to run repl commands in
-  , docFor        :: DocFor -- ^ The name the documentation is attached to
-  , docText       :: [Text] -- ^ The text of the attached docstring, if any
-  }
-
-data DocFor
-  = DocForMod (ImpName Name)
-  | DocForDef Name -- definitions that aren't modules
-
-instance PP DocFor where
-  ppPrec p x =
-    case x of
-      DocForMod m -> ppPrec p m
-      DocForDef n -> ppPrec p n 
-
-
-gatherModuleDocstrings ::
-  Map Name (ImpName Name) ->
-  Module ->
-  [DocItem]
-gatherModuleDocstrings nameToModule m =
-  [DocItem
-    { docModContext = ImpTop (mName m)
-    , docFor = DocForMod (ImpTop (mName m))
-    , docText = mDoc m
-    }
-  ] ++
-  -- mParams m
-  -- mParamTypes m
-  -- mParamFuns m
-  [DocItem
-    { docModContext = lookupModuleName n
-    , docFor = DocForDef n
-    , docText = maybeToList (tsDoc t)
-    } | (n, t) <- Map.assocs (mTySyns m)] ++
-  [DocItem
-    { docModContext = lookupModuleName n
-    , docFor = DocForDef n
-    , docText = maybeToList (ntDoc t)
-    } | (n, t) <- Map.assocs (mNominalTypes m)] ++
-  [DocItem
-    { docModContext = lookupModuleName (dName d)
-    , docFor = DocForDef (dName d)
-    , docText = maybeToList (dDoc d <> exhaustBoolProp d)
-    } | g <- mDecls m, d <- groupDecls g] ++
-  [DocItem
-    { docModContext = ImpNested n
-    , docFor = DocForMod (ImpNested n)
-    , docText = ifsDoc (smIface s)
-    } | (n, s) <- Map.assocs (mSubmodules m)] ++
-  [DocItem
-    { docModContext = ImpTop (mName m)
-    , docFor = DocForMod (ImpNested n)
-    , docText = maybeToList (mpnDoc s)
-    } | (n, s) <- Map.assocs (mSignatures m)]
-  where
-    lookupModuleName n =
-      case Map.lookup n nameToModule of
-        Just x -> x
-        Nothing -> panic "gatherModuleDocstrings" ["No owning module for name:", show (pp n)]
-
-    exhaustBoolProp d =
-      if (null . extractCodeBlocks . fromMaybe "" . dDoc) d &&
-         (tIsBit . sType . dSignature) d &&
-         PragmaProperty `elem` dPragmas d
-      then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> " // implicit" <> "\n```"
-      else Nothing
-
--- | Extract the code blocks from the body of a docstring.
---
--- A single code block starts with at least 3 backticks followed by an
--- optional language specifier of \"cryptol\". This allows other kinds
--- of code blocks to be included (and ignored) in docstrings. Longer
--- backtick sequences can be used when a code block needs to be able to
--- contain backtick sequences.
---
--- @
--- /**
---  * A docstring example
---  *
---  * ```cryptol
---  * :check example
---  * ```
---  */
--- @
-extractCodeBlocks :: Text -> [[Text]]
-extractCodeBlocks raw = go [] (T.lines raw)
-  where
-    go finished [] = reverse finished
-    go finished (x:xs)
-      | (spaces, x1) <- T.span (' ' ==) x
-      , (ticks, x2) <- T.span ('`' ==) x1
-      , 3 <= T.length ticks
-      , not (T.elem '`' x2)
-      , let info = T.strip x2
-      = if info `elem` ["", "repl"] -- supported languages "unlabeled" and repl
-        then keep finished (T.length spaces) (T.length ticks) [] xs
-        else skip finished ticks xs
-      | otherwise = go finished xs
-
-    -- process a code block that we're keeping
-    keep finished _ _ acc [] = go (reverse acc : finished) [] -- unterminated code fences are defined to be terminated by github
-    keep finished indentLen ticksLen acc (x:xs)
-      | x1 <- T.dropWhile (' ' ==) x
-      , (ticks, x2) <- T.span ('`' ==) x1
-      , ticksLen <= T.length ticks
-      , T.all (' ' ==) x2
-      = go (reverse acc : finished) xs
-
-      | otherwise =
-        let x' =
-              case T.span (' ' ==) x of
-                (spaces, x1)
-                  | T.length spaces <= indentLen -> x1
-                  | otherwise -> T.drop indentLen x
-        in keep finished indentLen ticksLen (x' : acc) xs
-
-    -- process a code block that we're skipping
-    skip finished _ [] = go finished []
-    skip finished close (x:xs)
-      | close == x = go finished xs
-      | otherwise = skip finished close xs

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -633,7 +633,7 @@ gatherModuleDocstrings nameToModule m =
 -- | Extract the code blocks from the body of a docstring.
 --
 -- A single code block starts with at least 3 backticks followed by an
--- optional language specifier of "cryptol". This allowed other kinds
+-- optional language specifier of \"cryptol\". This allowed other kinds
 -- of code blocks to be included (and ignored) in docstrings. Longer
 -- backtick sequences can be used when a code block needs to be able to
 -- contain backtick sequences.

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -61,6 +61,7 @@ import qualified Data.Map    as Map
 import           Data.Maybe  (mapMaybe, maybeToList, isJust)
 import           Data.Set    (Set)
 import           Data.Text   (Text)
+import qualified Data.Text   as T
 
 
 data TCTopEntity =
@@ -626,3 +627,58 @@ gatherModuleDocstrings nameToModule m =
       if (tIsBit . sType . dSignature) d && PragmaProperty `elem` dPragmas d
       then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> " // implicit" <> "\n```"
       else Nothing
+
+-- | Extract the code blocks from the body of a docstring.
+--
+-- A single code block starts with at least 3 backticks followed by an
+-- optional language specifier of "cryptol". This allowed other kinds
+-- of code blocks to be included (and ignored) in docstrings. Longer
+-- backtick sequences can be used when a code block needs to be able to
+-- contain backtick sequences.
+--
+-- @
+-- /**
+--  * A docstring example
+--  *
+--  * ```cryptol
+--  * :check example
+--  * ```
+--  */
+-- @
+extractCodeBlocks :: Text -> [[Text]]
+extractCodeBlocks raw = go [] (T.lines raw)
+  where
+    go finished [] = reverse finished
+    go finished (x:xs)
+      | (spaces, x1) <- T.span (' ' ==) x
+      , (ticks, x2) <- T.span ('`' ==) x1
+      , 3 <= T.length ticks
+      , not (T.elem '`' x2)
+      , let info = T.strip x2
+      = if info `elem` ["", "repl"] -- supported languages "unlabeled" and repl
+        then keep finished (T.length spaces) (T.length ticks) [] xs
+        else skip finished ticks xs
+      | otherwise = go finished xs
+
+    -- process a code block that we're keeping
+    keep finished _ _ acc [] = go (reverse acc : finished) [] -- unterminated code fences are defined to be terminated by github
+    keep finished indentLen ticksLen acc (x:xs)
+      | x1 <- T.dropWhile (' ' ==) x
+      , (ticks, x2) <- T.span ('`' ==) x1
+      , ticksLen <= T.length ticks
+      , T.all (' ' ==) x2
+      = go (reverse acc : finished) xs
+
+      | otherwise =
+        let x' =
+              case T.span (' ' ==) x of
+                (spaces, x1)
+                  | T.length spaces <= indentLen -> x1
+                  | otherwise -> T.drop indentLen x
+        in keep finished indentLen ticksLen (x' : acc) xs
+
+    -- process a code block that we're skipping
+    skip finished _ [] = go finished []
+    skip finished close (x:xs)
+      | close == x = go finished xs
+      | otherwise = skip finished close xs

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -624,5 +624,5 @@ gatherModuleDocstrings nameToModule m =
 
     exhaustBoolProp d =
       if (tIsBit . sType . dSignature) d && PragmaProperty `elem` dPragmas d
-      then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> "\n```"
+      then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> " // implicit" <> "\n```"
       else Nothing

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -33,7 +33,7 @@ module Cryptol.TypeCheck.AST
 
 import Data.Maybe(catMaybes)
 import Cryptol.Utils.Panic(panic)
-import Cryptol.Utils.Ident (Ident,isInfixIdent,ModName,PrimIdent,prelPrim)
+import Cryptol.Utils.Ident (Ident,identText,isInfixIdent,ModName,PrimIdent,prelPrim)
 import Cryptol.Parser.Position(Located, HasLoc(..), Range)
 import Cryptol.ModuleSystem.Name
 import Cryptol.ModuleSystem.NamingEnv.Types
@@ -621,3 +621,8 @@ gatherModuleDocstrings nameToModule m =
       case Map.lookup n nameToModule of
         Just x -> x
         Nothing -> panic "gatherModuleDocstrings" ["No owning module for name:", show (pp n)]
+
+    exhaustBoolProp d =
+      if (tIsBit . sType . dSignature) d && PragmaProperty `elem` dPragmas d
+      then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> "\n```"
+      else Nothing

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -604,7 +604,7 @@ gatherModuleDocstrings nameToModule m =
   [DocItem
     { docModContext = lookupModuleName (dName d)
     , docFor = DocForDef (dName d)
-    , docText = maybeToList (dDoc d)
+    , docText = maybeToList (dDoc d <> exhaustBoolProp d)
     } | g <- mDecls m, d <- groupDecls g] ++
   [DocItem
     { docModContext = ImpNested n

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -633,7 +633,7 @@ gatherModuleDocstrings nameToModule m =
 -- | Extract the code blocks from the body of a docstring.
 --
 -- A single code block starts with at least 3 backticks followed by an
--- optional language specifier of \"cryptol\". This allowed other kinds
+-- optional language specifier of \"cryptol\". This allows other kinds
 -- of code blocks to be included (and ignored) in docstrings. Longer
 -- backtick sequences can be used when a code block needs to be able to
 -- contain backtick sequences.

--- a/src/Cryptol/TypeCheck/AST.hs
+++ b/src/Cryptol/TypeCheck/AST.hs
@@ -58,7 +58,7 @@ import Control.DeepSeq
 import qualified Data.IntMap as IntMap
 import           Data.Map    (Map)
 import qualified Data.Map    as Map
-import           Data.Maybe  (mapMaybe, maybeToList, isJust)
+import           Data.Maybe  (mapMaybe, maybeToList, isJust, fromMaybe)
 import           Data.Set    (Set)
 import           Data.Text   (Text)
 import qualified Data.Text   as T
@@ -624,7 +624,9 @@ gatherModuleDocstrings nameToModule m =
         Nothing -> panic "gatherModuleDocstrings" ["No owning module for name:", show (pp n)]
 
     exhaustBoolProp d =
-      if (tIsBit . sType . dSignature) d && PragmaProperty `elem` dPragmas d
+      if (null . extractCodeBlocks . fromMaybe "" . dDoc) d &&
+         (tIsBit . sType . dSignature) d &&
+         PragmaProperty `elem` dPragmas d
       then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> " // implicit" <> "\n```"
       else Nothing
 

--- a/src/Cryptol/TypeCheck/Docstrings.hs
+++ b/src/Cryptol/TypeCheck/Docstrings.hs
@@ -1,0 +1,153 @@
+-- |
+-- Module      :  Cryptol.TypeCheck.Docstrings
+-- Copyright   :  (c) 2013-2025 Galois, Inc.
+-- License     :  BSD3
+-- Maintainer  :  cryptol@galois.com
+-- Stability   :  provisional
+-- Portability :  portable
+
+{-# LANGUAGE Safe #-}
+
+{-# LANGUAGE OverloadedStrings #-}
+module Cryptol.TypeCheck.Docstrings where
+
+import Cryptol.ModuleSystem.Interface
+import Cryptol.ModuleSystem.Name
+import Cryptol.Parser.AST (ImpName (..))
+import Cryptol.TypeCheck.AST (Decl(..), Module, ModuleG(..), Pragma(..),
+                              Submodule(..),  groupDecls)
+import Cryptol.TypeCheck.PP
+import Cryptol.TypeCheck.Type
+import Cryptol.Utils.Ident (identText)
+import Cryptol.Utils.Panic (panic)
+
+import           Data.Map  (Map)
+import qualified Data.Map  as Map
+import           Data.Maybe (fromMaybe, maybeToList)
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+data DocItem = DocItem
+  { docModContext :: ImpName Name -- ^ The module scope to run repl commands in
+  , docFor        :: DocFor -- ^ The name the documentation is attached to
+  , docText       :: [Text] -- ^ The text of the attached docstring, if any
+  }
+
+data DocFor
+  = DocForMod (ImpName Name)
+  | DocForDef Name -- definitions that aren't modules
+
+instance PP DocFor where
+  ppPrec p x =
+    case x of
+      DocForMod m -> ppPrec p m
+      DocForDef n -> ppPrec p n 
+
+
+gatherModuleDocstrings ::
+  Map Name (ImpName Name) ->
+  Module ->
+  [DocItem]
+gatherModuleDocstrings nameToModule m =
+  [DocItem
+    { docModContext = ImpTop (mName m)
+    , docFor = DocForMod (ImpTop (mName m))
+    , docText = mDoc m
+    }
+  ] ++
+  -- mParams m
+  -- mParamTypes m
+  -- mParamFuns m
+  [DocItem
+    { docModContext = lookupModuleName n
+    , docFor = DocForDef n
+    , docText = maybeToList (tsDoc t)
+    } | (n, t) <- Map.assocs (mTySyns m)] ++
+  [DocItem
+    { docModContext = lookupModuleName n
+    , docFor = DocForDef n
+    , docText = maybeToList (ntDoc t)
+    } | (n, t) <- Map.assocs (mNominalTypes m)] ++
+  [DocItem
+    { docModContext = lookupModuleName (dName d)
+    , docFor = DocForDef (dName d)
+    , docText = maybeToList (dDoc d <> exhaustBoolProp d)
+    } | g <- mDecls m, d <- groupDecls g] ++
+  [DocItem
+    { docModContext = ImpNested n
+    , docFor = DocForMod (ImpNested n)
+    , docText = ifsDoc (smIface s)
+    } | (n, s) <- Map.assocs (mSubmodules m)] ++
+  [DocItem
+    { docModContext = ImpTop (mName m)
+    , docFor = DocForMod (ImpNested n)
+    , docText = maybeToList (mpnDoc s)
+    } | (n, s) <- Map.assocs (mSignatures m)]
+  where
+    lookupModuleName n =
+      case Map.lookup n nameToModule of
+        Just x -> x
+        Nothing -> panic "gatherModuleDocstrings" ["No owning module for name:", show (pp n)]
+
+    exhaustBoolProp d =
+      if (null . extractCodeBlocks . fromMaybe "" . dDoc) d &&
+         (tIsBit . sType . dSignature) d &&
+         PragmaProperty `elem` dPragmas d
+      then Just $ "```\n" <> ":exhaust " <> (identText . nameIdent) (dName d) <> " // implicit" <> "\n```"
+      else Nothing
+
+-- | Extract the code blocks from the body of a docstring.
+--
+-- A single code block starts with at least 3 backticks followed by an
+-- optional language specifier of \"cryptol\". This allows other kinds
+-- of code blocks to be included (and ignored) in docstrings. Longer
+-- backtick sequences can be used when a code block needs to be able to
+-- contain backtick sequences.
+--
+-- @
+-- /**
+--  * A docstring example
+--  *
+--  * ```cryptol
+--  * :check example
+--  * ```
+--  */
+-- @
+extractCodeBlocks :: Text -> [[Text]]
+extractCodeBlocks raw = go [] (T.lines raw)
+  where
+    go finished [] = reverse finished
+    go finished (x:xs)
+      | (spaces, x1) <- T.span (' ' ==) x
+      , (ticks, x2) <- T.span ('`' ==) x1
+      , 3 <= T.length ticks
+      , not (T.elem '`' x2)
+      , let info = T.strip x2
+      = if info `elem` ["", "repl"] -- supported languages "unlabeled" and repl
+        then keep finished (T.length spaces) (T.length ticks) [] xs
+        else skip finished ticks xs
+      | otherwise = go finished xs
+
+    -- process a code block that we're keeping
+    keep finished _ _ acc [] = go (reverse acc : finished) [] -- unterminated code fences are defined to be terminated by github
+    keep finished indentLen ticksLen acc (x:xs)
+      | x1 <- T.dropWhile (' ' ==) x
+      , (ticks, x2) <- T.span ('`' ==) x1
+      , ticksLen <= T.length ticks
+      , T.all (' ' ==) x2
+      = go (reverse acc : finished) xs
+
+      | otherwise =
+        let x' =
+              case T.span (' ' ==) x of
+                (spaces, x1)
+                  | T.length spaces <= indentLen -> x1
+                  | otherwise -> T.drop indentLen x
+        in keep finished indentLen ticksLen (x' : acc) xs
+
+    -- process a code block that we're skipping
+    skip finished _ [] = go finished []
+    skip finished close (x:xs)
+      | close == x = go finished xs
+      | otherwise = skip finished close xs
+

--- a/tests/docstrings/T05.icry.stdout
+++ b/tests/docstrings/T05.icry.stdout
@@ -12,4 +12,8 @@ Checking module T05
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
-Successes: 2, No fences: 1, Failures: 0
+    :exhaust p
+      Using exhaustive testing.
+      Testing... Passed 1 tests.
+      Q.E.D.
+Successes: 3, No fences: 1, Failures: 0

--- a/tests/docstrings/T05.icry.stdout
+++ b/tests/docstrings/T05.icry.stdout
@@ -12,8 +12,4 @@ Checking module T05
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
-    :exhaust p // implicit
-      Using exhaustive testing.
-      Testing... Passed 1 tests.
-      Q.E.D.
-Successes: 3, No fences: 1, Failures: 0
+Successes: 2, No fences: 1, Failures: 0

--- a/tests/docstrings/T05.icry.stdout
+++ b/tests/docstrings/T05.icry.stdout
@@ -12,7 +12,7 @@ Checking module T05
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
-    :exhaust p
+    :exhaust p // implicit
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.

--- a/tests/docstrings/T10.icry.stdout
+++ b/tests/docstrings/T10.icry.stdout
@@ -22,27 +22,27 @@ Checking module T10
   Docstrings on T10::where_at__30_11::N
   Docstrings on T10::F1::N
   Docstrings on T10::M::q
-    :exhaust q
+    :exhaust q // implicit
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
   Docstrings on T10::M::r
-    :exhaust r
+    :exhaust r // implicit
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
   Docstrings on T10::F1::s
-    :exhaust s
+    :exhaust s // implicit
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
   Docstrings on T10::F1::t
-    :exhaust t
+    :exhaust t // implicit
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.
   Docstrings on T10::p
-    :exhaust p
+    :exhaust p // implicit
       Using exhaustive testing.
       Testing... Passed 1 tests.
       Q.E.D.

--- a/tests/docstrings/T10.icry.stdout
+++ b/tests/docstrings/T10.icry.stdout
@@ -22,12 +22,32 @@ Checking module T10
   Docstrings on T10::where_at__30_11::N
   Docstrings on T10::F1::N
   Docstrings on T10::M::q
+    :exhaust q
+      Using exhaustive testing.
+      Testing... Passed 1 tests.
+      Q.E.D.
   Docstrings on T10::M::r
+    :exhaust r
+      Using exhaustive testing.
+      Testing... Passed 1 tests.
+      Q.E.D.
   Docstrings on T10::F1::s
+    :exhaust s
+      Using exhaustive testing.
+      Testing... Passed 1 tests.
+      Q.E.D.
   Docstrings on T10::F1::t
+    :exhaust t
+      Using exhaustive testing.
+      Testing... Passed 1 tests.
+      Q.E.D.
   Docstrings on T10::p
+    :exhaust p
+      Using exhaustive testing.
+      Testing... Passed 1 tests.
+      Q.E.D.
   Docstrings on submodule T10::M
   Docstrings on submodule T10::where_at__30_11
   Docstrings on submodule T10::F1
   Docstrings on submodule T10::F__parameter
-Successes: 1, No fences: 11, Failures: 0
+Successes: 6, No fences: 6, Failures: 0


### PR DESCRIPTION
Closes #1842.

This works by adding `Text` of the form:

````md
```
:exhaust p
```
````

To the list of docstrings extracted from a module's `Decl`s, when `p` is a `Bit`-typed declaration that has the `property` `Pragma`.

I wasn't set up to run every test in the regression suite (particularly those requiring CVC4/CVC5/Bitwuzla/Yices); I've marked this as a draft for now, and will use CI to determine which (if any) additional golden/`.stdout` files I need to update.
