### PR TITLE
CI: Fix the tag matching patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: Cryptol
 on:
   push:
-    tags: ["[0-9]+.[0-9]+(.[0-9]+)?"]
+    tags:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
     branches: [master, "release-**"]
   pull_request:
   schedule:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,9 @@
 name: Cryptol Docs
 on:
   push:
-    tags: ["[0-9]+.[0-9]+(.[0-9]+)?"]
+    tags:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
     branches: [master, "release-**"]
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
They aren't regexps and don't support parenthesized subgroups.

Closes #1829.
Compare https://github.com/GaloisInc/saw-script/pull/2267.
