### PR TITLE
Get library building with FFI disabled

### DIFF
--- a/src/Cryptol/Eval/FFI.hs
+++ b/src/Cryptol/Eval/FFI.hs
@@ -10,11 +10,17 @@ module Cryptol.Eval.FFI
   ) where
 
 import Cryptol.Eval.FFI.ForeignSrc
-    ( ForeignSrc, ForeignImpl, loadForeignImpl )
+    ( ForeignSrc)
+#ifdef FFI_ENABLED
+import Cryptol.Eval.FFI.ForeignSrc
+    (ForeignImpl, loadForeignImpl )
+#else
+import Cryptol.Parser.AST (ForeignMode)
+#endif
 import Cryptol.Eval.FFI.Error ( FFILoadError )
-import Cryptol.Eval ( EvalEnv )
+import Cryptol.Eval (Eval, EvalEnv )
 import Cryptol.TypeCheck.AST
-    ( FFI(..), TVar(TVBound), findForeignDecls )
+    ( Name, FFI(..), TVar(TVBound), findForeignDecls )
 import Cryptol.TypeCheck.FFI.FFIType ( FFIFunType(..) )
 
 #ifdef FFI_ENABLED
@@ -80,7 +86,7 @@ foreignPrim ft k = buildNumPoly (ffiTParams ft) mempty
 
 -- | Dummy implementation for when FFI is disabled. Does not add anything to
 -- the environment or report any errors.
-evalForeignDecls :: ForeignSrc -> [(Name, ForeignMode, FFIFunType)] -> EvalEnv ->
+evalForeignDecls :: ForeignSrc -> [(Name, FFI)] -> EvalEnv ->
   Eval ([FFILoadError], EvalEnv)
 evalForeignDecls _ _ env = pure ([], env)
 

--- a/src/Cryptol/Eval/FFI/Abstract.hs
+++ b/src/Cryptol/Eval/FFI/Abstract.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE CPP #-}
 -- | How to call foreign function, following the "abstract" calling convention
 module Cryptol.Eval.FFI.Abstract where
+
+#ifdef FFI_ENABLED
 
 import Cryptol.Utils.Panic(panic)
 import Cryptol.ModuleSystem.Name(Name)
@@ -37,5 +40,4 @@ callForeignAbstract nm ty impl tenv args =
    where
    evalFinType = finNat' . evalNumType tenv . TVar . TVBound
 
-
- 
+#endif

--- a/src/Cryptol/Eval/FFI/Abstract/Call.hsc
+++ b/src/Cryptol/Eval/FFI/Abstract/Call.hsc
@@ -81,6 +81,11 @@ runFFI args ty k =
 
 #else
 
+import Cryptol.Eval.FFI.Abstract.Export (ExportVal)
+import Cryptol.Eval.FFI.Abstract.Import (Value, ImportErrorMessage(..))
+import Cryptol.Eval.Type (TValue)
+import Foreign.Ptr (Ptr)
+
 runFFI ::
   [ExportVal] ->
   TValue ->

--- a/src/Cryptol/Eval/FFI/C.hs
+++ b/src/Cryptol/Eval/FFI/C.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -8,6 +9,9 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE ViewPatterns        #-}
 -- | How to call foreign functions following the C-style calling convention.
+
+#ifdef FFI_ENABLED
+
 module Cryptol.Eval.FFI.C (callForeignC) where
 import           Cryptol.Eval.FFI.ForeignSrc
 
@@ -375,3 +379,7 @@ getMarshalBasicRefArg (FFIInteger _) f = f \val g ->
 getMarshalBasicRefArg FFIRational f = f \val g -> do
   let SRational {..} = fromVRational val
   withInRational' (sNum % sDenom) g
+
+#else
+module Cryptol.Eval.FFI.C where
+#endif


### PR DESCRIPTION
Being able to turn off the FFI is super-handy for being able to load cryptol in ghci and Haskell-language-server.

Obviously it should build with the feature turned off (if we're going to keep the feature). We might want an additional feature that *specifically* disabled the foreign exports just for when we're developing anything that's not the FFI itself.

This PR just gets things building again. We might want to solve some of the problems differently than implemented here.