### PR TITLE
CI: Bump macOS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # - cryptol-remote-api/Dockerfile
   # - README.md
   # - dev/dev_setup.sh
-  SOLVER_PKG_VERSION: "snapshot-20250606"
+  SOLVER_PKG_VERSION: "snapshot-20251112"
   # The CACHE_VERSION can be updated to force the use of a new cache if
   # the current cache contents become corrupted/invalid.  This can
   # sometimes happen when (for example) the OS version is changed but
@@ -79,15 +79,15 @@ jobs:
             run-tests: false
           # Windows and macOS CI runners are more expensive than Linux runners,
           # so we only build one particular GHC version to test them on. We
-          # include both an x86-64 macOS runner (macos-13) as well as an AArch64
-          # macOS runner (macos-14).
+          # include both an x86-64 macOS runner (macos-15-intel) as well as an
+          # AArch64 macOS runner (macos-15).
           - os: windows-2022
             ghc-version: 9.4.8
             run-tests: true
-          - os: macos-13
+          - os: macos-15-intel
             ghc-version: 9.4.8
             run-tests: true
-          - os: macos-14
+          - os: macos-15
             ghc-version: 9.4.8
             run-tests: true
     outputs:
@@ -281,7 +281,7 @@ jobs:
       matrix:
         suite: [test-lib]
         target: ${{ fromJson(needs.build.outputs.test-lib-json) }}
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2022]
         continue-on-error: [false]
         include:
           - suite: api-tests
@@ -294,7 +294,7 @@ jobs:
             continue-on-error: false
           #- suite: rpc
           #  target: ''
-          #  os: macos-13
+          #  os: macos-15-intel
           #  continue-on-error: false
           #- suite: rpc
           #  target: ''

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250606/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20251112/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 WORKDIR /cryptol
 ENV PATH=/cryptol/rootfs/usr/local/bin:/home/cryptol/.local/bin:/home/cryptol/.ghcup/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cryptol currently uses Microsoft Research's [Z3 SMT
 solver](https://github.com/Z3Prover/z3) by default to solve constraints
 during type checking, and as the default solver for the `:sat` and
 `:prove` commands.  Cryptol generally requires the most recent version
-of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20250606).
+of Z3, but you can see the specific version tested in CI by looking [here](https://github.com/GaloisInc/what4-solvers/releases/tag/snapshot-20251112).
 
 You can download Z3 binaries for a variety of platforms from their
 [releases page](https://github.com/Z3Prover/z3/releases). If you
@@ -74,8 +74,7 @@ on [GitHub](https://github.com/GaloisInc/cryptol).
 Cryptol builds and runs on various flavors of Linux, Mac OS X, and
 Windows. We regularly build and test it in the following environments:
 
-- macOS 13 (x86-64)
-- macOS 14 (ARM64)
+- macOS 15 (ARM64 and x86-64)
 - Ubuntu 22.04 (x86-64)
 - Ubuntu 24.04 (x86-64)
 - Windows Server 2022 (x86-64)

--- a/cryptol-remote-api/Dockerfile
+++ b/cryptol-remote-api/Dockerfile
@@ -106,7 +106,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250606/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip" && \
+    curl -sL -o solvers.zip "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20251112/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip" && \
     unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /cryptol/rootfs

--- a/dev/dev_setup.sh
+++ b/dev/dev_setup.sh
@@ -37,7 +37,7 @@ GHCUP_URL="https://downloads.haskell.org/~ghcup"
 GHC_VERSION="9.4.8"
 CABAL_VERSION="3.10.3.0"
 
-WHAT4_SOLVERS_SNAPSHOT="snapshot-20250606"
+WHAT4_SOLVERS_SNAPSHOT="snapshot-20251112"
 WHAT4_SOLVERS_URL="https://github.com/GaloisInc/what4-solvers/releases/download/$WHAT4_SOLVERS_SNAPSHOT"
 WHAT4_SOLVERS_MACOS_13="macos-13-X64-bin.zip"
 WHAT4_SOLVERS_MACOS_14="macos-14-ARM64-bin.zip"


### PR DESCRIPTION
Bump the Intel build from `macos-13` to `macos-15-intel`, and bump the ARM64 build from `macos-14` to `macos-15`. This requires bumping the `what4-solvers` version to a new snapshot that supports these macOS versions.