### PR TITLE
Fix conversion from values back to expressions

### DIFF
--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -119,11 +119,11 @@ toExpr prims t0 v0 = findOne (go t0 v0)
            ETuple <$> (zipWithM go ts =<< lift (sequence tvs))
       (TVBit, VBit b) ->
         pure (prim (if b then "True" else "False"))
-      (TVInteger, VInteger i) -> pure (numlit i tInteger)
+      (TVInteger, VInteger i) -> pure (intlit i)
       (TVIntMod n, VInteger i) -> pure (numlit i (tIntMod (tNum n)))
       (TVRational, VRational (SRational n d)) ->
-        do let n' = numlit n tInteger
-           let d' = numlit d tInteger
+        do let n' = intlit n
+           let d' = intlit d
            pure $ EApp (EApp (prim "ratio") n') d'
 
       (TVFloat e p, VFloat i) ->
@@ -141,8 +141,14 @@ toExpr prims t0 v0 = findOne (go t0 v0)
       (_,VNumPoly{}) -> mzero
       _ -> mismatch
     where
+      intlit n
+        | n < 0 = EApp (EProofApp (ETApp (prim "negate") tInteger))
+                       (numlit (-n) tInteger)
+        | otherwise = numlit n tInteger
+
       numlit i t =
         EProofApp (ETApp (ETApp (prim "number") (tNum (i::Integer))) t)
+
 
       mismatch :: forall a. ChoiceT Eval a
       mismatch =

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -133,7 +133,7 @@ toExpr prims t0 v0 = findOne (go t0 v0)
            pure $ EList ses (tValTy b)
       (TVSeq n TVBit, VWord wval) ->
         do BV _ v <- lift (asWordVal Concrete wval)
-           pure $ ETApp (ETApp (prim "number") (tNum v)) (tWord (tNum n))
+           pure (numlit v (tWord (tNum n)))
 
       (_,VStream{})  -> mzero
       (_,VFun{})     -> mzero
@@ -141,11 +141,13 @@ toExpr prims t0 v0 = findOne (go t0 v0)
       (_,VNumPoly{}) -> mzero
       _ -> mismatch
     where
+      -- Make a literal of type Integer
       intlit n
         | n < 0 = EApp (EProofApp (ETApp (prim "negate") tInteger))
                        (numlit (-n) tInteger)
         | otherwise = numlit n tInteger
 
+      -- Make a non-negative literal of the given type
       numlit i t =
         EProofApp (ETApp (ETApp (prim "number") (tNum (i::Integer))) t)
 


### PR DESCRIPTION
Fixes #1891

We were missing a `EProofApp` constructor when making numeric literals