### PR TITLE
Make validation commands use the currently focused module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## Language changes
 
+* When running validation commands (`:check`, `:prove`, `:exhaust`, etc)
+  without an explicit argument, we now run only the properties in the
+  currently *focused module*.  This is a change in behavior, because previously
+  we used to run all properties in the currently opened *file*.  This change
+  is only noticable when working with nested modules.  The new behavior works
+  better when these commands are used from docstrings (e.g., with the
+  new behavior, writing `:check` on a submodule, will only check the properties
+  in that submodule, as expected).  
+
 * When running the `:check-docstrings` command, `Bit` properties (e.g. `property
   p = True`) will be checked with `:exhaust`, unless their docstrings contain
   code blocks understood by `:check-docstrings`.
@@ -26,6 +35,10 @@
   call out to an external solver. Use `:set prover = w4-rme` to enable it.
 
 ## Bug fixes
+
+* Fix a discrepency between the behavior of `check-docstrings` when run
+  on the REPL vs. when run with a project.
+  ([#1903](https://github.com/GaloisInc/cryptol/issues/1903))
 
 * Fix #1696, which corrected an incorrect simplification rule, leading to
   panics.

--- a/cryptol-remote-api/cryptol-eval-server/Main.hs
+++ b/cryptol-remote-api/cryptol-eval-server/Main.hs
@@ -24,7 +24,7 @@ import Options.Applicative
       value )
 
 import CryptolServer.Check ( check, checkDescr )
-import CryptolServer.CheckDocstrings ( checkDocstrings, checkDocstringsDescr )
+import CryptolServer.CheckDocstrings ( checkDocstringsAPI, checkDocstringsDescr )
 import CryptolServer.ClearState
     ( clearState, clearStateDescr, clearAllStates, clearAllStatesDescr)
 import Cryptol.Eval (EvalOpts(..), defaultPPOpts)
@@ -214,7 +214,7 @@ cryptolEvalMethods =
   , command
      "check docstrings"
      checkDocstringsDescr
-     checkDocstrings
+     checkDocstringsAPI
   , notification
      "interrupt"
      interruptServerDescr

--- a/cryptol-remote-api/cryptol-remote-api/Main.hs
+++ b/cryptol-remote-api/cryptol-remote-api/Main.hs
@@ -20,7 +20,7 @@ import CryptolServer
     ( command, notification, initialState, extendSearchPath, ServerState )
 import CryptolServer.Call ( call, callDescr )
 import CryptolServer.Check ( check, checkDescr )
-import CryptolServer.CheckDocstrings ( checkDocstrings, checkDocstringsDescr )
+import CryptolServer.CheckDocstrings ( checkDocstringsAPI, checkDocstringsDescr )
 import CryptolServer.ClearState
     ( clearState, clearStateDescr, clearAllStates, clearAllStatesDescr )
 import CryptolServer.Data.Expression ( Expression )
@@ -176,7 +176,7 @@ cryptolMethods =
   , command
      "check docstrings"
      checkDocstringsDescr
-     checkDocstrings
+     checkDocstringsAPI
   , command
      "load project"
      loadProjectDescr

--- a/cryptol-remote-api/src/CryptolServer/CheckDocstrings.hs
+++ b/cryptol-remote-api/src/CryptolServer/CheckDocstrings.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE InstanceSigs #-}
 module CryptolServer.CheckDocstrings
-  ( checkDocstrings
+  ( checkDocstringsAPI
   , checkDocstringsDescr
   , CheckDocstringsParams(..)
   , CheckDocstringsResult(..)
@@ -39,8 +39,8 @@ checkDocstringsDescr =
   Doc.Paragraph
     [ Doc.Text "Check docstrings" ]
 
-checkDocstrings :: CheckDocstringsParams -> CryptolCommand CheckDocstringsResult
-checkDocstrings (CheckDocstringsParams cache) = do
+checkDocstringsAPI :: CheckDocstringsParams -> CryptolCommand CheckDocstringsResult
+checkDocstringsAPI (CheckDocstringsParams cache) = do
   env <- getModuleEnv
   ln <- case M.meFocusedModule env of
           Just (ImpTop n) -> pure n

--- a/src/Cryptol/REPL/Command.hs
+++ b/src/Cryptol/REPL/Command.hs
@@ -520,7 +520,7 @@ qcCmd qcMode "" _pos _fnm =
      let nameStr x = show (fixNameDisp disp (pp x))
      if null xs
         then do
-          rPutStrLn "There are no properties in scope."
+          rPutStrLn "There are no properties in this module."
           pure emptyCommandResult { crSuccess = False }
         else do
           let evalProp result (x,d) =
@@ -843,7 +843,7 @@ cmdProveSat isSat "" _pos _fnm =
      let nameStr x = show (fixNameDisp disp (pp x))
      if null xs
         then do
-          rPutStrLn "There are no properties in scope."
+          rPutStrLn "There are no properties in this module."
           pure emptyCommandResult { crSuccess = False }
         else do
           let check acc (x,d) = do

--- a/src/Cryptol/REPL/Monad.hs
+++ b/src/Cryptol/REPL/Monad.hs
@@ -649,29 +649,44 @@ getTypeNames  =
      return (map (show . pp) (Map.keys (M.namespaceMap M.NSType fNames)))
 
 -- | Return a list of property names, sorted by position in the file.
--- Only properties defined in the current module are returned, including
--- private properties in the current module. Imported properties are not
--- returned.
+-- Only properties defined in the currently focused module are returned,
+-- (including private properties).  Other properties that are in scope
+-- are not returned.
 getPropertyNames :: REPL ([(M.Name, T.Decl)], NameDisp)
 getPropertyNames =
  do fe <- getFocusedEnv
     let nd = M.mctxNameDisp fe
-    mblm <- fmap (lName =<<) getLoadedMod
-    case mblm of
+    mbFocused <- M.meFocusedModule <$> getModuleEnv
+    case mbFocused of
       Nothing -> pure ([], nd)
-      Just mn ->
-       do mb <- M.lookupModule mn <$> getModuleEnv
+      Just focusMod ->
+        do 
+          mb <- M.lookupModule modName <$> getModuleEnv
           case mb of
             Nothing -> pure ([], nd)
             Just lm -> pure (ps, nd)
               where
                 ps =
                   sortBy (comparing (from . M.nameLoc . fst))
-                    [ (T.dName d,d)
+                    [ (nm,d)
                     | d <- T.groupDecls =<< T.mDecls (M.lmdModule (M.lmData lm))
+                    , let nm = T.dName d
+                    , consider nm
                     , T.PragmaProperty `elem` T.dPragmas d
                     ]
-
+        where
+        (modName,consider) =
+          case focusMod of
+             P.ImpTop mn -> (mn, const True)
+             P.ImpNested m ->
+              ( M.nameTopModule m,
+                \d ->
+                  case I.modPathCommon mp (M.nameModPath d) of
+                    Just (_, [], _ : _) -> True
+                    _ -> False
+              )
+              where mp = M.nameModPath m
+              
 
 getModNames :: REPL [I.ModName]
 getModNames =


### PR DESCRIPTION
Fixes #1903

This is a change from the previous behavior where we use the "loaded module" from the REPL monad to determine what properties to check.  The effect is proper support for submodules.   With the new change, running `:check` with a focused submodule (or when using a docstring) should only check the things in that module, while previously it would check the whole file.

This also fixes #1903, because loading a project does not set the "loaded module" in the REPL, which lead to confusing differences between docstring validation from the REPL vs with a project.

