### PR TITLE
Freeze files: Bump `what4` dependency to include fix for GaloisInc/what4#329

### DIFF
--- a/cabal.GHC-9.4.8.config
+++ b/cabal.GHC-9.4.8.config
@@ -366,7 +366,7 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.warp ==3.4.8,
              warp +allow-sendfilefd -network-bytestring -warp-debug +x509,
              any.warp-tls ==3.4.13,
-             any.what4 ==1.7.1.0,
+             any.what4 ==1.7.2,
              what4 -drealtestdisable -solvertests -stptestdisable,
              any.witherable ==0.5,
              any.wl-pprint-annotated ==0.1.0.1,
@@ -375,4 +375,4 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.zenc ==0.1.2,
              any.zlib ==0.7.1.0,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2025-11-07T04:31:49Z
+index-state: hackage.haskell.org 2025-11-19T10:56:47Z

--- a/cabal.GHC-9.6.5.config
+++ b/cabal.GHC-9.6.5.config
@@ -364,7 +364,7 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.warp ==3.4.8,
              warp +allow-sendfilefd -network-bytestring -warp-debug +x509,
              any.warp-tls ==3.4.13,
-             any.what4 ==1.7.1.0,
+             any.what4 ==1.7.2,
              what4 -drealtestdisable -solvertests -stptestdisable,
              any.witherable ==0.5,
              any.wl-pprint-annotated ==0.1.0.1,
@@ -373,4 +373,4 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.zenc ==0.1.2,
              any.zlib ==0.7.1.0,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2025-11-07T04:31:49Z
+index-state: hackage.haskell.org 2025-11-19T10:56:47Z

--- a/cabal.GHC-9.8.2.config
+++ b/cabal.GHC-9.8.2.config
@@ -364,7 +364,7 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.warp ==3.4.8,
              warp +allow-sendfilefd -network-bytestring -warp-debug +x509,
              any.warp-tls ==3.4.13,
-             any.what4 ==1.7.1.0,
+             any.what4 ==1.7.2,
              what4 -drealtestdisable -solvertests -stptestdisable,
              any.witherable ==0.5,
              any.wl-pprint-annotated ==0.1.0.1,
@@ -373,4 +373,4 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.zenc ==0.1.2,
              any.zlib ==0.7.1.0,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2025-11-07T04:31:49Z
+index-state: hackage.haskell.org 2025-11-19T10:56:47Z


### PR DESCRIPTION
This bumps the `what4` dependency in the `cabal.GHC-*.config` freeze files to version `1.7.2`. This version includes the changes from https://github.com/GaloisInc/what4/pull/330, which fixes a soundness-related regression involving the `sbvToInteger` operation (see https://github.com/GaloisInc/what4/issues/329 for the specifics).