### PR TITLE
Fix documentation typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
   without an explicit argument, we now run only the properties in the
   currently *focused module*.  This is a change in behavior, because previously
   we used to run all properties in the currently opened *file*.  This change
-  is only noticable when working with nested modules.  The new behavior works
+  is only noticeable when working with nested modules.  The new behavior works
   better when these commands are used from docstrings (e.g., with the
   new behavior, writing `:check` on a submodule, will only check the properties
   in that submodule, as expected).  
@@ -56,7 +56,7 @@
 
 ## Bug fixes
 
-* Fix a discrepency between the behavior of `:check-docstrings` when run
+* Fix a discrepancy between the behavior of `:check-docstrings` when run
   on the REPL vs. when run with a project.
   ([#1903](https://github.com/GaloisInc/cryptol/issues/1903))
 
@@ -309,7 +309,7 @@
 
 * Add `:new-seed` and `:set-seed` commands to the REPL.
   These affect random test generation,
-  and help write reproducable Cryptol scripts.
+  and help write reproducible Cryptol scripts.
 
 * Add support for the CVC5 solver, which can be selected with
   `:set prover=cvc5`. If you want to specify a What4 or SBV backend, you can
@@ -365,7 +365,7 @@
 * "Type mismatch" errors now show a context giving more information
   about the location of the error.   The context is shown when the
   part of the types match, but then some nested types do not.
-  For example, when mathching `{ a : [8], b : [8] }` with
+  For example, when matching `{ a : [8], b : [8] }` with
   `{ a : [8], b : [16] }` the error will be `8` does not match `16`
   and the context will be `{ b : [ERROR] _ }` indicating that the
   error is in the length of the sequence of field `b`.
@@ -477,7 +477,7 @@ parameters when pretty printing type signature (closes issue #1867).
 ## Language changes
 
 * The `newtype` construct, which has existed in the interpreter in an
-  incomplete and undocumented form for quite a while, is now fullly
+  incomplete and undocumented form for quite a while, is now fully
   supported. The construct is documented in section 1.22 of [Programming
   Cryptol](https://cryptol.net/files/ProgrammingCryptol.pdf). Note,
   however, that the `cryptol-remote-api` RPC server currently does not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ which is defined in the `/tests/` directory. It is invoked with the
 location of the `cryptol` executable, an output directory, and
 standard `test-framework` command line arguments.
 
-## Creaing a new test
+## Creating a new test
 
 A test consists at minimum of an `.icry` file, which is a batch-mode
 file for the interpreter, and an `.icry.stdout` file, which contains

--- a/ConditionalConstraints.md
+++ b/ConditionalConstraints.md
@@ -52,4 +52,4 @@ Decl
   }
 ```
 
-Each case of an `EPropGuards` is typechecked by first asssuming the `props` and then typechecking the expression. However, this typechecking isn't really that important because by construction the expression is just a simple application that is ensured to be well-typed. But we can use this structure for more general purposes.
+Each case of an `EPropGuards` is typechecked by first assuming the `props` and then typechecking the expression. However, this typechecking isn't really that important because by construction the expression is just a simple application that is ensured to be well-typed. But we can use this structure for more general purposes.

--- a/docs/AbstractValuesAndModuleParameters.md
+++ b/docs/AbstractValuesAndModuleParameters.md
@@ -10,7 +10,7 @@ We would like to extend Cryptol with two related, yet different features:
     mechanism to instantiate abstract values with concrete implamentations:
     this might be useful for testing abstract theories,
     implementing language primitives or, more generally, providing a
-    foregin function interface to Cryptol.
+    foreign function interface to Cryptol.
 
   2. The ability to parametrize modules by types and values.  This feature
     is similar to the first in that from the point of view of a module,
@@ -149,7 +149,7 @@ With this restriction, the rule is that two module instantiations are the
 same if they have the same parameters, where types are compared as usual,
 and values are compared by name.  Here are some examples:
 
-      moudle X where
+      module X where
       parameter
         type T : #
         val : [T]
@@ -162,17 +162,17 @@ and values are compared by name.  Here are some examples:
 In module `Examples` all instantiations of `X` are different because `val`
 uses different names.  In particular, `E2` and `E3` are different even though
 `val` is essentially given the same value.  Comparing names allows us to
-avoid having to evalute while checking, but more importantly it allows us
+avoid having to evaluate while checking, but more importantly it allows us
 to deal with parameters that are functions, which are can't be easily compared
 for equality.
 
 Naming Instantiations
 ---------------------
 
-If a module has quite a few paramters, it might be nice to allow to
+If a module has quite a few parameters, it might be nice to allow to
 name a specific instantiation which can then be used in many places.
 For example, we could have a module implementing some parametrized algorithm,
-but in a speicific application we would always use a specific instance of
+but in a specific application we would always use a specific instance of
 the algorithm.  One way to do this might be allow module like this:
 
     module SpecificAlg = GeneralAlg where
@@ -197,10 +197,10 @@ of `GeneralAlg`.  The declarations following the `where` keyword are
 similar to an ordinary module, but in this form they are just there
 to specify the instantiation of `GeneralAlg`.  In particular, the
 body should have a name in scope for each parameter of `GeneralAlg`.
-The body may contain other auxilliary declaratoins that are used
+The body may contain other auxiliary declaratoins that are used
 to define the instance but are not exported directly.
 
-XXX: Deisgn choice: we may want to insist that this kind of named instantiation
+XXX: Design choice: we may want to insist that this kind of named instantiation
 is the only way to instantiate modules.  If we do that, then the generativity
 issues from the previous section become less important: each named instance
 generates a fresh instance of everything, and one has to import the same module

--- a/docs/CryptolPrims.md
+++ b/docs/CryptolPrims.md
@@ -1,4 +1,4 @@
-Typeclass Heriarchy
+Typeclass Hierarchy
 ---------------------
 
           Zero

--- a/docs/ParameterizedModules/talk.md
+++ b/docs/ParameterizedModules/talk.md
@@ -1,5 +1,5 @@
 
-ML-Sytle Modules for Cryptol
+ML-Style Modules for Cryptol
 ----------------------------
 
 Iavor S. Diatchki
@@ -152,7 +152,7 @@ Note: `P` is *not* a normal name.
 Instantiation
 -------------
 
-Another way to introduce a module entitiy:
+Another way to introduce a module entity:
 ```cryptol
 module I where
 

--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -269,7 +269,7 @@ Local declarations have the weakest precedence of all expressions.
       where x = 2         // `x` is in scope in the whole `if`
 
     \y -> x + y
-      where x = 2         // `y` is not in scope in the defintion of `x`
+      where x = 2         // `y` is not in scope in the definition of `x`
 
 
 **Block Arguments**
@@ -523,7 +523,7 @@ to accommodate the value of the type:
     `t : {a} (Literal t a) => a
 
 This backtick notation is syntax sugar for an application of the
-`number` primtive, so the above may be written as:
+`number` primitive, so the above may be written as:
 
     number`{t} : {a} (Literal t a) => a
 

--- a/examples/MiniLock/File.md
+++ b/examples/MiniLock/File.md
@@ -26,7 +26,7 @@ The file format is:
 Variable sized formats are potentially awkward for Cryptol because Cryptol
 encodes the length of values in the type. For example, the header size varies
 in the JS implementation. Fortunately this variablity is all due to either the
-arbitrary choices of the encoder or things deterministicly dependent on the
+arbitrary choices of the encoder or things deterministically dependent on the
 input type (vs value).  For an example of the later case, the number of
 recipients leads to a variable header size that is computable from the input
 type. The former is a larger issue - for example a Base58 encoding of 0 could
@@ -45,7 +45,7 @@ The header format is:
 >     (One copy of the below object for every recipient)
 >     Unique nonce for decrypting this object (Base64): {
 >         senderID: Sender's miniLock ID (Base58),
->         recipientID: miniLock ID of this recipient (used for verfication) (Base58),
+>         recipientID: miniLock ID of this recipient (used for verification) (Base58),
 >         fileInfo: {
 >             fileKey: Key for file decryption (Base64),
 >             fileNonce: Nonce for file decryption (Base64),
@@ -55,7 +55,7 @@ The header format is:
 > }
 
 ```cryptol
-// Size of a given minilock container depends soley on the number of recipients and the plaintext
+// Size of a given minilock container depends solely on the number of recipients and the plaintext
 type MiniLockBytes nrRecip fileSize = 8 + 4 + 89 + (DecryptInfoSize + 1) * nrRecip + EncryptedBytes fileSize - 1
 
 minilock : {nrRecip, fileNameBytes, msgBytes}

--- a/examples/MiniLock/prim/CfrgCurves.md
+++ b/examples/MiniLock/prim/CfrgCurves.md
@@ -946,8 +946,8 @@ Internet-Draft                  cfrgcurve                     March 2015
 8.2 Utility Functions
 
 
-In the textual specification arithmatic is modular.  For the Cryptol code
-modular arithmatic must be explicitly implemented, which has been done in a
+In the textual specification arithmetic is modular.  For the Cryptol code
+modular arithmetic must be explicitly implemented, which has been done in a
 separate file.
 
 ```cryptol

--- a/language-server/client/README.md
+++ b/language-server/client/README.md
@@ -9,5 +9,5 @@ The exteions supports:
 
   * Syntax highlighting
   * View documentation when hovering over an identify
-  * Go to defintion
-  * Show type information for identifers and numeric literal
+  * Go to definition
+  * Show type information for identifiers and numeric literal


### PR DESCRIPTION
Found and fixed with [`typos`]:

```sh
git ls-files --exclude-standard '*.md' | \
  xargs --max-args=1 --max-procs=8 -- typos -w
```

[`typos`]: https://github.com/crate-ci/typos