### PR TITLE
CI: Exclude Dependabot from actions where forks aren't permitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,10 @@ jobs:
       # request info because we might also be on master in a fork. It
       # seems that you can't stop scheduled jobs from also running in
       # forks. See https://github.com/orgs/community/discussions/16109.
-      - if: runner.os == 'Windows' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+      - if: runner.os == 'Windows' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -220,7 +223,9 @@ jobs:
       # request info because we might also be on master in a fork. It
       # seems that you can't stop scheduled jobs from also running in
       # forks. See https://github.com/orgs/community/discussions/16109.
-      - if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+      - if: github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -424,7 +429,9 @@ jobs:
     # Do not run this on forks. It seems that you can't stop scheduled
     # jobs from also running in forks. See
     # https://github.com/orgs/community/discussions/16109.
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true') && github.repository_owner == 'GaloisInc'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true') &&
+        github.repository_owner == 'GaloisInc' &&
+        github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,9 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-23.05
       - name: build PDF docs
-        if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+        if: github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         uses: docker://pandoc/latex:2.9.2
         with:
           args: >-
@@ -51,7 +53,9 @@ jobs:
     # request info because we might also be on master in a fork. It
     # seems that you can't stop scheduled jobs from also running in
     # forks. See https://github.com/orgs/community/discussions/16109.
-    if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+    if: github.event.pull_request.head.repo.fork == false &&
+        github.repository_owner == 'GaloisInc' &&
+        github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     # The public interface should then allow the user to browse the cryptol
     # documentation at the master branch, but also the documentation associated


### PR DESCRIPTION
Although Dependabot PRs technically run CI as though they were a branch in the upstream repo, not a fork, in practice they do not have access to any of the secrets required to do things such as signing binaries. As such, Dependabot PRs effectively behave as though they were running from forks, so we should treat Dependabot accordingly in the CI.

Fixes #1940.