### PR TITLE
Add `--version`/`-v` option to `cryptol-remote-api` and `cryptol-eval-server`

### DIFF
--- a/cryptol-remote-api/CHANGELOG.md
+++ b/cryptol-remote-api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next -- TBA
 
-Nothing yet.
+* Add a `--version`/`-v` command-line option.
 
 ## 3.3.0 -- 2025-03-21
 

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -105,7 +105,14 @@ executable cryptol-remote-api
 
   build-depends:
     cryptol-remote-api,
+    optparse-applicative,
     sbv
+
+  other-modules:
+    Paths_cryptol_remote_api
+
+  autogen-modules:
+    Paths_cryptol_remote_api
 
   if os(linux) && flag(static)
       ld-options:      -static -pthread
@@ -123,6 +130,12 @@ executable cryptol-eval-server
     cryptol-remote-api,
     optparse-applicative,
     sbv
+
+  other-modules:
+    Paths_cryptol_remote_api
+
+  autogen-modules:
+    Paths_cryptol_remote_api
 
   if os(linux) && flag(static)
       ld-options:      -static -pthread

--- a/cryptol-remote-api/cryptol-remote-api/Main.hs
+++ b/cryptol-remote-api/cryptol-remote-api/Main.hs
@@ -4,11 +4,15 @@
 {-# LANGUAGE TypeApplications #-}
 module Main (main) where
 
+import Data.List (intercalate)
+import Data.Version (showVersion)
+import Options.Applicative
+    ( Parser, help, hidden, infoOption, long, short )
 import System.Environment (lookupEnv)
 import System.FilePath (splitSearchPath)
 
 import Argo (AppMethod, mkApp, defaultAppOpts, StateMutability( PureState ))
-import Argo.DefaultMain (defaultMain)
+import Argo.DefaultMain (customMain, parseNoOpts)
 import qualified Argo.Doc as Doc
 
 
@@ -40,6 +44,8 @@ import CryptolServer.Version ( version, versionDescr )
 import CryptolServer.FileDeps( fileDeps, fileDepsDescr )
 import Cryptol.REPL.Command (CommandResult, DocstringResult)
 import Cryptol.Project (ScanStatus, LoadProjectMode)
+import Cryptol.Version (displayVersionStr)
+import qualified Paths_cryptol_remote_api as RPC
 
 main :: IO ()
 main =
@@ -51,7 +57,32 @@ main =
                  (defaultAppOpts PureState)
                  (const (pure initSt))
                  cryptolMethods
-     defaultMain description theApp
+     customMain
+       parseNoOpts
+       parseNoOpts
+       parseNoOpts
+       parseNoOpts
+       versionParser
+       description
+       (const (pure theApp))
+
+-- | Display the version number when the @--version@/@-v@ option is supplied.
+versionParser :: Parser (a -> a)
+versionParser =
+  infoOption versionStr $
+  mconcat
+    [ long "version"
+    , short 'v'
+    , help "Display version number"
+    , hidden
+    ]
+  where
+    versionStr :: String
+    versionStr =
+      intercalate "\n"
+        [ "Cryptol RPC server " ++ showVersion RPC.version
+        , displayVersionStr
+        ]
 
 serverDocs :: [Doc.Block]
 serverDocs =

--- a/src/Cryptol/Version.hs
+++ b/src/Cryptol/Version.hs
@@ -16,12 +16,15 @@ module Cryptol.Version (
   , ffiEnabled
   , version
   , displayVersion
+  , displayVersionStr
   ) where
 
 import Paths_cryptol
 import qualified GitRev
+import Data.List (intercalate)
 import Data.Version (showVersion)
 import Control.Monad (when)
+import Control.Monad.Writer (MonadWriter(..), Writer, execWriter)
 
 commitHash :: String
 commitHash = GitRev.hash
@@ -52,3 +55,11 @@ displayVersion putLn = do
       where
       dirtyLab | commitDirty = " (non-committed files present during build)"
                | otherwise   = ""
+
+-- | A pure version of 'displayVersion' that renders the displayed version
+-- directly to a 'String'.
+displayVersionStr :: String
+displayVersionStr = intercalate "\n" $ execWriter $ displayVersion putLn
+  where
+    putLn :: String -> Writer [String] ()
+    putLn str = tell [str]


### PR DESCRIPTION
This bumps the `argo` submodule to bring in the changes from https://github.com/GaloisInc/argo/pull/220 and uses them to define `--version`/`-v` command-line options for the `cryptol-remote-api` and `cryptol-eval-server` executables, which behave much like they do in the `cryptol` executable.

Fixes #1815.