### PR TITLE
Update VSCode extension README.

### DIFF
--- a/language-server/client/README.md
+++ b/language-server/client/README.md
@@ -1,9 +1,13 @@
 # Cryptol for Visual Studio Code
 
-#### [Repository](https://github.com/GaloisInc/cryptol)&nbsp;&nbsp;|&nbsp;&nbsp;[Issues](https://github.com/GaloisInc/cryptol/issues)&nbsp;&nbsp;|&nbsp;&nbsp;[Documentation](https://galoisinc.github.io/cryptol/master/RefMan.html)
+#### [Repository](https://github.com/GaloisInc/cryptol)&nbsp;&nbsp;|&nbsp;&nbsp;[Downloads](https://github.com/GaloisInc/cryptol/releases)&nbsp;&nbsp;|&nbsp;&nbsp;[Issues](https://github.com/GaloisInc/cryptol/issues)&nbsp;&nbsp;|&nbsp;&nbsp;[Documentation](https://galoisinc.github.io/cryptol/master/RefMan.html)
 
 This extension provides support for working with [Cryptol](https://cryptol.net).
-To use the extension you'll need a pre-installed `cryptol-language-server`.
+
+The extension requires `cryptol-language-server`, which is included with
+Cryptol's binary release distributions. Once the extension is installed,
+modify its `language-server-path` setting to point to the language server
+binary.
 
 The extension supports:
 


### PR DESCRIPTION
Clarify where `cryptol-language-server` can be found and add a link to the release page.