### PR TITLE
RefMan/BasicSyntax.rst: fix `len` examples.

### DIFF
--- a/docs/RefMan/BasicSyntax.rst
+++ b/docs/RefMan/BasicSyntax.rst
@@ -45,7 +45,7 @@ actual ``if`` statement:
   
   len' : {n, a} (fin n) => [n]a -> Integer
   len' xs = if `n > 0
-              then 1 + len (drop `{1} xs)
+              then 1 + len' (drop `{1} xs)
               else 0
 
 The definition of ``len'`` is rejected, because the *value based* ``if``


### PR DESCRIPTION
The `len` examples in the manual seem to be wrong -- particularly the multi-way `if` syntax in the second one, which doesn't seem to be legal Cryptol syntax as it was written.

I changed the `len'` definition a bit so the `0` case is handled by the `else` branch and then re-ordered the `len` definition to match.