### PR TITLE
Fix `Exportable` for `Vec<T>`

### DIFF
--- a/rust/cry-ffi/src/lib.rs
+++ b/rust/cry-ffi/src/lib.rs
@@ -734,13 +734,11 @@ impl <T: Exportable> Exportable for Vec<T> {
     fn recv_with(params: Self::Parameters, args: &CryValExporter) -> Self {
         let (Len(len), t_params) = params;
         let mut vec: Vec<T> = Vec::with_capacity(len);
-        let remaining = vec.spare_capacity_mut();
 
-        for elem in remaining.iter_mut() {
-            elem.write(T::recv_with(t_params.clone(), args));
+        for _ in 0..len {
+            vec.push(T::recv_with(t_params.clone(), args));
         }
 
-        unsafe { vec.set_len(len); }
         vec
     }
 }

--- a/rust/cry-ffi/src/lib.rs
+++ b/rust/cry-ffi/src/lib.rs
@@ -740,6 +740,7 @@ impl <T: Exportable> Exportable for Vec<T> {
             elem.write(T::recv_with(t_params.clone(), args));
         }
 
+        unsafe { vec.set_len(len); }
         vec
     }
 }


### PR DESCRIPTION
The rust FFI doesn't correctly call `set_len` after initializing a `Vec` in `Exportable` - this small change fixes this behavior