### PR TITLE
Encode enum tags as words, not integers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,10 @@
   updates on newtype values.
   ([#2025](https://github.com/GaloisInc/cryptol/issues/2025))
 
+* Fix a bug that would cause Bitwuzla-based provers to fail when reasoning
+  about enums.
+  ([#2027](https://github.com/GaloisInc/cryptol/issues/2027))
+
 # 3.5.0 -- 2026-01-27
 
 ## Administrative changes

--- a/src/Cryptol/Backend/What4.hs
+++ b/src/Cryptol/Backend/What4.hs
@@ -175,9 +175,9 @@ instance W4.IsSymExprBuilder sym => MonadIO (W4Eval sym) where
 
 -- | Add a definitional equation.
 -- This will always be asserted when we make queries to the solver.
-addDefEqn :: W4.IsSymExprBuilder sym => What4 sym -> W4.Pred sym -> W4Eval sym ()
+addDefEqn :: W4.IsSymExprBuilder sym => What4 sym -> W4.Pred sym -> IO ()
 addDefEqn sym p =
-  liftIO (modifyMVar_ (w4defs sym) (W4.andPred (w4 sym) p))
+  modifyMVar_ (w4defs sym) (W4.andPred (w4 sym) p)
 
 -- | Add s safety condition.
 addSafety :: W4.IsSymExprBuilder sym => W4.Pred sym -> W4Eval sym ()
@@ -645,7 +645,7 @@ fpCvtToRational sym fp =
                W4.notPred (w4 sym) =<< W4.orPred (w4 sym) bad1 bad2
      assertSideCondition sym grd (BadValue "fpToRational")
      (rel,x,y) <- liftIO (FP.fpToRational (w4 sym) fp)
-     addDefEqn sym =<< liftIO (W4.impliesPred (w4 sym) grd rel)
+     liftIO (addDefEqn sym =<< W4.impliesPred (w4 sym) grd rel)
      ratio sym x y
 
 fpCvtFromRational ::
@@ -686,6 +686,6 @@ sModRecip sym m x
        z <- liftIO (W4.freshBoundedInt (w4 sym) W4.emptySymbol (Just 1) (Just (m-1)))
        xz <- liftIO (W4.intMul (w4 sym) x z)
        rel <- znEq sym m xz =<< liftIO (W4.intLit (w4 sym) 1)
-       addDefEqn sym =<< liftIO (W4.orPred (w4 sym) divZero rel)
+       liftIO (addDefEqn sym =<< W4.orPred (w4 sym) divZero rel)
 
        return z

--- a/src/Cryptol/Eval.hs
+++ b/src/Cryptol/Eval.hs
@@ -53,7 +53,7 @@ import Cryptol.ModuleSystem.Name
 import Cryptol.Parser.Position
 import Cryptol.Parser.Selector(ppSelector)
 import Cryptol.TypeCheck.AST
-import Cryptol.TypeCheck.Solver.InfNat(Nat'(..),nMul)
+import Cryptol.TypeCheck.Solver.InfNat(Nat'(..),nMul,widthInteger)
 import Cryptol.Utils.Ident
 import Cryptol.Utils.Panic (panic)
 import Cryptol.Utils.PP
@@ -344,14 +344,14 @@ evalNominalDecl ::
 evalNominalDecl sym nt env0 =
   case ntDef nt of
     Struct c -> pure (bindVarDirect (ntConName c) (mkCon structCon) env0)
-    Enum cs  -> foldM enumCon env0 cs
+    Enum cs  -> foldM (enumCon (length cs)) env0 cs
     Abstract -> pure env0
   where
   structCon = PFun PPrim
   mkCon c   = foldr tabs c (ntParams nt)
 
-  enumCon env c =
-    do con <- evalEnumCon sym (nameIdent (ecName c)) (ecNumber c)
+  enumCon numCons env c =
+    do con <- evalEnumCon sym (nameIdent (ecName c)) (ecNumber c) numCons
        let done        = PVal . con . Vector.fromList . reverse
            fu _t f xs  = PFun (\v -> f (v:xs))
        pure (bindVarDirect (ecName c)
@@ -368,14 +368,20 @@ evalNominalDecl sym nt env0 =
 
 {-# INLINE evalNominalDecl #-}
 
--- | Make the function for a known constructor
+-- | Make the function for a known constructor in an enum.
 evalEnumCon ::
   Backend sym =>
-  sym -> Ident -> Int ->
+  sym ->
+  -- | The constructor's name.
+  Ident ->
+  -- | The constructor's tag (zero-indexed).
+  Int ->
+  -- | The total number of constructors in the enum.
+  Int ->
   SEval sym (Vector (SEval sym (GenValue sym)) -> GenValue sym)
-evalEnumCon sym i n =
-  do tag <- integerLit sym (toInteger n)
-     pure (VEnum tag . IntMap.singleton n . ConInfo i)
+evalEnumCon sym i conIdx numCons =
+  do tag <- wordLit sym (widthInteger (toInteger numCons)) (toInteger conIdx)
+     pure (VEnum tag . IntMap.singleton conIdx . ConInfo i)
 
 
 

--- a/src/Cryptol/Eval/Concrete.hs
+++ b/src/Cryptol/Eval/Concrete.hs
@@ -91,7 +91,7 @@ toExpr prims t0 v0 = findOne (go t0 v0)
                          Abstract -> panic "toExp" ["Asbtract vs Record"]
                    f = foldl (\x t -> ETApp x (tNumValTy t)) (EVar c) ts
                 in pure (EApp f (ERec efs))
-      (TVNominal nt ts (TVEnum tfss), VEnum i' vf_map) ->
+      (TVNominal nt ts (TVEnum tfss), VEnum (BV _ i') vf_map) ->
         let i = fromInteger i'
         in
         case tfss Vector.!? i of

--- a/src/Cryptol/Eval/FFI/Abstract/Export.hs
+++ b/src/Cryptol/Eval/FFI/Abstract/Export.hs
@@ -60,7 +60,7 @@ exportValue v =
     VSeq n sm    -> exportValues (enumerateSeqMap n sm)
 
     -- 1. tag, 2. constructor values
-    VEnum tag mp
+    VEnum (BV _ tag) mp
       | 0 <= tag && tag <= toInteger (maxBound :: Int)
       , let n = fromInteger tag
       , Just con <- IntMap.lookup n mp ->

--- a/src/Cryptol/Eval/FFI/Abstract/Import.hs
+++ b/src/Cryptol/Eval/FFI/Abstract/Import.hs
@@ -127,7 +127,7 @@ haveTag n fs0 =
 
               mkV :: [Value] -> Value
               mkV vs = pure (VEnum
-                              (toInteger n)
+                              (BV (enumTagWidth opts) (toInteger n))
                               (IntMap.singleton n
                                   ci { conFields = Vector.fromList vs }))
 

--- a/src/Cryptol/Eval/Generic.hs
+++ b/src/Cryptol/Eval/Generic.hs
@@ -756,7 +756,7 @@ toSignedIntegerV sym =
   (Integer -> SInteger Concrete -> SInteger Concrete -> SEval Concrete a -> SEval Concrete a) ->
   (SRational Concrete -> SRational Concrete -> SEval Concrete a -> SEval Concrete a) ->
   (SFloat Concrete -> SFloat Concrete -> SEval Concrete a -> SEval Concrete a) ->
-  (SInteger Concrete -> SInteger Concrete -> SEval Concrete a -> SEval Concrete a) ->
+  (SWord Concrete -> SWord Concrete -> SEval Concrete a -> SEval Concrete a) ->
   (TValue -> GenValue Concrete -> GenValue Concrete -> SEval Concrete a -> SEval Concrete a)
   #-}
 
@@ -770,7 +770,7 @@ cmpValue ::
   (Integer -> SInteger sym -> SInteger sym -> SEval sym a -> SEval sym a) ->
   (SRational sym -> SRational sym -> SEval sym a -> SEval sym a) ->
   (SFloat sym -> SFloat sym -> SEval sym a -> SEval sym a) ->
-  (SInteger sym -> SInteger sym -> SEval sym a -> SEval sym a) -> -- ^ how to compare enum tags
+  (SWord sym -> SWord sym -> SEval sym a -> SEval sym a) -> -- ^ how to compare enum tags
   (TValue -> GenValue sym -> GenValue sym -> SEval sym a -> SEval sym a)
 cmpValue sym merge fb fw fi fz fq ff ftag = cmp
   where
@@ -818,8 +818,8 @@ cmpValue sym merge fb fw fi fz fq ff ftag = cmp
           -- first compare based on tag...
           ftag tag1 tag2
             -- if both tags are concrete...
-            case (integerAsLit sym tag1, integerAsLit sym tag2) of
-              (Just i, Just j)
+            case (wordAsLit sym tag1, wordAsLit sym tag2) of
+              (Just (_, i), Just (_, j))
                 -- ...then because the comparisons are lazy, this part should
                 -- only be evaluated if tag1 == tag2
                 | i == j -> do
@@ -837,7 +837,7 @@ cmpValue sym merge fb fw fi fz fq ff ftag = cmp
               _ -> do
                 -- in the symbolic case, here tag1 may or may not equal tag2, so
                 -- we need to explicitly check this
-                sameTag <- intEq sym tag1 tag2
+                sameTag <- wordEq sym tag1 tag2
                 -- if tag1 == tag2, then compare by field, otherwise we are done
                 -- comparing
                 mergeEval sym merge sameTag doFields k
@@ -852,9 +852,9 @@ cmpValue sym merge fb fw fi fz fq ff ftag = cmp
                       IMap.intersectionWith (,) cons1 cons2
                   doFieldsForTag i (con1, con2) doRest = do
                     -- if the tag is i, then compare fields for constructor i
-                    i' <- integerLit sym (toInteger i)
+                    i' <- wordLit sym (wordLen sym tag1) (toInteger i)
                     -- we know tag1 == tag2, so we arbitrarily use tag1 here
-                    isThisTag <- intEq sym tag1 i'
+                    isThisTag <- wordEq sym tag1 i'
                     mergeEval sym merge isThisTag
                       (cmpFields i con1 con2)
                       doRest
@@ -894,7 +894,7 @@ valEq sym ty v1 v2 = cmpValue sym (iteBit sym) fb fw fi fz fq ff ftag ty v1 v2 (
   fz m x y k = eqCombine sym (znEq sym m x y) k
   fq x y k   = eqCombine sym (rationalEq sym x y) k
   ff x y k   = eqCombine sym (fpEq sym x y) k
-  ftag       = fi
+  ftag       = fw
 
 {-# INLINE valLt #-}
 valLt :: Backend sym =>
@@ -907,7 +907,7 @@ valLt sym ty v1 v2 final = cmpValue sym (iteBit sym) fb fw fi fz fq ff ftag ty v
   fz _ _ _ _ = panic "valLt" ["Z_n is not in `Cmp`"]
   fq x y k   = lexCombine sym (rationalLessThan sym x y) (rationalEq sym x y) k
   ff x y k   = lexCombine sym (fpLessThan   sym x y) (fpEq   sym x y) k
-  ftag       = fi
+  ftag       = fw
 
 {-# INLINE valGt #-}
 valGt :: Backend sym =>
@@ -920,7 +920,7 @@ valGt sym ty v1 v2 final = cmpValue sym (iteBit sym) fb fw fi fz fq ff ftag ty v
   fz _ _ _ _ = panic "valGt" ["Z_n is not in `Cmp`"]
   fq x y k   = lexCombine sym (rationalGreaterThan sym x y) (rationalEq sym x y) k
   ff x y k   = lexCombine sym (fpGreaterThan   sym x y) (fpEq   sym x y) k
-  ftag       = fi
+  ftag       = fw
 
 {-# INLINE eqCombine #-}
 eqCombine :: Backend sym =>
@@ -989,7 +989,10 @@ signedLessThanV sym ty v1 v2 =
   fz m _ _ _ = panic "signedLessThan" ["Attempted to perform signed comparison on Z_" ++ show m ++ " type"]
   fq _ _ _   = panic "signedLessThan" ["Attempted to perform signed comparison on Rational type"]
   ff _ _ _   = panic "signedLessThan" ["Attempted to perform signed comparison on Float"]
-  ftag x y k = lexCombine sym (intLessThan sym x y) (intEq sym x y) k
+  ftag x y k = lexCombine sym (wordLessThan sym x y) (wordEq sym x y) k
+                 -- NB: Use `wordLessThan` to compare enum constructor tags,
+                 -- not `wordSignedLessThan`. We only used signed comparisons
+                 -- on the constructors' fields, not on the tags.
 
 
 

--- a/src/Cryptol/Eval/Type.hs
+++ b/src/Cryptol/Eval/Type.hs
@@ -34,7 +34,7 @@ import Control.DeepSeq
 -- | An evaluated type of kind *.
 -- These types do not contain type variables, type synonyms, or type functions.
 data TValue
-  = TVBit                     -- ^ @ Bit @  
+  = TVBit                     -- ^ @ Bit @
   | TVInteger                 -- ^ @ Integer @
   | TVFloat Integer Integer   -- ^ @ Float e p @
   | TVIntMod Integer          -- ^ @ Z n @
@@ -256,7 +256,7 @@ instance PP TValue where
       TVFloat e p -> wrapAfter 1 ("Float" <+> integer e <+> integer p)
       TVIntMod m -> wrapAfter 1 ("Z" <+> integer m)
       TVRational -> "Rational"
-      TVArray a b -> wrapAfter 1 ("Array" <+> pp2 0 a <+> pp2 1 b) 
+      TVArray a b -> wrapAfter 1 ("Array" <+> pp2 0 a <+> pp2 1 b)
       TVSeq m v ->
         case v of
           TVBit -> brackets (integer m)

--- a/src/Cryptol/Eval/Type.hs
+++ b/src/Cryptol/Eval/Type.hs
@@ -127,6 +127,14 @@ finNat' n' =
     Nat x -> x
     Inf   -> panic "Cryptol.Eval.Value.finNat'" [ "Unexpected `inf`" ]
 
+-- | Compute the mininum number of bits needed to represent an enum tag with
+-- the given constructors. See @Note [Represent enum tags as words]@ in
+-- "Cryptol.Eval.Value".
+enumTagWidth :: Vector (ConInfo a) -> Integer
+enumTagWidth cons = widthInteger $ toInteger $ Vector.length cons - 1
+  -- Note the use of `- 1` above, which assumes that `cons` is non-empty. This
+  -- should always be the case because Cryptol requires enums to have at least
+  -- one constructor.
 
 -- Type Evaluation -------------------------------------------------------------
 

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -127,11 +127,13 @@ data EvalOpts = EvalOpts
 data GenValue sym
   = VRecord !(RecordMap Ident (SEval sym (GenValue sym))) -- ^ @ { .. } @
   | VTuple ![SEval sym (GenValue sym)]              -- ^ @ ( .. ) @
-  | VEnum !(SInteger sym) !(IntMap (ConValue sym))
-    -- ^ As an example, consider the enum value @Just ()@. The 'SInteger' is the
+  | VEnum !(SWord sym) !(IntMap (ConValue sym))
+    -- ^ As an example, consider the enum value @Just ()@. The 'SWord' is the
     -- tag (e.g., 'Just' would have the tag @0@), and the 'IntMap' contains the
     -- fields (e.g., @{ 0 -> ("Just",()) }@. The 'IntMap' is only really needed
     -- to represent symbolic values.
+    --
+    -- See also @Note [Represent enum tags as words]@.
   | VBit !(SBit sym)                           -- ^ @ Bit    @
   | VInteger !(SInteger sym)                   -- ^ @ Integer @ or @ Z n @
   | VRational !(SRational sym)                 -- ^ @ Rational @
@@ -158,6 +160,43 @@ pattern VSeq len vals <- VSeqCtor len vals
 {-# COMPLETE VRecord, VTuple, VEnum, VBit, VInteger,
              VRational, VFloat, VWord, VStream,
              VFun, VPoly, VNumPoly, VSeq #-}
+
+{-
+Note [Represent enum tags as words]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When translating enum values to Cryptol's various backends, we encode an enum
+constructor by its tag, i.e., an index (starting at zero) representing the
+constructor's position in the overall enum. For instance, given:
+
+  enum Option a = None | Some a
+
+Cryptol would give `None` the tag 0, and it would give `Some` the tag 1.
+
+There is a design question of how best to represent these tags when translating
+to symbolic backends. Two reasonable options that come to mind are:
+
+1. Represent the tag as an integer (i.e., SMT-Lib's `Int` type).
+2. Represent the tag as a word (i.e., SMT-Lib's `BitVec` type).
+
+Option (1) comes with a severe downside that not all solvers support SMT-LIB's
+`Int` type (notably, Bitwuzla does not). Moreover, solvers tend to be slightly
+faster on purely bitvector-oriented queries than they do with integer-oriented
+queries. As such, Cryptol picks option (2).
+
+There is a catch to option (2), however: in addition to knowing what the value
+of the tag will be as a word, one must also know the word size in bits.
+Different enums will require different word sizes. For instance, `Option` only
+has two constructors, so a word size with 1 bit suffices to encode all of its
+constructors. On the other hand, it would not suffice to encode all of the
+constructors in an an enum like this one:
+
+  enum Grade = A | B | C | D | E | F
+
+Since `Grade` has 6 constructors, we'd need a minimum of three bits to encode
+all of its constructors. As such, several parts of the enum implementation in
+Cryptol must keep track of the total number of constructors for the sake of
+computing the tag's bit width.
+-}
 
 type ConValue sym = ConInfo (SEval sym (GenValue sym))
 
@@ -243,8 +282,8 @@ ppValuePrec x opts = loop
     CanonicalOrder -> canonicalFields
 
   ppEnumVal prec i mp =
-    case integerAsLit x i of
-      Just c ->
+    case wordAsLit x i of
+      Just (_, c) ->
         case IMap.lookup (fromInteger c) mp of
           Just con
             | isNullaryCon con -> pure (pp (conIdent con))
@@ -544,7 +583,7 @@ fromVRecord val = case val of
   VRecord fs -> fs
   _          -> evalPanic "fromVRecord" ["not a record", show val]
 
-fromVEnum :: Backend sym => GenValue sym -> (SInteger sym, IntMap (ConValue sym))
+fromVEnum :: Backend sym => GenValue sym -> (SWord sym, IntMap (ConValue sym))
 fromVEnum val =
   case val of
     VEnum c xs -> (c,xs)
@@ -585,20 +624,20 @@ data CaseCont sym = CaseCont
 
 caseValue :: Backend sym =>
   sym ->
-  SInteger sym ->
+  SWord sym ->
   IntMap (ConValue sym) ->
   CaseCont sym ->
   SEval sym (GenValue sym)
 caseValue sym tag alts k
-  | Just c <- integerAsLit sym tag =
+  | Just (_, c) <- wordAsLit sym tag =
     case IMap.lookup (fromInteger c) alts of
       Just conV -> doCase conV
       Nothing -> panic "caseValue" ["Missing constructor for tag", show c]
   | otherwise = foldr doSymCase (doDefault Nothing) (IMap.toList alts)
   where
   doSymCase (n,con) otherOpts =
-    do expect <- integerLit sym (toInteger n)
-       yes    <- intEq sym tag expect
+    do expect <- wordLit sym (wordLen sym tag) (toInteger n)
+       yes    <- wordEq sym tag expect
        iteValue sym yes (doCase con) otherOpts
 
   doDefault mb =
@@ -639,7 +678,7 @@ mergeValue sym c v1 v2 =
            Right r -> pure (VRecord r)
 
     (VEnum c1 fs1, VEnum c2 fs2) ->
-      VEnum <$> iteInteger sym c c1 c2
+      VEnum <$> iteWord sym c c1 c2
             <*> pure (IMap.unionWith (mergeConValue sym c) fs1 fs2)
 
     (VTuple vs1  , VTuple vs2  ) | length vs1 == length vs2  ->

--- a/src/Cryptol/Eval/Value.hs
+++ b/src/Cryptol/Eval/Value.hs
@@ -26,7 +26,7 @@
 
 module Cryptol.Eval.Value
   ( -- * GenericValue
-    GenValue 
+    GenValue
       (VRecord, VTuple
       , VEnum, VBit
       , VInteger, VRational
@@ -435,14 +435,14 @@ mkSeq sym len elty vals = case len of
   Inf             -> pure $ VStream vals
 
 -- | Construct a finite sequence of word values.
-wordSeq :: 
-  Backend sym => 
+wordSeq ::
+  Backend sym =>
   sym ->
   -- | The length of the sequence.
   Integer ->
   -- | The word size of the element type.
   Integer ->
-  SeqMap sym (GenValue sym) -> 
+  SeqMap sym (GenValue sym) ->
   SEval sym (GenValue sym)
 wordSeq sym n w vals = mkSeq sym (Nat n) (TVSeq w TVBit) vals
 

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -182,7 +182,7 @@ finType ty =
     TVSeq n t           -> FTSeq n <$> doSub 0 (finType t)
     TVTuple ts          -> FTTuple <$> zipWithM doSub [ 0 .. ] (map finType ts)
     TVRec fields        -> FTRecord <$> doFields fields
-      where 
+      where
     TVNominal u ts nv   -> setHere $ FTNominal u ts <$>
       case nv of
         TVStruct body -> FStruct <$> traverse finType body

--- a/src/Cryptol/Symbolic.hs
+++ b/src/Cryptol/Symbolic.hs
@@ -66,7 +66,8 @@ import           Cryptol.Eval.Value
 import           Cryptol.TypeCheck.AST
 import           Cryptol.TypeCheck.Solver.InfNat
 import           Cryptol.Eval.Type
-  (TValue(..), TNominalTypeValue(..), evalType,tValTy,tNumValTy,ConInfo(..))
+  ( ConInfo(..), TValue(..), TNominalTypeValue(..)
+  , enumTagWidth, evalType, tValTy, tNumValTy )
 import           Cryptol.Utils.Ident (Ident,prelPrim,floatPrim)
 import           Cryptol.Utils.RecordMap
 import           Cryptol.Utils.Panic
@@ -248,7 +249,8 @@ data VarShape sym
   | VarFinSeq Integer [VarShape sym]
   | VarTuple [VarShape sym]
   | VarRecord (RecordMap Ident (VarShape sym))
-  | VarEnum (SInteger sym) (Vector (ConInfo (VarShape sym)))
+  | VarEnum (SWord sym) (Vector (ConInfo (VarShape sym)))
+      -- See Note [Represent enum tags as words] in Cryptol.Eval.Value
 
 ppVarShape :: Backend sym => sym -> VarShape sym -> Doc
 ppVarShape _sym (VarBit _b) = text "<bit>"
@@ -309,7 +311,9 @@ varShapeToValue sym var =
 data FreshVarFns sym =
   FreshVarFns
   { freshBitVar     :: IO (SBit sym)
-  , freshWordVar    :: Integer -> IO (SWord sym)
+    -- | The @Maybe Integer@ field is an optional upper bound.
+  , freshWordVar    :: Integer -> Maybe Integer -> IO (SWord sym)
+    -- | The @Maybe Integer@ fields are optional lower and upper bounds.
   , freshIntegerVar :: Maybe Integer -> Maybe Integer -> IO (SInteger sym)
   , freshFloatVar   :: Integer -> Integer -> IO (SFloat sym)
   }
@@ -325,7 +329,7 @@ freshVar fns tp =
     FTIntMod 0    -> panic "freshVariable" ["0 modulus not allowed"]
     FTIntMod m    -> VarInteger  <$> freshIntegerVar fns (Just 0) (Just (m-1))
     FTFloat e p   -> VarFloat    <$> freshFloatVar fns e p
-    FTSeq n FTBit -> VarWord     <$> freshWordVar fns (toInteger n)
+    FTSeq n FTBit -> VarWord     <$> freshWordVar fns (toInteger n) Nothing
     FTSeq n t     -> VarFinSeq (toInteger n) <$> sequence (genericReplicate n (freshVar fns t))
     FTTuple ts    -> VarTuple    <$> mapM (freshVar fns) ts
     FTRecord fs   -> VarRecord   <$> traverse (freshVar fns) fs
@@ -334,7 +338,7 @@ freshVar fns tp =
         FStruct fs -> VarRecord <$> traverse (freshVar fns) fs
         FEnum conTs ->
           do let maxCon = toInteger (Vector.length conTs - 1)
-             tag <- freshIntegerVar fns (Just 0) (Just maxCon)
+             tag <- freshWordVar fns (enumTagWidth conTs) (Just maxCon)
              cons <- traverse (traverse (freshVar fns)) conTs
              pure (VarEnum tag cons)
 
@@ -392,9 +396,9 @@ varModelPred sym vx =
     (VarFinSeq _n vs, VarFinSeq _ xs) -> modelPred sym vs xs
     (VarTuple vs, VarTuple xs) -> modelPred sym vs xs
     (VarRecord vs, VarRecord xs) -> modelPred sym (recordElements vs) (recordElements xs)
-    (VarEnum vi vcons,  VarEnum i cons) ->
-      do tag     <- integerLit sym i
-         sameTag <- intEq sym tag vi
+    (VarEnum vi vcons,  VarEnum (Concrete.BV w i) cons) ->
+      do tag     <- wordLit sym w i
+         sameTag <- wordEq sym tag vi
          let i' = fromInteger i
              flds = Vector.toList . conFields
          sameFs  <- case (vcons Vector.!? i', cons Vector.!? i') of
@@ -428,7 +432,7 @@ varToExpr prims = go
                     f = foldl (\x t -> ETApp x (tNumValTy t)) (EVar con) ts
                  in EApp f (ERec efs)
 
-      (FTNominal nt ts (FEnum cons), VarEnum tag conVs) ->
+      (FTNominal nt ts (FEnum cons), VarEnum (Concrete.BV _ tag) conVs) ->
          foldl EApp conName args
          where
          tag' = fromInteger tag

--- a/src/Cryptol/Symbolic/SBV.hs
+++ b/src/Cryptol/Symbolic/SBV.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cryptol.Symbolic.SBV
  ( SBVProverConfig
@@ -622,12 +623,14 @@ parseValue (FTNominal _ _ nv) cvs =
     FStruct r -> parseValue (FTRecord r) cvs
     FEnum cons ->
       fromMaybe (panic "Cryptol.Symbolic.parseValue" ["no enum"]) $
-      do (tag, cvs') <- SBV.genParse SBV.KUnbounded cvs
+      do let tagWidth = enumTagWidth cons
+         (tag, cvs') <-
+           SBV.genParse (SBV.KBounded False (fromInteger @Int tagWidth)) cvs
          let doCon input con =
                case parseValues (Vector.toList (conFields con)) input of
                  (vs,input') -> (input', con { conFields = Vector.fromList vs })
              (input3, conVs) = mapAccumL doCon cvs' cons
-         pure (VarEnum tag conVs, input3)
+         pure (VarEnum (Concrete.BV tagWidth tag) conVs, input3)
 
 parseValue (FTFloat e p) cvs =
    (VarFloat FH.BF { FH.bfValue = bfNaN
@@ -650,10 +653,16 @@ freshBoundedInt sym lo hi =
        Nothing -> pure ()
      return x
 
-freshBitvector :: SBV -> Integer -> IO SBV.SVal
-freshBitvector sym w
+freshBitvector :: SBV -> Integer -> Maybe Integer -> IO SBV.SVal
+freshBitvector sym w hi
   | w == 0 = pure (SBV.svInteger (SBV.KBounded False 0) 0)
-  | otherwise = freshBV_ sym (fromInteger w)
+  | otherwise =
+    do let w' = fromInteger @Int w
+       x <- freshBV_ sym w'
+       case hi of
+         Just h -> addDefEqn sym (SBV.svLessEq x (SBV.svInteger (SBV.KBounded False w') h))
+         Nothing -> pure ()
+       pure x
 
 sbvFreshFns :: SBV -> FreshVarFns SBV
 sbvFreshFns sym =

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -150,8 +150,8 @@ doW4Eval sym m =
 
 -- | Wraps a 'W4.ConfigOption' to provide a consistent interface for setting
 --   solver goal timeouts (see 'configTimeoutMilliSeconds', 'configTimeoutSeconds', 'setConfigTimeout').
-data ConfigTimeout = 
-        ConfigTimeout 
+data ConfigTimeout =
+        ConfigTimeout
           (W4.ConfigOption W4.BaseIntegerType)
           -- | Translate a 'W4.SolverGoalTimeout' into the integer backing this config option.
           (W4.SolverGoalTimeout -> Integer)
@@ -162,19 +162,19 @@ configTimeoutMilliSeconds :: W4.ConfigOption W4.BaseIntegerType -> ConfigTimeout
 configTimeoutMilliSeconds opt = ConfigTimeout opt W4.getGoalTimeoutInMilliSeconds
 
 -- | Construct a 'ConfigTimeout' from a 'W4.ConfigOption', where the given
---   option configures a solver-specific timeout measured in seconds. 
---   Rounds up to at least 1 second when setting a non-zero timeout 
+--   option configures a solver-specific timeout measured in seconds.
+--   Rounds up to at least 1 second when setting a non-zero timeout
 --   (see 'W4.getGoalTimeoutInSeconds').
 configTimeoutSeconds :: W4.ConfigOption W4.BaseIntegerType -> ConfigTimeout
 configTimeoutSeconds opt = ConfigTimeout opt W4.getGoalTimeoutInSeconds
 
-setConfigTimeout :: 
+setConfigTimeout ::
   W4.IsExprBuilder sym =>
   ConfigTimeout ->
   W4.SolverGoalTimeout ->
   sym ->
   IO ()
-setConfigTimeout (ConfigTimeout opt toOpt) t sym = 
+setConfigTimeout (ConfigTimeout opt toOpt) t sym =
   do optSetting <- W4.getOptionSetting opt (W4.getConfiguration sym)
      _ <- W4.trySetOpt optSetting (toOpt t)
      pure ()
@@ -807,7 +807,7 @@ varShapeToConcrete evalFn v =
       VarEnum <$> W4.groundEval evalFn tag
               <*> traverse (traverse (varShapeToConcrete evalFn)) cons
 
-setAdapterTimeout :: 
+setAdapterTimeout ::
   W4.IsExprBuilder sym =>
   AnAdapter ->
   W4.SolverGoalTimeout ->

--- a/src/Cryptol/Symbolic/What4.hs
+++ b/src/Cryptol/Symbolic/What4.hs
@@ -340,13 +340,29 @@ setupAdapterOptions cfg sym =
   setupAnAdapter (AnOnlineAdapter _n _fs opts _ _p) =
     W4.extendConfig opts (W4.getConfiguration sym)
 
-what4FreshFns :: W4.IsSymExprBuilder sym => sym -> FreshVarFns (What4 sym)
+freshBV ::
+  W4.IsSymExprBuilder sym =>
+  What4 sym ->
+  Integer ->
+  Maybe Integer ->
+  IO (SW.SWord sym)
+freshBV sym w hi =
+  do x <- SW.freshBV (w4 sym) W4.emptySymbol w
+     case hi of
+       Just h ->
+         do sh <- SW.bvLit (w4 sym) w h
+            p <- SW.bvule (w4 sym) x sh
+            addDefEqn sym p
+       Nothing -> pure ()
+     pure x
+
+what4FreshFns :: W4.IsSymExprBuilder sym => What4 sym -> FreshVarFns (What4 sym)
 what4FreshFns sym =
   FreshVarFns
-  { freshBitVar     = W4.freshConstant sym W4.emptySymbol W4.BaseBoolRepr
-  , freshWordVar    = SW.freshBV sym W4.emptySymbol
-  , freshIntegerVar = W4.freshBoundedInt sym W4.emptySymbol
-  , freshFloatVar   = W4.fpFresh sym
+  { freshBitVar     = W4.freshConstant (w4 sym) W4.emptySymbol W4.BaseBoolRepr
+  , freshWordVar    = freshBV sym
+  , freshIntegerVar = W4.freshBoundedInt (w4 sym) W4.emptySymbol
+  , freshFloatVar   = W4.fpFresh (w4 sym)
   }
 
 -- | Simulate and manipulate query into a form suitable to be sent
@@ -363,7 +379,7 @@ prepareQuery sym ProverCommand { .. } = do
   case predArgTypes pcQueryType pcSchema of
     Left msg -> pure (Left msg)
     Right ts ->
-      do args <- liftIO (mapM (freshVar (what4FreshFns (w4 sym))) ts)
+      do args <- liftIO (mapM (freshVar (what4FreshFns sym)) ts)
          (safety,b) <- simulate ntEnv args
          liftIO
            do -- Ignore the safety condition if the flag is set
@@ -782,18 +798,17 @@ computeModelPred sym v c =
   snd <$> doW4Eval (w4 sym) (varModelPred sym (v, c))
 
 varShapeToConcrete ::
+  forall sym t fm.
+  sym ~ W4.ExprBuilder t CryptolState fm =>
   W4.GroundEvalFn t ->
-  VarShape (What4 (W4.ExprBuilder t CryptolState fm)) ->
+  VarShape (What4 sym) ->
   IO (VarShape Concrete.Concrete)
 varShapeToConcrete evalFn v =
   case v of
     VarBit b -> VarBit <$> W4.groundEval evalFn b
     VarInteger i -> VarInteger <$> W4.groundEval evalFn i
     VarRational n d -> VarRational <$> W4.groundEval evalFn n <*> W4.groundEval evalFn d
-    VarWord SW.ZBV -> pure (VarWord (Concrete.mkBv 0 0))
-    VarWord (SW.DBV x) ->
-      let w = W4.intValue (W4.bvWidth x)
-       in VarWord . Concrete.mkBv w . BV.asUnsigned <$> W4.groundEval evalFn x
+    VarWord w -> VarWord <$> sWordToConcrete w
     VarFloat fv@(W4.SFloat f) ->
       let (e,p) = W4.fpSize fv
        in VarFloat . FH.BF e p <$> W4.groundEval evalFn f
@@ -804,8 +819,14 @@ varShapeToConcrete evalFn v =
     VarRecord fs ->
       VarRecord <$> traverse (varShapeToConcrete evalFn) fs
     VarEnum tag cons ->
-      VarEnum <$> W4.groundEval evalFn tag
+      VarEnum <$> sWordToConcrete tag
               <*> traverse (traverse (varShapeToConcrete evalFn)) cons
+  where
+    sWordToConcrete :: SW.SWord sym -> IO Concrete.BV
+    sWordToConcrete SW.ZBV = pure (Concrete.mkBv 0 0)
+    sWordToConcrete (SW.DBV x) =
+      let w = W4.intValue (W4.bvWidth x)
+       in Concrete.mkBv w . BV.asUnsigned <$> W4.groundEval evalFn x
 
 setAdapterTimeout ::
   W4.IsExprBuilder sym =>

--- a/src/Cryptol/Testing/Random.hs
+++ b/src/Cryptol/Testing/Random.hs
@@ -52,7 +52,7 @@ import Cryptol.Backend.WordValue (wordVal)
 
 import Cryptol.Eval(evalEnumCon)
 import Cryptol.Eval.Type      ( TValue(..), TNominalTypeValue(..), ConInfo(..)
-                              , isNullaryCon )
+                              , enumTagWidth, isNullaryCon )
 import Cryptol.Eval.Value     ( GenValue(..), ppValue, defaultPPOpts, fromVFun, mkSeq, unsafeToFinSeq, finSeq)
 import Cryptol.TypeCheck.Solver.InfNat (widthInteger, Nat' (..))
 import Cryptol.Utils.Ident    (Ident)
@@ -343,7 +343,7 @@ randomCon sym cons
                 let (v, g') = gen sz g in
                 seq v (g', v))
               g1 (conFields con) in
-      (($ flds') <$> evalEnumCon sym (conIdent con) num, g2)
+      (($ flds') <$> evalEnumCon sym (conIdent con) num (length cons), g2)
 
 randomFloat ::
   (Backend sym, RandomGen g) =>
@@ -513,10 +513,11 @@ typeValues ty =
       case nv of
         TVStruct tbody -> typeValues (TVRec tbody)
         TVEnum cons ->
-          [ VEnum (toInteger tag) (IntMap.singleton tag con')
+          [ VEnum tag' (IntMap.singleton tag con')
           | (tag,con) <- zip [0..] (Vector.toList cons)
           , vs        <- mapM typeValues (conFields con)
           , let con' = con { conFields = pure <$> vs }
+          , let tag' = BV (enumTagWidth cons) (toInteger tag)
           ]
         TVAbstract -> []
 

--- a/tests/issues/issue2027.cry
+++ b/tests/issues/issue2027.cry
@@ -1,0 +1,11 @@
+// `MyBoolean` requires 1 bit to encode its tags
+enum MyBoolean = MyFalse | MyTrue deriving (Eq)
+
+myBooleanEqReflexive : MyBoolean -> Bit
+property myBooleanEqReflexive mb = mb == mb
+
+// `Grade` requires 3 bits to encode its tags
+enum Grade = A | B | C | D | E | F deriving (Eq)
+
+gradeEqReflexive : Grade -> Bit
+property gradeEqReflexive g = g == g

--- a/tests/issues/issue2027.icry
+++ b/tests/issues/issue2027.icry
@@ -1,0 +1,7 @@
+:load issue2027.cry
+:set prover=sbv-bitwuzla
+:prove myBooleanEqReflexive
+:prove gradeEqReflexive
+:set prover=w4-bitwuzla
+:prove myBooleanEqReflexive
+:prove gradeEqReflexive

--- a/tests/issues/issue2027.icry.stdout
+++ b/tests/issues/issue2027.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.


### PR DESCRIPTION
Doing so allows Bitwuzla-based provers to reason about enums, given that Bitwuzla does not support SMT-LIB's `Int` type.

Fixes https://github.com/GaloisInc/cryptol/issues/2027.