### PR TITLE
Suppress extraneous output when running Cabal from scripts.

### DIFF
--- a/cry
+++ b/cry
@@ -37,7 +37,7 @@ COMMAND=$1
 shift
 
 case $COMMAND in
-  run) cabal v2-exec cryptol -- $* ;;
+  run) cabal -v0 v2-exec cryptol -- $* ;;
 
   build)
     echo Building Cryptol

--- a/cryptol-remote-api/check_docs.sh
+++ b/cryptol-remote-api/check_docs.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $DIR/docs
 
-export CRYPTOL_SERVER=$(cabal v2-exec which cryptol-remote-api)
+export CRYPTOL_SERVER=$(cabal v2-exec -v0 -- which cryptol-remote-api)
 if [[ ! -x "$CRYPTOL_SERVER" ]]; then
   echo "could not locate cryptol-remote-api executable - try executing with cabal v2-exec"
   echo "or try building with 'cabal build cryptol-remote-api'"


### PR DESCRIPTION
This pull request adds some tweaks to the `cry` script, and a testing script in `cryptol-remote-api`, to suppress diagnostic messages when running Cabal, which, *i.a.*, allows running the CI experimentally on release candidates for Cryptol dependencies.