### PR TITLE
CI: Use GITHUB_TOKEN to log into Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
`GITHUB_TOKEN` is a special, automatically generated token in GitHub Actions that is suitable as a temporary, repository-scoped credential for authentication purposes. This should be better suited for logging into GitHub's Docker container registry, as it avoids the need for us to maintain a custom access token for this purpose. (We are currently maintaining a custom access token, and it breaks about once a year due to us forgetting to renew the token---see #1959 for an example).

Fixes #1959.