### PR TITLE
Tune pretty-printer line breaks and alignment for tuples and records.

### DIFF
--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -969,10 +969,10 @@ ppL :: PP a => Located a -> Doc
 ppL = pp . thing
 
 ppNamed :: PP a => String -> Named a -> Doc
-ppNamed s x = ppL (name x) <+> text s <+> pp (value x)
+ppNamed s x = nest 1 (ppL (name x) <+> text s </> pp (value x))
 
 ppNamed' :: PP a => String -> (Ident, (Range, a)) -> Doc
-ppNamed' s (i,(_,v)) = pp i <+> text s <+> pp v
+ppNamed' s (i,(_,v)) = nest 1 (pp i <+> text s </> pp v)
 
 
 
@@ -1378,7 +1378,7 @@ instance (Show name, PPName name) => PP (Expr name) where
                                        , nest 2 (vcat (map pp as))
                                        ]
 
-      ETyped e t    -> wrap n 0 (ppPrec 2 e <+> text ":" <+> pp t)
+      ETyped e t    -> wrap n 0 (ppPrec 2 e <+> text ":" </> pp t)
 
       EWhere  e ds  -> wrap n 0 $ align $ vsep
                          [ pp e
@@ -1479,9 +1479,9 @@ instance PPName name => PP (Type name) where
   ppPrec n ty =
     case ty of
       TWild          -> text "_"
-      TTuple ts      -> parens $ commaSep $ map pp ts
+      TTuple ts      -> ppTuple $ map pp ts
       TTyApp fs      -> braces $ commaSep $ map (ppNamed " = ") fs
-      TRecord fs     -> braces $ commaSep $ map (ppNamed' ":") (displayFields fs)
+      TRecord fs     -> ppRecord $ map (ppNamed' ":") (displayFields fs)
       TBit           -> text "Bit"
       TNum x         -> integer x
       TChar x        -> text (show x)

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -1183,7 +1183,7 @@ instance PP (WithNames Type) where
       TNominal nt ts -> optParens (prec > 3)
                                   (fsep (pp (ntName nt) : map (go 5) ts))
       TRec fs -> ppRecord
-                    [ pp l <+> text ":" <+> go 0 t | (l,t) <- displayFields fs ]
+                    [ nest 1 (pp l <+> text ":" </> go 0 t) | (l,t) <- displayFields fs ]
 
       _ | Just tinf <- isTInfix ty0 -> optParens (prec > 2)
                                      $ ppInfix 2 isTInfix tinf


### PR DESCRIPTION
Printers for parser AST and type-checked AST are now more consistent, keeping field names vertically aligned.

Fixes #2031.