### PR TITLE
More improvements to Rust `cry-ffi` crate

### DIFF
--- a/rust/cry-ffi/Cargo.toml
+++ b/rust/cry-ffi/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/example.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-num = "0.4.0"
+num = { version = "0.4.0", default-features = false, features = ["alloc"] }

--- a/rust/cry-ffi/src/lib.rs
+++ b/rust/cry-ffi/src/lib.rs
@@ -95,9 +95,15 @@
 //! arguments, or exporting/importing different types), all of which could lead
 //! to undefined behavior.
 
-use std::ffi::*;
-use std::mem::{self, MaybeUninit};
-use std::slice::from_raw_parts_mut;
+#![cfg_attr(not(test), no_std)]
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::slice::from_raw_parts_mut;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ffi::*;
+use core::mem::{self, MaybeUninit};
 use num::{BigInt, BigRational, BigUint, ToPrimitive};
 use num::bigint::{Sign, ToBigInt};
 


### PR DESCRIPTION
* Remove an unnecessary `license-files` stanza in the `Cargo.toml` file.
* Add a missing exclamation mark in the top-level docstring in `src/lib.rs`.
* Allow building with `no_std`.