### PR TITLE
Allow `;` between case branches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
   section](https://galoisinc.github.io/cryptol/master/FFI.html#the-abstract-calling-convention)
   for more information.
 
+* Allow an explicit `;` separator between `case` branches. This change removes the
+  unreachable code in the grammar for `case` and `where` expressions with explicit
+  `{` and `}` that was never reachable due to the way the layout rule worked.
+
 ## Bug fixes
 
 * Allow changing the `tcSolver` setting to non-Z3 solvers (e.g., CVC5) without

--- a/src/Cryptol/Parser/Layout.hs
+++ b/src/Cryptol/Parser/Layout.hs
@@ -93,7 +93,7 @@ layout isMod ts0
        noVirtSep:
           Do not emit a virtual separator even if token matches block alignment.
           This is enabled at the beginning of a block, or after a doc string,
-          or if we just emitted a separtor, but have not yet consumed the
+          or if we just emitted a separator, but have not yet consumed the
           next token.
 
        tokens:

--- a/tests/enum/BasicEnums.cry
+++ b/tests/enum/BasicEnums.cry
@@ -1,5 +1,5 @@
 
-/** Custom docs fo E1 */
+/** Custom docs for E1 */
 enum E1  = A | B | C
 enum M a = N | J a
 enum N n a =
@@ -22,6 +22,8 @@ c2 e =
     X a -> a
     Y b -> zero # b
     Z a -> a
+
+c3 e = case e of A -> 1 : [8]; B -> 2; C -> 3
 
 // Construction
 

--- a/tests/enum/BasicEnums.icry
+++ b/tests/enum/BasicEnums.icry
@@ -2,6 +2,8 @@
 :help E1
 :help X
 :t c1
+:t c2
+:t c3
 :t e1
 :t e2
 e1

--- a/tests/enum/BasicEnums.icry.stdout
+++ b/tests/enum/BasicEnums.icry.stdout
@@ -6,7 +6,7 @@ enum E1: *
 
     Constructors: A, B, C
 
-Custom docs fo E1
+Custom docs for E1
 
 
 Constructor of N
@@ -15,6 +15,8 @@ Constructor of N
 Note that we allow a starting |
 
 c1 : E1 -> [8]
+c2 : {n} (n >= 2) => N n [n] -> [n]
+c3 : E1 -> [8]
 e1 : {a} M a
 e2 : {n, a} (n - 2 >= 2, n >= 2, fin n) => N n a
 Showing a specific instance of polymorphic result:


### PR DESCRIPTION
This change removes an unnecessary shift/reduce error in the parser and removes previously unreachable grammar productions.