### PR TITLE
`CryptolTC.z3`: Use SMT-LIB 2.6 syntax for `declare-datatypes`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@
   section](https://galoisinc.github.io/cryptol/master/FFI.html#the-abstract-calling-convention)
   for more information.
 
+## Bug fixes
+
+* Allow changing the `tcSolver` setting to non-Z3 solvers (e.g., CVC5) without
+  crashing. ([#1874](https://github.com/GaloisInc/cryptol/issues/1874))
+
 ## New Features
 
 * New REPL command `:saw` to run SAW on a SAW file, usable in docstrings.

--- a/lib/CryptolTC.z3
+++ b/lib/CryptolTC.z3
@@ -1,13 +1,13 @@
 ; ------------------------------------------------------------------------------
 ; Basic datatypes
 
-(declare-datatypes ()
-  ( (InfNat (mk-infnat (value Int) (isFin Bool) (isErr Bool)))
+(declare-datatypes ((InfNat 0))
+  ( ((mk-infnat (value Int) (isFin Bool) (isErr Bool)))
   )
 )
 
-(declare-datatypes ()
-  ( (MaybeBool (mk-mb (prop Bool) (isErrorProp Bool)))
+(declare-datatypes ((MaybeBool 0))
+  ( ((mk-mb (prop Bool) (isErrorProp Bool)))
   )
 )
 

--- a/src/Cryptol/TypeCheck/Solver/SMT.hs
+++ b/src/Cryptol/TypeCheck/Solver/SMT.hs
@@ -76,6 +76,7 @@ data Solver = Solver
 setupSolver :: Solver -> SolverConfig -> IO ()
 setupSolver s cfg = do
   _ <- SMT.setOptionMaybe (solver s) ":global-decls" "false"
+  SMT.setLogic (solver s) "ALL"
   loadTcPrelude s (solverPreludePath cfg)
 
 -- | Start a fresh solver instance

--- a/tests/issues/issue1874.icry
+++ b/tests/issues/issue1874.icry
@@ -1,0 +1,5 @@
+// A regression test for #1874. This ensures that we can change tcSolver to a
+// non-Z3 solver (e.g., CVC5) and still handle the basics of Cryptol's
+// typechecking.
+:set tcSolver = cvc5 --lang smt2 --incremental
+let f (x : [8]) = x # [True]

--- a/tests/issues/issue1874.icry.stdout
+++ b/tests/issues/issue1874.icry.stdout
@@ -1,0 +1,1 @@
+Loading module Cryptol


### PR DESCRIPTION
Previously, `CryptolTC.z3` was using a Z3-specific syntax for the
`declare-datatypes` command that differs from the syntax prescribed by SMT-LIB
2.6. This meant that non-Z3 solvers (e.g., CVC5) could not parse the datatypes
declared in the file.

Thankfully, Z3 4.8.8 or later accept both `declare-datatypes` syntaxes. To
allow for non-Z3 solvers to be used, I have switched `CryptolTC.z3` over to the
SMT-LIB syntax. This suffices to allow alternative solvers like CVC5 to be used
as the `tcSolver`, as demonstrated in the newly added `issue1874.icry` test
case.

Fixes https://github.com/GaloisInc/cryptol/issues/1874.