### PR TITLE
Dockerfile: Pass `--env-ext=.env` to `test-runner`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN cabal v2-update && \
     cabal v2-build -j cryptol:exe:cryptol && \
     cp $(cabal v2-exec which cryptol) rootfs/usr/local/bin && \
     cabal v2-install --install-method=copy --overwrite-policy=always --installdir=bin test-lib
-RUN ./bin/test-runner --ext=.icry --exe=./rootfs/usr/local/bin/cryptol -F -b tests
+RUN ./bin/test-runner --ext=.icry --env-ext=.env --exe=./rootfs/usr/local/bin/cryptol -F -b tests
 ENV PATH=/usr/local/bin:/cryptol/rootfs/usr/local/bin:$PATH
 RUN    ! $(cryptol -c ":s prover=yices" | tail -n +2 | grep -q .) \
     #    && ! $(cryptol -c ":s prover=mathsat" | tail -n +2 | grep -q .) \


### PR DESCRIPTION
Fixes #1849 (for good this time).