### PR TITLE
`coreLint`: Fix checking of newtype update expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,10 @@
   type error.
   ([#2011](https://github.com/GaloisInc/cryptol/issues/2011))
 
+* Fix a bug in `coreLint` that would trigger a panic when checking record
+  updates on newtype values.
+  ([#2025](https://github.com/GaloisInc/cryptol/issues/2025))
+
 # 3.5.0 -- 2026-01-27
 
 ## Administrative changes

--- a/src/Cryptol/TypeCheck/Sanity.hs
+++ b/src/Cryptol/TypeCheck/Sanity.hs
@@ -408,18 +408,13 @@ checkHas t sel =
     RecordSel f mb ->
       case tNoUser t of
         TRec fs ->
+          checkRecordSel UnexpectedRecordShape f mb fs
 
-          do case mb of
-               Nothing -> return ()
-               Just fs1 ->
-                 do let ns  = Set.toList (fieldSet fs)
-                        ns1 = sort fs1
-                    unless (ns == ns1) $
-                      reportError $ UnexpectedRecordShape ns1 ns
-
-             case lookupField f fs of
-               Nothing -> reportError $ MissingField f $ displayOrder fs
-               Just ft -> return ft
+        TNominal nt _ ->
+          case ntDef nt of
+            Struct con ->
+              checkRecordSel UnexpectedNewtypeShape f mb (ntFields con)
+            _ -> reportError $ BadSelector sel t
 
         TCon (TC TCSeq) [s,elT] -> do res <- checkHas elT sel
                                       return (TCon (TC TCSeq) [s,res])
@@ -448,8 +443,31 @@ checkHas t sel =
 
         _ -> reportError $ BadSelector sel t
 
+-- | Check that a record selection or update expression is well-formed. This is
+-- written to work for both record values and newtype values.
+checkRecordSel ::
+  -- | What error to raise if the record or newtype value is malformed.
+  ([Ident] -> [Ident] -> Error) ->
+  -- | The field name being selected.
+  Ident ->
+  -- | The expected field names for the record or newtype.
+  Maybe [Ident] ->
+  -- | The actual field names for the record or newtype.
+  RecordMap Ident Type ->
+  -- | The type of the field being selected.
+  TcM Type
+checkRecordSel unexpectedShape f mb fs =
+  do case mb of
+       Nothing -> return ()
+       Just fs1 ->
+         do let ns  = Set.toList (fieldSet fs)
+                ns1 = sort fs1
+            unless (ns == ns1) $
+              reportError $ unexpectedShape ns1 ns
 
-
+     case lookupField f fs of
+       Nothing -> reportError $ MissingField f $ displayOrder fs
+       Just ft -> return ft
 
 -- | Check if the one type is convertible to the other.
 convertible :: Type -> Type -> TcM ()
@@ -638,6 +656,7 @@ data Error =
   | MissingField Ident [Ident]
   | UnexpectedTupleShape Int Int
   | UnexpectedRecordShape [Ident] [Ident]
+  | UnexpectedNewtypeShape [Ident] [Ident]
   | UnexpectedSequenceShape Int Type
   | BadSelector Selector Type
   | BadInstantiation
@@ -749,6 +768,12 @@ instance PP Error where
 
       UnexpectedRecordShape expected actual ->
         ppErr "Unexpected record shape"
+          [ "Expected:" <+> commaSep (map pp expected)
+          , "Actual  :" <+> commaSep (map pp actual)
+          ]
+
+      UnexpectedNewtypeShape expected actual ->
+        ppErr "Unexpected newtype shape"
           [ "Expected:" <+> commaSep (map pp expected)
           , "Actual  :" <+> commaSep (map pp actual)
           ]

--- a/src/Cryptol/TypeCheck/Sanity.hs
+++ b/src/Cryptol/TypeCheck/Sanity.hs
@@ -394,14 +394,6 @@ checkHas t sel =
              unless (n < sz) $ reportError (TupleSelectorOutOfRange n sz)
              return $ ts !! n
 
-        TCon (TC TCSeq) [s,elT] ->
-           do res <- checkHas elT sel
-              return (TCon (TC TCSeq) [s,res])
-
-        TCon (TC TCFun) [a,b] ->
-            do res <- checkHas b sel
-               return (TCon (TC TCFun) [a,res])
-
         _ -> reportError $ BadSelector sel t
 
 
@@ -415,13 +407,6 @@ checkHas t sel =
             Struct con ->
               checkRecordSel UnexpectedNewtypeShape f mb (ntFields con)
             _ -> reportError $ BadSelector sel t
-
-        TCon (TC TCSeq) [s,elT] -> do res <- checkHas elT sel
-                                      return (TCon (TC TCSeq) [s,res])
-
-        TCon (TC TCFun) [a,b]   -> do res <- checkHas b sel
-                                      return (TCon (TC TCFun) [a,res])
-
 
         _ -> reportError $ BadSelector sel t
 

--- a/tests/issues/issue2025.cry
+++ b/tests/issues/issue2025.cry
@@ -1,0 +1,70 @@
+// Tuples
+
+type T = ([8], [16])
+
+tA : T
+tA = (1, 2)
+
+tB : T
+tB = { tA | 1 = 22 }
+
+tFunA : () -> T
+tFunA () = tA
+
+tFunB : () -> T
+tFunB = { tFunA | 1 = \() -> 22 }
+
+tSeqA : [2]T
+tSeqA = repeat tA
+
+tSeqB : [2]T
+tSeqB = { tSeqA | 1 = repeat 22 }
+
+// Records
+
+type R = { getR1 : [8], getR2 : [16] }
+
+rA : R
+rA = { getR1 = 1, getR2 = 2 }
+
+rB : R
+rB = { rA | getR2 = 22 }
+
+rFunA : () -> R
+rFunA () = rA
+
+rFunB : () -> R
+rFunB = { rFunA | getR2 = \() -> 22 }
+
+rSeqA : [2]R
+rSeqA = repeat rA
+
+rSeqB : [2]R
+rSeqB = { rSeqA | getR2 = repeat 22 }
+
+// Newtypes
+
+// Commented out to avoid a Cryptol panic
+// TODO(#2025): Remove this workaround.
+
+/*
+newtype N = { getN1 : [8], getN2 : [16] }
+
+nA : N
+nA = N { getN1 = 1, getN2 = 2 }
+
+nB : N
+nB = { nA | getN2 = 22 }
+
+nFunA : () -> N
+nFunA () = nA
+
+nFunB : () -> N
+nFunB = { nFunA | getN2 = \() -> 22 }
+
+nSeqA : [2]N
+nSeqA = repeat nA
+
+nSeqB : [2]N
+nSeqB = { nSeqA | getN2 = repeat 22 }
+*/

--- a/tests/issues/issue2025.cry
+++ b/tests/issues/issue2025.cry
@@ -44,10 +44,6 @@ rSeqB = { rSeqA | getR2 = repeat 22 }
 
 // Newtypes
 
-// Commented out to avoid a Cryptol panic
-// TODO(#2025): Remove this workaround.
-
-/*
 newtype N = { getN1 : [8], getN2 : [16] }
 
 nA : N
@@ -67,4 +63,3 @@ nSeqA = repeat nA
 
 nSeqB : [2]N
 nSeqB = { nSeqA | getN2 = repeat 22 }
-*/

--- a/tests/issues/issue2025.icry
+++ b/tests/issues/issue2025.icry
@@ -1,0 +1,2 @@
+:set coreLint=on
+:load issue2025.cry

--- a/tests/issues/issue2025.icry.stdout
+++ b/tests/issues/issue2025.icry.stdout
@@ -8,3 +8,4 @@ Loading module Cryptol
 Loading module Main
 2 == min 2 2
 2 == min 2 2
+2 == min 2 2

--- a/tests/issues/issue2025.icry.stdout
+++ b/tests/issues/issue2025.icry.stdout
@@ -1,0 +1,10 @@
+Loading module Cryptol
+Loading module Cryptol
+{n, a, b, c} n == min n n
+{a, n} (fin n) => inf == inf * (1 * (1 * 1))
+{a, n} (fin n) => n / 2 + n /^ 2 == n
+{n, a, b} n == min n n
+{n} (n >= 1, fin n) => (fin n, n >= 1)
+Loading module Main
+2 == min 2 2
+2 == min 2 2


### PR DESCRIPTION
The `coreLint` implementation previously assumed that record update syntax could only occur on record values, but they can also occur on newtype values. As such, `coreLint` would panic if it encountered a record update on a newtype. This commit fixes the issue by adding a new case under `RecordSel` for newtypes.

Fixes https://github.com/GaloisInc/cryptol/issues/2025.