### PR TITLE
Draft: Fix browsing of anonymous / implicit `Main` modules

### DIFF
--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -1447,6 +1447,10 @@ browseCmd input
       Nothing -> do
         rPutStrLn "Invalid module name"
         pure emptyCommandResult { crSuccess = False }
+      Just (P.ImpTop mn) | M.modNameToText mn == "Main" -> do
+        mainContexts <- M.mainContexts <$> getModuleEnv
+        mapM_ (rPrint . browseModContext BrowseExported) mainContexts
+        pure emptyCommandResult
       Just pimpName -> do
         impName <- liftModuleCmd (`M.runModuleM` M.renameImpNameInCurrentEnv pimpName)
         mb <- M.modContextOf impName <$> getModuleEnv


### PR DESCRIPTION
Apologies for the long delay on this. 

This is ~95% of the way there; these changes successfully avoid the error condition encountered previously, _but_ the output of `:browse` appears to be completely empty (i.e. with the `Test.cry` example in #1843, the symbol `f` doesn't show up when you `:browse Main`).

I'm not entirely sure what's going wrong; if someone could take a look and see where/how I am doing something silly, that would be appreciated!