### PR TITLE
Add expansive test case for floating-point properties

### DIFF
--- a/tests/regression/FloatPropertiesGeneric.cry
+++ b/tests/regression/FloatPropertiesGeneric.cry
@@ -1,0 +1,840 @@
+// Various properties about floating-point operations. Naming conventions:
+//
+// - prop_*: This property should hold for all inputs, and an SMT solver can
+//   prove it within a reasonable amount of time.
+// - check_*: This property should hold for all inputs, but an SMT solver
+//   cannot prove it within a reasonable amount of time.
+// - counterexample_*: This property does not hold for all inputs.
+module FloatPropertiesGeneric where
+
+import Float
+
+///// Helpers
+
+// `True` if negative, `False` if positive
+fpSign : {e, p} (ValidFloat e p, p >= 1) => Float e p -> Bit
+fpSign x = head (fpToBits x)
+
+fpExponent : {e, p} (ValidFloat e p, p >= 1) => Float e p -> [e]
+fpExponent x = take`{e} (drop`{1} (fpToBits x))
+
+fpSignificand : {e, p} (ValidFloat e p, p >= 1) => Float e p -> [p - 1]
+fpSignificand x = drop`{1 + e} (fpToBits x)
+
+fpIsPos : {e, p} ValidFloat e p => Float e p -> Bit
+fpIsPos x = ~ (fpIsNeg x)
+
+///// fpNaN
+
+prop_fpNaNIsNaN : {e, p} ValidFloat e p => Bit
+prop_fpNaNIsNaN = fpIsNaN (fpNaN`{e, p})
+
+prop_fpNaNIsNotInf : {e, p} ValidFloat e p => Bit
+prop_fpNaNIsNotInf = ~ (fpIsInf (fpNaN`{e, p}))
+
+prop_fpNaNIsNotZero : {e, p} ValidFloat e p => Bit
+prop_fpNaNIsNotZero = ~ (fpIsZero (fpNaN`{e, p}))
+
+// Cryptol chooses to represent NaN as a positive value.
+prop_fpNaNIsPos : {e, p} ValidFloat e p => Bit
+prop_fpNaNIsPos = fpIsPos (fpNaN`{e, p})
+
+prop_fpNaNIsNotNormal : {e, p} ValidFloat e p => Bit
+prop_fpNaNIsNotNormal = ~ (fpIsNormal (fpNaN`{e, p}))
+
+prop_fpNaNIsNotSubnormal : {e, p} ValidFloat e p => Bit
+prop_fpNaNIsNotSubnormal = ~ (fpIsSubnormal (fpNaN`{e, p}))
+
+// Cryptol chooses to represent NaN as quiet with no info:
+prop_fpNaNIsQuiet : {e, p} (ValidFloat e p, p >= 2) => Bit
+prop_fpNaNIsQuiet = fpSignificand (fpNaN`{e, p}) == (0b1 # 0)
+
+///// fpPosInf
+
+prop_fpPosInfIsPos : {e, p} ValidFloat e p => Bit
+prop_fpPosInfIsPos = fpIsPos (fpPosInf`{e, p})
+
+prop_fpPosInfIsInf : {e, p} ValidFloat e p => Bit
+prop_fpPosInfIsInf = fpIsInf (fpPosInf`{e, p})
+
+prop_fpPosInfIsNotZero : {e, p} ValidFloat e p => Bit
+prop_fpPosInfIsNotZero = ~ (fpIsZero (fpPosInf`{e, p}))
+
+prop_fpPosInfIsNotNaN : {e, p} ValidFloat e p => Bit
+prop_fpPosInfIsNotNaN = ~ (fpIsNaN (fpPosInf`{e, p}))
+
+prop_fpPosInfIsNotNormal : {e, p} ValidFloat e p => Bit
+prop_fpPosInfIsNotNormal = ~ (fpIsNormal (fpPosInf`{e, p}))
+
+prop_fpPosInfIsNotSubnormal : {e, p} ValidFloat e p => Bit
+prop_fpPosInfIsNotSubnormal = ~ (fpIsSubnormal (fpPosInf`{e, p}))
+
+///// fpNegInf
+
+prop_fpNegInfIsNeg : {e, p} ValidFloat e p => Bit
+prop_fpNegInfIsNeg = fpIsNeg (fpNegInf`{e, p})
+
+prop_fpNegInfIsInf : {e, p} ValidFloat e p => Bit
+prop_fpNegInfIsInf = fpIsInf (fpNegInf`{e, p})
+
+prop_fpNegInfIsNotZero : {e, p} ValidFloat e p => Bit
+prop_fpNegInfIsNotZero = ~ (fpIsZero (fpNegInf`{e, p}))
+
+prop_fpNegInfIsNotNaN : {e, p} ValidFloat e p => Bit
+prop_fpNegInfIsNotNaN = ~ (fpIsNaN (fpNegInf`{e, p}))
+
+prop_fpNegInfIsNotNormal : {e, p} ValidFloat e p => Bit
+prop_fpNegInfIsNotNormal = ~ (fpIsNormal (fpNegInf`{e, p}))
+
+prop_fpNegInfIsNotSubnormal : {e, p} ValidFloat e p => Bit
+prop_fpNegInfIsNotSubnormal = ~ (fpIsSubnormal (fpNegInf`{e, p}))
+
+///// fpPosZero
+
+prop_fpPosZeroIsPos : {e, p} ValidFloat e p => Bit
+prop_fpPosZeroIsPos = fpIsPos (fpPosZero`{e, p})
+
+prop_fpPosZeroIsZero : {e, p} ValidFloat e p => Bit
+prop_fpPosZeroIsZero = fpIsZero (fpPosZero`{e, p})
+
+prop_fpPosZeroIsNotNaN : {e, p} ValidFloat e p => Bit
+prop_fpPosZeroIsNotNaN = ~ (fpIsNaN (fpPosZero`{e, p}))
+
+prop_fpPosZeroIsNotInf : {e, p} ValidFloat e p => Bit
+prop_fpPosZeroIsNotInf = ~ (fpIsInf (fpPosZero`{e, p}))
+
+prop_fpPosZeroIsNotNormal : {e, p} ValidFloat e p => Bit
+prop_fpPosZeroIsNotNormal = ~ (fpIsNormal (fpPosZero`{e, p}))
+
+prop_fpPosZeroIsNotSubnormal : {e, p} ValidFloat e p => Bit
+prop_fpPosZeroIsNotSubnormal = ~ (fpIsSubnormal (fpPosZero`{e, p}))
+
+///// fpNegZero
+
+prop_fpNegZeroIsNeg : {e, p} ValidFloat e p => Bit
+prop_fpNegZeroIsNeg = fpIsNeg (fpNegZero`{e, p})
+
+prop_fpNegZeroIsZero : {e, p} ValidFloat e p => Bit
+prop_fpNegZeroIsZero = fpIsZero (fpNegZero`{e, p})
+
+prop_fpNegZeroIsNotNaN : {e, p} ValidFloat e p => Bit
+prop_fpNegZeroIsNotNaN = ~ (fpIsNaN (fpNegZero`{e, p}))
+
+prop_fpNegZeroIsNotInf : {e, p} ValidFloat e p => Bit
+prop_fpNegZeroIsNotInf = ~ (fpIsInf (fpNegZero`{e, p}))
+
+prop_fpNegZeroIsNotNormal : {e, p} ValidFloat e p => Bit
+prop_fpNegZeroIsNotNormal = ~ (fpIsNormal (fpNegZero`{e, p}))
+
+prop_fpNegZeroIsNotSubnormal : {e, p} ValidFloat e p => Bit
+prop_fpNegZeroIsNotSubnormal = ~ (fpIsSubnormal (fpNegZero`{e, p}))
+
+///// fpFromBits and fpToBits
+
+prop_fpFromToBits : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpFromToBits x = fpFromBits (fpToBits x) =.= x
+
+// Special case for NaN: there are multiple bit patterns for NaN values, but
+// there is only one distinguished NaN value for the Float type.
+prop_fpToFromBits : {e, p} ValidFloat e p => [e + p] -> Bit
+prop_fpToFromBits bits = (fpToBits x == bits) \/ fpIsNaN x
+  where
+    x : Float e p
+    x = fpFromBits bits
+
+// Special case for NaN: there are multiple bit patterns for NaN values, but
+// there is only one distinguished NaN value for the Float type.
+prop_fpFromBitsCorrect :
+  {e, p} (ValidFloat e p, p >= 2) => Bit -> [e] -> [p - 1] -> Bit
+prop_fpFromBitsCorrect sign exponent significand =
+  ((fpSign x == sign) /\
+   (fpExponent x == exponent) /\
+   (fpSignificand x == significand)) \/ fpIsNaN x
+   where
+      x : Float e p
+      x = fpFromBits ([sign] # exponent # significand)
+
+// Special case for NaN: there are multiple bit patterns for NaN values, but
+// there is only one distinguished NaN value for the Float type.
+prop_fpFromBitsEq : {e, p} ValidFloat e p => [e + p] -> [e + p] -> Bit
+prop_fpFromBitsEq xbits ybits =
+  ~ (fpIsNaN x \/ fpIsNaN y) ==> ((xbits == ybits) == (x =.= y))
+    where
+      x : Float e p
+      x = fpFromBits xbits
+
+      y : Float e p
+      y = fpFromBits ybits
+
+prop_fpToBitsCorrect : {e, p} (ValidFloat e p, p >= 1) => Float e p -> Bit
+prop_fpToBitsCorrect x =
+  fpToBits x == ([fpSign x] # fpExponent x # fpSignificand x)
+
+prop_fpToBitsEq : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpToBitsEq x y = (x =.= y) == (fpToBits x == fpToBits y)
+
+///// (=.=)
+
+prop_fpLogicalEqNaN : {e, p} ValidFloat e p => Bit
+prop_fpLogicalEqNaN = fpNaN`{e, p} =.= fpNaN
+
+prop_fpLogicalEqZero : {e, p} ValidFloat e p => Bit
+prop_fpLogicalEqZero = ~ (fpNegZero`{e, p} =.= fpPosZero)
+
+prop_fpLogicalEqToIeeeEq :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpLogicalEqToIeeeEq x y =
+  (x =.= y /\ ~ (fpIsNaN x) /\ ~ (fpIsNaN y))
+    ==> (x == y)
+
+prop_fpIeeeEqToLogicalEq :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpIeeeEqToLogicalEq x y =
+  ((x == y /\ (fpIsNeg x == fpIsNeg y)) \/ (fpIsNaN x /\ fpIsNaN y))
+    ==> (x =.= y)
+
+prop_fpLogicalEqReflexive : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpLogicalEqReflexive x = x =.= x
+
+prop_fpLogicalEqSymmetric :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpLogicalEqSymmetric x y = (x =.= y) ==> (y =.= x)
+
+prop_fpLogicalEqTransitive :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Float e p -> Bit
+prop_fpLogicalEqTransitive x y z = (x =.= y /\ y =.= z) ==> (x =.= z)
+
+///// fpIsNeg
+
+prop_fpIsNegSign : {e, p} (ValidFloat e p, p >= 1) => Float e p -> Bit
+prop_fpIsNegSign x = fpIsNeg x == fpSign x
+
+///// fpIsNormal
+
+prop_fpIsNormalCorrect : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpIsNormalCorrect x =
+  fpIsNormal x ==
+    (~ (fpIsNaN x) /\ ~ (fpIsInf x) /\ ~ (fpIsZero x) /\ ~ (fpIsSubnormal x))
+
+///// fpAdd
+
+prop_fpAddNaN :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddNaN m x y = (fpIsNaN x \/ fpIsNaN y) ==> fpIsNaN (fpAdd m x y)
+
+prop_fpAddPosNegInf : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpAddPosNegInf m = fpAdd m fpPosInf`{e, p} fpNegInf =.= fpNaN
+
+prop_fpAddNegPosInf : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpAddNegPosInf m = fpAdd m fpNegInf`{e, p} fpPosInf =.= fpNaN
+
+// Special cases:
+//
+// * NaN: inf + NaN =.= NaN (not inf)
+// * Infinity values: inf + (-inf) =.= NaN (not inf)
+prop_fpAddLeftInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddLeftInf m x y =
+  fpIsInf x /\ ~ (fpIsNaN y \/ (x =.= -y)) ==>
+    (fpAdd m x y =.= if fpIsNeg x then fpNegInf else fpPosInf)
+
+// Special cases:
+//
+// * NaN: NaN + inf =.= NaN (not inf)
+// * Infinity values: (-inf) + inf =.= NaN (not inf)
+prop_fpAddRightInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddRightInf m x y =
+  fpIsInf y /\ ~ (fpIsNaN x \/ (x =.= -y)) ==>
+    (fpAdd m x y =.= if fpIsNeg y then fpNegInf else fpPosInf)
+
+prop_fpAddLeftIdentity :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddLeftIdentity m x z =
+  ~ (fpIsNaN x) /\ fpIsZero z ==>
+    fpAdd m x z == x
+
+prop_fpAddRightIdentity :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddRightIdentity m x z =
+  ~ (fpIsNaN x) /\ fpIsZero z ==>
+    fpAdd m z x == x
+
+prop_fpAddCommutative :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddCommutative m x y = fpAdd m x y =.= fpAdd m y x
+
+// Special cases:
+//
+// * Infinite values, e.g., `inf + (-inf) =.= NaN` (not 0)
+// * NaN values, since `NaN + (-NaN) =.= NaN` (not 0)
+prop_fpAddInverse :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpAddInverse m x =
+  (~ (fpIsInf x) /\ ~ (fpIsNaN x)) ==> fpIsZero (fpAdd m x (- x))
+
+counterexample_fpAddAssociative :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+counterexample_fpAddAssociative m x y z =
+  ~ (fpAdd m x (fpAdd m y z) =.= fpAdd m (fpAdd m x y) z)
+
+///// fpSub
+
+prop_fpSubNaN :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubNaN m x y = (fpIsNaN x \/ fpIsNaN y) ==> fpIsNaN (fpSub m x y)
+
+prop_fpSubPosPosInf : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpSubPosPosInf m = fpSub m fpPosInf`{e, p} fpPosInf =.= fpNaN
+
+prop_fpSubNegNegInf : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpSubNegNegInf m = fpSub m fpNegInf`{e, p} fpNegInf =.= fpNaN
+
+// Special cases:
+//
+// * NaN: inf - NaN =.= NaN (not inf)
+// * Infinity values: inf - inf =.= NaN (not inf)
+prop_fpSubLeftInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubLeftInf m x y =
+  fpIsInf x /\ ~ (fpIsNaN y \/ (x =.= y)) ==>
+    (fpSub m x y =.= if fpIsNeg x then fpNegInf else fpPosInf)
+
+// Special cases:
+//
+// * NaN: NaN - inf =.= NaN (not inf)
+// * Infinity values: inf - inf =.= NaN (not inf)
+prop_fpSubRightInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubRightInf m x y =
+  fpIsInf y /\ ~ (fpIsNaN x \/ (x =.= y)) ==>
+    (fpSub m x y =.= if fpIsNeg y then fpPosInf else fpNegInf)
+
+prop_fpSubZeroLeft :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubZeroLeft m x z =
+
+  ~ (fpIsNaN x) /\ fpIsZero z ==>
+    fpSub m z x == -x
+
+prop_fpSubZeroRight :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubZeroRight m x z =
+  ~ (fpIsNaN x) /\ fpIsZero z ==>
+    fpSub m x z == x
+
+prop_fpSubPosPos :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubPosPos m x y =
+  (fpIsPos x /\ fpIsPos y) ==>
+    (((x > y) ==> fpIsPos s) /\ ((y > x) ==> fpIsNeg s))
+  where
+    s = fpSub m x y
+
+prop_fpSubNegAdd :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubNegAdd m x y = fpSub m x (-y) =.= fpAdd m x y
+
+prop_fpAddNegSub :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpAddNegSub m x y = fpAdd m x (-y) =.= fpSub m x y
+
+// Special case for equal arguments, since `(x - x) =.= +0`, but
+// `-(x - x) =.= -0`.
+prop_fpSubAnticommutative :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpSubAnticommutative m x y =
+  ~ (x == x) ==> (fpSub m x y =.= -(fpSub m y x))
+
+// Special cases:
+//
+// * Infinite values, e.g., `inf - inf =.= NaN` (not 0)
+// * NaN values, since `NaN - NaN =.= NaN` (not 0)
+prop_fpSubSelfInverse :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpSubSelfInverse m x =
+  (~ (fpIsInf x) /\ ~ (fpIsNaN x)) ==> fpIsZero (fpSub m x x)
+
+///// fpMul
+
+prop_fpMulNaN :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulNaN m x y =
+  (fpIsNaN x \/ fpIsNaN y) ==> fpIsNaN (fpMul m x y)
+
+prop_fpMulZeroInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulZeroInf m x y =
+  (fpIsZero x /\ fpIsInf y) ==> fpIsNaN (fpMul m x y)
+
+
+prop_fpMulInfZero :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulInfZero m x y =
+  (fpIsInf x /\ fpIsZero y) ==> fpIsNaN (fpMul m x y)
+
+prop_fpMulLeftInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulLeftInf m x y =
+  (fpIsInf x /\ ~ (fpIsZero y \/ fpIsNaN y)) ==> fpIsInf (fpMul m x y)
+
+prop_fpMulRightInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulRightInf m x y =
+  (~ (fpIsZero x \/ fpIsNaN x) /\ fpIsInf y) ==> fpIsInf (fpMul m x y)
+
+prop_fpMulLeftIdentity :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpMulLeftIdentity m y = fpMul m 1.0 y =.= y
+
+prop_fpMulRightIdentity :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpMulRightIdentity m x = fpMul m x 1.0 =.= x
+
+// Special cases:
+//
+// * NaN: NaN * 0 =.= NaN (not 0)
+// * Infinite values: inf * 0 =.= NaN (not 0)
+prop_fpMulLeftPosZero :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpMulLeftPosZero m y =
+  ~ (fpIsNaN y \/ fpIsInf y) ==>
+    (fpMul m fpPosZero y =.= if fpIsNeg y then fpNegZero else fpPosZero)
+
+// Special cases:
+//
+// * NaN: 0 * NaN =.= NaN (not 0)
+// * Infinite values: 0 * inf =.= NaN (not 0)
+prop_fpMulRightPosZero :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpMulRightPosZero m x =
+  ~ (fpIsNaN x \/ fpIsInf x) ==>
+    (fpMul m x fpPosZero =.= if fpIsNeg x then fpNegZero else fpPosZero)
+
+// Special cases:
+//
+// * NaN: NaN * 0 =.= NaN (not 0)
+// * Infinite values: inf * 0 =.= NaN (not 0)
+prop_fpMulLeftNegZero :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpMulLeftNegZero m y =
+  ~ (fpIsNaN y \/ fpIsInf y) ==>
+    (fpMul m fpNegZero y =.= if fpIsNeg y then fpPosZero else fpNegZero)
+
+// Special cases:
+//
+// * NaN: 0 * NaN =.= NaN (not 0)
+// * Infinite values: 0 * inf =.= NaN (not 0)
+prop_fpMulRightNegZero :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpMulRightNegZero m x =
+  ~ (fpIsNaN x \/ fpIsInf x) ==>
+    (fpMul m x fpNegZero =.= if fpIsNeg x then fpPosZero else fpNegZero)
+
+prop_fpMulNegNeg :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulNegNeg m x y = (fpIsNeg x /\ fpIsNeg y) ==> fpIsPos (fpMul m x y)
+
+prop_fpMulPosPos :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulPosPos m x y = (fpIsPos x /\ fpIsPos y) ==> fpIsPos (fpMul m x y)
+
+// Special cases:
+//
+// * Infinite/zero: `-inf * 0 =.= -0 * inf =.= NaN`, and NaN is defined to be
+//   positive.
+// * NaN: `-x * NaN =.= NaN`, and NaN is defined to be positive.
+prop_fpMulNegPos :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulNegPos m x y =
+  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y) \/ fpIsNaN y) ==>
+    (fpIsNeg x /\ fpIsPos y) ==> fpIsNeg (fpMul m x y)
+
+// Special cases:
+//
+// * Infinite/zero: `inf * -0 =.= 0 * -inf =.= NaN`, and NaN is defined to be
+//   positive.
+// * NaN: `NaN * -inf =.= NaN`, and NaN is defined to be positive.
+prop_fpMulPosNeg :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulPosNeg m x y =
+  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y) \/ fpIsNaN x) ==>
+    (fpIsPos x /\ fpIsNeg y) ==> fpIsNeg (fpMul m x y)
+
+prop_fpMulCommutative :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulCommutative m x y = fpMul m x y =.= fpMul m y x
+
+counterexample_fpMulAssociative :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+counterexample_fpMulAssociative m x y z =
+   ~ (fpMul m x (fpMul m y z) =.= fpMul m (fpMul m x y) z)
+
+counterexample_fpMulDistributive :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+counterexample_fpMulDistributive m x y z =
+  ~ (fpMul m x (fpAdd m y z) =.= fpAdd m (fpMul m x y) (fpMul m x z))
+
+///// fpDiv
+
+prop_fpDivNaN :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpDivNaN m x y =
+  (fpIsNaN x \/ fpIsNaN y) ==> fpIsNaN (fpDiv m x y)
+
+prop_fpDivInfInf :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpDivInfInf m x y =
+  (fpIsInf x /\ fpIsInf y) ==> fpIsNaN (fpDiv m x y)
+
+// Special cases:
+//
+// * Infinite values: inf / inf =.= NaN (not inf)
+// * NaN: inf / NaN =.= NaN (not inf)
+prop_fpDivPosInfDividend :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivPosInfDividend m x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    fpDiv m fpPosInf x =.= if fpIsNeg x then fpNegInf else fpPosInf
+
+// Special cases:
+//
+// * Infinite values: -inf / inf =.= NaN (not -inf)
+// * NaN: -inf / NaN =.= NaN (not -inf)
+prop_fpDivNegInfDividend :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivNegInfDividend m x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    fpDiv m fpNegInf x =.= if fpIsNeg x then fpPosInf else fpNegInf
+
+// Special cases:
+//
+// * Infinite values: inf / inf =.= NaN (not 0)
+// * NaN: NaN / inf =.= NaN (not 0)
+prop_fpDivPosInfDivisor :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivPosInfDivisor m x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    fpDiv m x fpPosInf =.= if fpIsNeg x then fpNegZero else fpPosZero
+
+// Special cases:
+//
+// * Infinite values: inf / -inf =.= NaN (not -0)
+// * NaN: NaN / -inf =.= NaN (not -0)
+prop_fpDivNegInfDivisor :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivNegInfDivisor m x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    fpDiv m x fpNegInf =.= if fpIsNeg x then fpPosZero else fpNegZero
+
+// Special cases:
+//
+// * Zero: 0 / 0 =.= NaN (not 0)
+// * NaN: 0 / NaN =.= NaN (not 0)
+prop_fpDivPosZeroDividend :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivPosZeroDividend m x =
+  ~ (fpIsZero x \/ fpIsNaN x) ==>
+    fpDiv m fpPosZero x =.= if fpIsNeg x then fpNegZero else fpPosZero
+
+// Special cases:
+//
+// * Zero: -0 / 0 =.= NaN (not -0)
+// * NaN: -0 / NaN =.= NaN (not -0)
+prop_fpDivNegZeroDividend :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivNegZeroDividend m x =
+  ~ (fpIsZero x \/ fpIsNaN x) ==>
+    fpDiv m fpNegZero x =.= if fpIsNeg x then fpPosZero else fpNegZero
+
+// Special cases:
+//
+// * Zero: 0 / 0 =.= NaN (not inf)
+// * NaN: NaN / 0 =.= NaN (not inf)
+prop_fpDivPosZeroDivisor :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivPosZeroDivisor m x =
+  ~ (fpIsZero x \/ fpIsNaN x) ==>
+    fpDiv m x fpPosZero =.= if fpIsNeg x then fpNegInf else fpPosInf
+
+// Special cases:
+//
+// * Zero: 0 / -0 =.= NaN (not -inf)
+// * NaN: NaN / -0 =.= NaN (not -inf)
+prop_fpDivNegZeroDivisor :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivNegZeroDivisor m x =
+  ~ (fpIsZero x \/ fpIsNaN x) ==>
+    fpDiv m x fpNegZero =.= if fpIsNeg x then fpPosInf else fpNegInf
+
+prop_fpDivOne :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivOne m x = fpDiv m x 1.0 =.= x
+
+// Special cases for zero, infinite, and NaN values, where `x / x =.= NaN`
+// (not 1).
+prop_fpDivInverse :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpDivInverse m x =
+  ~ (fpIsZero x \/ fpIsInf x \/ fpIsNaN x) ==> (fpDiv m x x =.= 1.0)
+
+counterexample_fpDivDistributive :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+counterexample_fpDivDistributive m x y z =
+  ~ (fpDiv m (fpAdd m x y) z =.= fpAdd m (fpDiv m x z) (fpDiv m y z))
+
+///// fpFMA
+
+prop_fpFMACommutative :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+prop_fpFMACommutative m x y z = fpFMA m x y z =.= fpFMA m y x z
+
+counterexample_fpFMAAssociative :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+counterexample_fpFMAAssociative m x y z =
+  ~ (fpFMA m x y z =.= fpAdd m (fpMul m x y) z)
+
+counterexample_fpFMAExpand :
+  {e, p} ValidFloat e p => RoundingMode ->
+  Float e p -> Float e p -> Float e p -> Bit
+counterexample_fpFMAExpand m x y z =
+  ~ (fpFMA m x y z =.= fpAdd m (fpMul m x y) z)
+
+///// fpAbs
+
+prop_fpAbsZero : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpAbsZero x = fpIsZero x ==> (fpAbs x =.= fpPosZero)
+
+prop_fpAbsPos : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpAbsPos x = fpIsPos x ==> (fpAbs x =.= x)
+
+prop_fpAbsNeg : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpAbsNeg x = fpIsNeg x ==> (fpAbs x =.= -x)
+
+prop_fpAbsNaN : {e, p} ValidFloat e p => Bit
+prop_fpAbsNaN = fpAbs (fpNaN`{e, p}) =.= fpNaN
+
+
+prop_fpAbsInf : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpAbsInf x = fpIsInf x ==> (fpAbs x =.= fpPosInf)
+
+///// fpSqrt
+
+prop_fpSqrtNaN : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpSqrtNaN m = fpIsNaN (fpSqrt m fpNaN`{e, p})
+
+prop_fpSqrtPosInf : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpSqrtPosInf m = fpSqrt m fpPosInf`{e, p} =.= fpPosInf
+
+prop_fpSqrtPosZero : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpSqrtPosZero m = fpSqrt m fpPosZero`{e, p} =.= fpPosZero
+
+prop_fpSqrtNegZero : {e, p} ValidFloat e p => RoundingMode -> Bit
+prop_fpSqrtNegZero m = fpSqrt m fpNegZero`{e,p} =.= fpNegZero
+
+// Normally, the square root of any negative value results in a NaN, but we
+// must include a special case for `sqrt(-0) =.= -0`.
+prop_fpSqrtNeg : {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+prop_fpSqrtNeg m x = fpIsNeg x ==> (fpIsNaN (fpSqrt m x) \/ (x =.= fpNegZero))
+
+counterexample_fpSqrtMul :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+counterexample_fpSqrtMul m x y =
+  ~ ((fpIsNeg x == fpIsNeg y)
+      ==> fpSqrt m (fpMul m x y) =.= fpMul m (fpSqrt m x) (fpSqrt m y))
+
+counterexample_fpSqrtDiv :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+counterexample_fpSqrtDiv m x y =
+  ~ ((fpIsNeg x == fpIsNeg y)
+      ==> fpSqrt m (fpDiv m x y) =.= fpDiv m (fpSqrt m x) (fpSqrt m y))
+
+counterexample_fpSqrtSquare :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+counterexample_fpSqrtSquare m x =
+  ~ (fpIsPos x ==> fpSqrt m (fpMul m x x) =.= x)
+
+counterexample_fpSqrtSquared :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+counterexample_fpSqrtSquared m x =
+  ~ (fpIsPos x ==> (fpMul m root root =.= x))
+    where
+      root = fpSqrt m x
+
+///// fpToRational and fpFromRational
+
+check_fpFromToRational :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Bit
+check_fpFromToRational m x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    fpFromRational m (fpToRational x) == x
+
+///// Eq
+
+prop_fpEqNaN : {e, p} ValidFloat e p => Bit
+prop_fpEqNaN = fpNaN`{e, p} != fpNaN
+
+prop_fpEqZero : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpEqZero x y = (fpIsZero x /\ fpIsZero y) ==> (x == y)
+
+prop_fpEqReflexive : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpEqReflexive x = ~ (fpIsNaN x) ==> (x == x)
+
+prop_fpEqSymmetric : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpEqSymmetric x y = (x == y) ==> (y == x)
+
+prop_fpEqTransitive :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Float e p -> Bit
+prop_fpEqTransitive x y z = (x == y /\ y == z) ==> (x == z)
+
+///// Cmp
+
+prop_fpCmpNaN : {e, p} ValidFloat e p => Bit
+prop_fpCmpNaN =
+  ~ ((x < x) \/ (x <= x) \/ (x > x) \/ (x >= x))
+    where
+      x : Float e p
+      x = fpNaN
+
+prop_fpCmpZero : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpCmpZero x y =
+  (fpIsZero x /\ fpIsZero y) ==>
+    (((x <= y) /\ (x >= y)) /\ ~((x < x) \/ (x > x)))
+
+prop_fpCmpLtIrreflexive : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpCmpLtIrreflexive x = ~ (x < x)
+
+prop_fpCmpLtAsymmetric : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpCmpLtAsymmetric x y = (x < y) ==> ~ (y < x)
+
+prop_fpCmpLtTransitive :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Float e p -> Bit
+prop_fpCmpLtTransitive x y z = (x < y /\ y < z) ==> (x < z)
+
+prop_fpCmpLeReflexive : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpCmpLeReflexive x = ~ (fpIsNaN x) ==> (x <= x)
+
+prop_fpCmpLeAntisymmetric :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpCmpLeAntisymmetric x y =
+  (x <= y /\ y <= x) ==> (x == y)
+
+prop_fpCmpLeTransitive :
+  {e, p} ValidFloat e p => Float e p -> Float e p -> Float e p -> Bit
+prop_fpCmpLeTransitive x y z =
+  (x <= y /\ y <= z) ==> (x <= z)
+
+prop_fpCmpLeTotal : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpCmpLeTotal x y = ~ (fpIsNaN x \/ fpIsNaN y) ==> ((x <= y) \/ (y <= x))
+
+prop_fpCmpGtCorrect : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpCmpGtCorrect x y = ~ (fpIsNaN x \/ fpIsNaN y) ==> ((x > y) == ~ (x <= y))
+
+prop_fpCmpGeCorrect : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpCmpGeCorrect x y = ~ (fpIsNaN x \/ fpIsNaN y) ==> (x <= y) == ~ (x > y)
+
+///// Zero
+
+prop_fpZero : {e, p} ValidFloat e p => Bit
+prop_fpZero = zero =.= fpPosZero`{e, p}
+
+///// Ring
+
+prop_fpRingAdd : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpRingAdd x y = (x + y) =.= fpAdd rne x y
+
+prop_fpRingSub : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpRingSub x y = (x - y) =.= fpSub rne x y
+
+prop_fpRingMul : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpRingMul x y = (x * y) =.= fpMul rne x y
+
+prop_fpRingNegate : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpRingNegate x = negate x =.= fpSub rne (-0.0) x
+
+///// Field
+
+prop_fpFieldDiv : {e, p} ValidFloat e p => Float e p -> Float e p -> Bit
+prop_fpFieldDiv x y = (x /. y) =.= fpDiv rne x y
+
+prop_fpFieldRecip : {e, p} ValidFloat e p => Float e p -> Bit
+prop_fpFieldRecip x = recip x =.= fpDiv rne 1.0 x
+
+///// Round
+
+check_fpRoundFloorCeiling : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundFloorCeiling x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    floor x == -(ceiling (-x))
+
+check_fpRoundCeilingFloor : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundCeilingFloor x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    ceiling x == -(floor (-x))
+
+check_fpRoundFloorCorrect : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundFloorCorrect x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    (f <= x' /\ x' < f + 1)
+  where
+    x' : Rational
+    x' = fpToRational x
+
+    f : Rational
+    f = ratio (floor x) 1
+
+check_fpRoundCeilingCorrect : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundCeilingCorrect x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    (x' <= c /\ c < x' + 1)
+  where
+    x' : Rational
+    x' = fpToRational x
+
+    c : Rational
+    c = ratio (ceiling x) 1
+
+check_fpRoundTruncCeilingFloor : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundTruncCeilingFloor x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    trunc x == if fpIsNeg x then ceiling x else floor x
+
+check_fpRoundTruncCorrect : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundTruncCorrect x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    if fpIsNeg x
+      then (x' <= t /\ t < x' + 1)
+      else (t <= x' /\ x' < t + 1)
+  where
+    x' : Rational
+    x' = fpToRational x
+
+    t : Rational
+    t = ratio (trunc x) 1
+
+check_fpRoundAwayTrunc : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundAwayTrunc x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    roundAway x == if fpIsNeg x then trunc (x' - 0.5) else trunc (x' + 0.5)
+  where
+    x' : Rational
+    x' = fpToRational x
+
+check_fpRoundAwayCorrect : {e, p} ValidFloat e p => Float e p -> Bit
+check_fpRoundAwayCorrect x =
+  ~ (fpIsInf x \/ fpIsNaN x) ==>
+    if fpIsNeg x
+      then (2*x' - 1 <= 2*r) /\ (2*r <  2*x' + 1)
+      else (2*x' - 1 <  2*r) /\ (2*r <= 2*x' + 1)
+  where
+    x' : Rational
+    x' = fpToRational x
+
+    r : Rational
+    r = ratio (roundAway x) 1

--- a/tests/regression/GenFloatProperties.hs
+++ b/tests/regression/GenFloatProperties.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall #-}
+-- | Generate a Cryptol script that proves, checks, or disproves various
+-- Cryptol properties about floating-point operations.
+--
+-- Note that all of these properties are parameterized over arbitrary exponents
+-- and precisions, and many of the properties are also parameterized over
+-- arbitrary rounding modes, so this will generate code which instantiates each
+-- property at a particular float size and at all supported rounding modes.
+module Main (main) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+data ResultType
+  = ProveProperty
+    -- ^ Something which should hold for all inputs, and an SMT solver is able
+    -- to prove it.
+  | CheckProperty
+    -- ^ Something which should hold for all inputs, but most SMT solvers
+    -- cannot prove it (at least, not without taking an extraordinarily long
+    -- time). We resort to spot-checking these properties on specific inputs.
+  | Counterexample
+    -- ^ Something which does not hold for at least one input.
+
+data Result = Result
+  { resultName :: !Text
+  , resultType :: !ResultType
+  , resultHasRoundingMode :: !Bool
+  }
+
+propertiesFile :: FilePath
+propertiesFile = "FloatPropertiesGeneric.cry"
+
+icryFile :: FilePath
+icryFile = "float_properties.icry"
+
+scriptFile :: FilePath
+scriptFile = "GenFloatProperties.hs"
+
+scrapeResults :: IO [Result]
+scrapeResults = do
+  ls0 <- T.lines <$> T.readFile propertiesFile
+  let ls1 = zip ls0 (drop 1 (cycle ls0))
+  let ls2 =
+        filter
+          (\(l, _) ->
+            any (`T.isPrefixOf` l) ["prop_", "check_", "counterexample_"] &&
+            (" :" `T.isInfixOf` l))
+          ls1
+  pure $
+    map
+      (\(l1, l2) ->
+        let name = head (T.splitOn " " l1) in
+        Result
+          { resultName =
+              name
+          , resultType =
+              if "prop_" `T.isPrefixOf` l1 then ProveProperty
+              else if "check_" `T.isPrefixOf` l1 then CheckProperty
+              else if "counterexample_" `T.isPrefixOf` l1 then Counterexample
+              else error $ "Unsupported result name: " ++ T.unpack name
+          , resultHasRoundingMode =
+              any ("RoundingMode" `T.isInfixOf`) [l1, l2]
+          })
+      ls2
+
+resultCommandLines :: Result -> [Text]
+resultCommandLines r =
+  [ "\"" <> action <> " " <> resultName r <> "...\""
+  | let action = case resultType r of
+                   ProveProperty -> "Proving"
+                   CheckProperty -> "Checking"
+                   Counterexample -> "Disproving"
+  ] ++
+  if resultHasRoundingMode r
+    then [basicCommand <> " " <> rm | rm <- roundingModes]
+    else [basicCommand]
+  where
+    -- We arbitrarily instantiate each property at Float32 (`{8, 24}), but
+    -- these properties should hold for any Float size.
+    basicCommand :: Text
+    basicCommand = command <> " " <> resultName r <> "`{8, 24}"
+      where
+        command = case resultType r of
+                    ProveProperty -> ":prove"
+                    CheckProperty -> ":check"
+                    Counterexample -> ":sat"
+
+    roundingModes :: [Text]
+    roundingModes = ["rne", "rna", "rtp", "rtn", "rtz"]
+
+main :: IO ()
+main = do
+  results <- scrapeResults
+  T.putStrLn $ T.unlines $
+    [ "// THIS IS AUTO-GENERATED"
+    , "//"
+    , "// Rather than modifying this file, please modify the script which"
+    , "// generated it (" <> T.pack scriptFile <> ") and regenerate it using:"
+    , "//"
+    , "//   runghc " <> T.pack scriptFile <> " > " <> T.pack icryFile
+    , ""
+    , ":load " <> T.pack propertiesFile
+    , ":set prover=w4-bitwuzla" -- A reasonably fast solver for floating-point-related properties
+    , ":set ascii=on"
+    , ":set show-examples=no"
+    ] ++
+    concatMap resultCommandLines results

--- a/tests/regression/float_properties.icry
+++ b/tests/regression/float_properties.icry
@@ -1,0 +1,572 @@
+// THIS IS AUTO-GENERATED
+//
+// Rather than modifying this file, please modify the script which
+// generated it (GenFloatProperties.hs) and regenerate it using:
+//
+//   runghc GenFloatProperties.hs > float_properties.icry
+
+:load FloatPropertiesGeneric.cry
+:set prover=w4-bitwuzla
+:set ascii=on
+:set show-examples=no
+"Proving prop_fpNaNIsNaN..."
+:prove prop_fpNaNIsNaN`{8, 24}
+"Proving prop_fpNaNIsNotInf..."
+:prove prop_fpNaNIsNotInf`{8, 24}
+"Proving prop_fpNaNIsNotZero..."
+:prove prop_fpNaNIsNotZero`{8, 24}
+"Proving prop_fpNaNIsPos..."
+:prove prop_fpNaNIsPos`{8, 24}
+"Proving prop_fpNaNIsNotNormal..."
+:prove prop_fpNaNIsNotNormal`{8, 24}
+"Proving prop_fpNaNIsNotSubnormal..."
+:prove prop_fpNaNIsNotSubnormal`{8, 24}
+"Proving prop_fpNaNIsQuiet..."
+:prove prop_fpNaNIsQuiet`{8, 24}
+"Proving prop_fpPosInfIsPos..."
+:prove prop_fpPosInfIsPos`{8, 24}
+"Proving prop_fpPosInfIsInf..."
+:prove prop_fpPosInfIsInf`{8, 24}
+"Proving prop_fpPosInfIsNotZero..."
+:prove prop_fpPosInfIsNotZero`{8, 24}
+"Proving prop_fpPosInfIsNotNaN..."
+:prove prop_fpPosInfIsNotNaN`{8, 24}
+"Proving prop_fpPosInfIsNotNormal..."
+:prove prop_fpPosInfIsNotNormal`{8, 24}
+"Proving prop_fpPosInfIsNotSubnormal..."
+:prove prop_fpPosInfIsNotSubnormal`{8, 24}
+"Proving prop_fpNegInfIsNeg..."
+:prove prop_fpNegInfIsNeg`{8, 24}
+"Proving prop_fpNegInfIsInf..."
+:prove prop_fpNegInfIsInf`{8, 24}
+"Proving prop_fpNegInfIsNotZero..."
+:prove prop_fpNegInfIsNotZero`{8, 24}
+"Proving prop_fpNegInfIsNotNaN..."
+:prove prop_fpNegInfIsNotNaN`{8, 24}
+"Proving prop_fpNegInfIsNotNormal..."
+:prove prop_fpNegInfIsNotNormal`{8, 24}
+"Proving prop_fpNegInfIsNotSubnormal..."
+:prove prop_fpNegInfIsNotSubnormal`{8, 24}
+"Proving prop_fpPosZeroIsPos..."
+:prove prop_fpPosZeroIsPos`{8, 24}
+"Proving prop_fpPosZeroIsZero..."
+:prove prop_fpPosZeroIsZero`{8, 24}
+"Proving prop_fpPosZeroIsNotNaN..."
+:prove prop_fpPosZeroIsNotNaN`{8, 24}
+"Proving prop_fpPosZeroIsNotInf..."
+:prove prop_fpPosZeroIsNotInf`{8, 24}
+"Proving prop_fpPosZeroIsNotNormal..."
+:prove prop_fpPosZeroIsNotNormal`{8, 24}
+"Proving prop_fpPosZeroIsNotSubnormal..."
+:prove prop_fpPosZeroIsNotSubnormal`{8, 24}
+"Proving prop_fpNegZeroIsNeg..."
+:prove prop_fpNegZeroIsNeg`{8, 24}
+"Proving prop_fpNegZeroIsZero..."
+:prove prop_fpNegZeroIsZero`{8, 24}
+"Proving prop_fpNegZeroIsNotNaN..."
+:prove prop_fpNegZeroIsNotNaN`{8, 24}
+"Proving prop_fpNegZeroIsNotInf..."
+:prove prop_fpNegZeroIsNotInf`{8, 24}
+"Proving prop_fpNegZeroIsNotNormal..."
+:prove prop_fpNegZeroIsNotNormal`{8, 24}
+"Proving prop_fpNegZeroIsNotSubnormal..."
+:prove prop_fpNegZeroIsNotSubnormal`{8, 24}
+"Proving prop_fpFromToBits..."
+:prove prop_fpFromToBits`{8, 24}
+"Proving prop_fpToFromBits..."
+:prove prop_fpToFromBits`{8, 24}
+"Proving prop_fpFromBitsCorrect..."
+:prove prop_fpFromBitsCorrect`{8, 24}
+"Proving prop_fpFromBitsEq..."
+:prove prop_fpFromBitsEq`{8, 24}
+"Proving prop_fpToBitsCorrect..."
+:prove prop_fpToBitsCorrect`{8, 24}
+"Proving prop_fpToBitsEq..."
+:prove prop_fpToBitsEq`{8, 24}
+"Proving prop_fpLogicalEqNaN..."
+:prove prop_fpLogicalEqNaN`{8, 24}
+"Proving prop_fpLogicalEqZero..."
+:prove prop_fpLogicalEqZero`{8, 24}
+"Proving prop_fpLogicalEqToIeeeEq..."
+:prove prop_fpLogicalEqToIeeeEq`{8, 24}
+"Proving prop_fpIeeeEqToLogicalEq..."
+:prove prop_fpIeeeEqToLogicalEq`{8, 24}
+"Proving prop_fpLogicalEqReflexive..."
+:prove prop_fpLogicalEqReflexive`{8, 24}
+"Proving prop_fpLogicalEqSymmetric..."
+:prove prop_fpLogicalEqSymmetric`{8, 24}
+"Proving prop_fpLogicalEqTransitive..."
+:prove prop_fpLogicalEqTransitive`{8, 24}
+"Proving prop_fpIsNegSign..."
+:prove prop_fpIsNegSign`{8, 24}
+"Proving prop_fpIsNormalCorrect..."
+:prove prop_fpIsNormalCorrect`{8, 24}
+"Proving prop_fpAddNaN..."
+:prove prop_fpAddNaN`{8, 24} rne
+:prove prop_fpAddNaN`{8, 24} rna
+:prove prop_fpAddNaN`{8, 24} rtp
+:prove prop_fpAddNaN`{8, 24} rtn
+:prove prop_fpAddNaN`{8, 24} rtz
+"Proving prop_fpAddPosNegInf..."
+:prove prop_fpAddPosNegInf`{8, 24} rne
+:prove prop_fpAddPosNegInf`{8, 24} rna
+:prove prop_fpAddPosNegInf`{8, 24} rtp
+:prove prop_fpAddPosNegInf`{8, 24} rtn
+:prove prop_fpAddPosNegInf`{8, 24} rtz
+"Proving prop_fpAddNegPosInf..."
+:prove prop_fpAddNegPosInf`{8, 24} rne
+:prove prop_fpAddNegPosInf`{8, 24} rna
+:prove prop_fpAddNegPosInf`{8, 24} rtp
+:prove prop_fpAddNegPosInf`{8, 24} rtn
+:prove prop_fpAddNegPosInf`{8, 24} rtz
+"Proving prop_fpAddLeftInf..."
+:prove prop_fpAddLeftInf`{8, 24} rne
+:prove prop_fpAddLeftInf`{8, 24} rna
+:prove prop_fpAddLeftInf`{8, 24} rtp
+:prove prop_fpAddLeftInf`{8, 24} rtn
+:prove prop_fpAddLeftInf`{8, 24} rtz
+"Proving prop_fpAddRightInf..."
+:prove prop_fpAddRightInf`{8, 24} rne
+:prove prop_fpAddRightInf`{8, 24} rna
+:prove prop_fpAddRightInf`{8, 24} rtp
+:prove prop_fpAddRightInf`{8, 24} rtn
+:prove prop_fpAddRightInf`{8, 24} rtz
+"Proving prop_fpAddLeftIdentity..."
+:prove prop_fpAddLeftIdentity`{8, 24} rne
+:prove prop_fpAddLeftIdentity`{8, 24} rna
+:prove prop_fpAddLeftIdentity`{8, 24} rtp
+:prove prop_fpAddLeftIdentity`{8, 24} rtn
+:prove prop_fpAddLeftIdentity`{8, 24} rtz
+"Proving prop_fpAddRightIdentity..."
+:prove prop_fpAddRightIdentity`{8, 24} rne
+:prove prop_fpAddRightIdentity`{8, 24} rna
+:prove prop_fpAddRightIdentity`{8, 24} rtp
+:prove prop_fpAddRightIdentity`{8, 24} rtn
+:prove prop_fpAddRightIdentity`{8, 24} rtz
+"Proving prop_fpAddCommutative..."
+:prove prop_fpAddCommutative`{8, 24} rne
+:prove prop_fpAddCommutative`{8, 24} rna
+:prove prop_fpAddCommutative`{8, 24} rtp
+:prove prop_fpAddCommutative`{8, 24} rtn
+:prove prop_fpAddCommutative`{8, 24} rtz
+"Proving prop_fpAddInverse..."
+:prove prop_fpAddInverse`{8, 24} rne
+:prove prop_fpAddInverse`{8, 24} rna
+:prove prop_fpAddInverse`{8, 24} rtp
+:prove prop_fpAddInverse`{8, 24} rtn
+:prove prop_fpAddInverse`{8, 24} rtz
+"Disproving counterexample_fpAddAssociative..."
+:sat counterexample_fpAddAssociative`{8, 24} rne
+:sat counterexample_fpAddAssociative`{8, 24} rna
+:sat counterexample_fpAddAssociative`{8, 24} rtp
+:sat counterexample_fpAddAssociative`{8, 24} rtn
+:sat counterexample_fpAddAssociative`{8, 24} rtz
+"Proving prop_fpSubNaN..."
+:prove prop_fpSubNaN`{8, 24} rne
+:prove prop_fpSubNaN`{8, 24} rna
+:prove prop_fpSubNaN`{8, 24} rtp
+:prove prop_fpSubNaN`{8, 24} rtn
+:prove prop_fpSubNaN`{8, 24} rtz
+"Proving prop_fpSubPosPosInf..."
+:prove prop_fpSubPosPosInf`{8, 24} rne
+:prove prop_fpSubPosPosInf`{8, 24} rna
+:prove prop_fpSubPosPosInf`{8, 24} rtp
+:prove prop_fpSubPosPosInf`{8, 24} rtn
+:prove prop_fpSubPosPosInf`{8, 24} rtz
+"Proving prop_fpSubNegNegInf..."
+:prove prop_fpSubNegNegInf`{8, 24} rne
+:prove prop_fpSubNegNegInf`{8, 24} rna
+:prove prop_fpSubNegNegInf`{8, 24} rtp
+:prove prop_fpSubNegNegInf`{8, 24} rtn
+:prove prop_fpSubNegNegInf`{8, 24} rtz
+"Proving prop_fpSubLeftInf..."
+:prove prop_fpSubLeftInf`{8, 24} rne
+:prove prop_fpSubLeftInf`{8, 24} rna
+:prove prop_fpSubLeftInf`{8, 24} rtp
+:prove prop_fpSubLeftInf`{8, 24} rtn
+:prove prop_fpSubLeftInf`{8, 24} rtz
+"Proving prop_fpSubRightInf..."
+:prove prop_fpSubRightInf`{8, 24} rne
+:prove prop_fpSubRightInf`{8, 24} rna
+:prove prop_fpSubRightInf`{8, 24} rtp
+:prove prop_fpSubRightInf`{8, 24} rtn
+:prove prop_fpSubRightInf`{8, 24} rtz
+"Proving prop_fpSubZeroLeft..."
+:prove prop_fpSubZeroLeft`{8, 24} rne
+:prove prop_fpSubZeroLeft`{8, 24} rna
+:prove prop_fpSubZeroLeft`{8, 24} rtp
+:prove prop_fpSubZeroLeft`{8, 24} rtn
+:prove prop_fpSubZeroLeft`{8, 24} rtz
+"Proving prop_fpSubZeroRight..."
+:prove prop_fpSubZeroRight`{8, 24} rne
+:prove prop_fpSubZeroRight`{8, 24} rna
+:prove prop_fpSubZeroRight`{8, 24} rtp
+:prove prop_fpSubZeroRight`{8, 24} rtn
+:prove prop_fpSubZeroRight`{8, 24} rtz
+"Proving prop_fpSubPosPos..."
+:prove prop_fpSubPosPos`{8, 24} rne
+:prove prop_fpSubPosPos`{8, 24} rna
+:prove prop_fpSubPosPos`{8, 24} rtp
+:prove prop_fpSubPosPos`{8, 24} rtn
+:prove prop_fpSubPosPos`{8, 24} rtz
+"Proving prop_fpSubNegAdd..."
+:prove prop_fpSubNegAdd`{8, 24} rne
+:prove prop_fpSubNegAdd`{8, 24} rna
+:prove prop_fpSubNegAdd`{8, 24} rtp
+:prove prop_fpSubNegAdd`{8, 24} rtn
+:prove prop_fpSubNegAdd`{8, 24} rtz
+"Proving prop_fpAddNegSub..."
+:prove prop_fpAddNegSub`{8, 24} rne
+:prove prop_fpAddNegSub`{8, 24} rna
+:prove prop_fpAddNegSub`{8, 24} rtp
+:prove prop_fpAddNegSub`{8, 24} rtn
+:prove prop_fpAddNegSub`{8, 24} rtz
+"Proving prop_fpSubAnticommutative..."
+:prove prop_fpSubAnticommutative`{8, 24} rne
+:prove prop_fpSubAnticommutative`{8, 24} rna
+:prove prop_fpSubAnticommutative`{8, 24} rtp
+:prove prop_fpSubAnticommutative`{8, 24} rtn
+:prove prop_fpSubAnticommutative`{8, 24} rtz
+"Proving prop_fpSubSelfInverse..."
+:prove prop_fpSubSelfInverse`{8, 24} rne
+:prove prop_fpSubSelfInverse`{8, 24} rna
+:prove prop_fpSubSelfInverse`{8, 24} rtp
+:prove prop_fpSubSelfInverse`{8, 24} rtn
+:prove prop_fpSubSelfInverse`{8, 24} rtz
+"Proving prop_fpMulNaN..."
+:prove prop_fpMulNaN`{8, 24} rne
+:prove prop_fpMulNaN`{8, 24} rna
+:prove prop_fpMulNaN`{8, 24} rtp
+:prove prop_fpMulNaN`{8, 24} rtn
+:prove prop_fpMulNaN`{8, 24} rtz
+"Proving prop_fpMulZeroInf..."
+:prove prop_fpMulZeroInf`{8, 24} rne
+:prove prop_fpMulZeroInf`{8, 24} rna
+:prove prop_fpMulZeroInf`{8, 24} rtp
+:prove prop_fpMulZeroInf`{8, 24} rtn
+:prove prop_fpMulZeroInf`{8, 24} rtz
+"Proving prop_fpMulInfZero..."
+:prove prop_fpMulInfZero`{8, 24} rne
+:prove prop_fpMulInfZero`{8, 24} rna
+:prove prop_fpMulInfZero`{8, 24} rtp
+:prove prop_fpMulInfZero`{8, 24} rtn
+:prove prop_fpMulInfZero`{8, 24} rtz
+"Proving prop_fpMulLeftInf..."
+:prove prop_fpMulLeftInf`{8, 24} rne
+:prove prop_fpMulLeftInf`{8, 24} rna
+:prove prop_fpMulLeftInf`{8, 24} rtp
+:prove prop_fpMulLeftInf`{8, 24} rtn
+:prove prop_fpMulLeftInf`{8, 24} rtz
+"Proving prop_fpMulRightInf..."
+:prove prop_fpMulRightInf`{8, 24} rne
+:prove prop_fpMulRightInf`{8, 24} rna
+:prove prop_fpMulRightInf`{8, 24} rtp
+:prove prop_fpMulRightInf`{8, 24} rtn
+:prove prop_fpMulRightInf`{8, 24} rtz
+"Proving prop_fpMulLeftIdentity..."
+:prove prop_fpMulLeftIdentity`{8, 24} rne
+:prove prop_fpMulLeftIdentity`{8, 24} rna
+:prove prop_fpMulLeftIdentity`{8, 24} rtp
+:prove prop_fpMulLeftIdentity`{8, 24} rtn
+:prove prop_fpMulLeftIdentity`{8, 24} rtz
+"Proving prop_fpMulRightIdentity..."
+:prove prop_fpMulRightIdentity`{8, 24} rne
+:prove prop_fpMulRightIdentity`{8, 24} rna
+:prove prop_fpMulRightIdentity`{8, 24} rtp
+:prove prop_fpMulRightIdentity`{8, 24} rtn
+:prove prop_fpMulRightIdentity`{8, 24} rtz
+"Proving prop_fpMulLeftPosZero..."
+:prove prop_fpMulLeftPosZero`{8, 24} rne
+:prove prop_fpMulLeftPosZero`{8, 24} rna
+:prove prop_fpMulLeftPosZero`{8, 24} rtp
+:prove prop_fpMulLeftPosZero`{8, 24} rtn
+:prove prop_fpMulLeftPosZero`{8, 24} rtz
+"Proving prop_fpMulRightPosZero..."
+:prove prop_fpMulRightPosZero`{8, 24} rne
+:prove prop_fpMulRightPosZero`{8, 24} rna
+:prove prop_fpMulRightPosZero`{8, 24} rtp
+:prove prop_fpMulRightPosZero`{8, 24} rtn
+:prove prop_fpMulRightPosZero`{8, 24} rtz
+"Proving prop_fpMulLeftNegZero..."
+:prove prop_fpMulLeftNegZero`{8, 24} rne
+:prove prop_fpMulLeftNegZero`{8, 24} rna
+:prove prop_fpMulLeftNegZero`{8, 24} rtp
+:prove prop_fpMulLeftNegZero`{8, 24} rtn
+:prove prop_fpMulLeftNegZero`{8, 24} rtz
+"Proving prop_fpMulRightNegZero..."
+:prove prop_fpMulRightNegZero`{8, 24} rne
+:prove prop_fpMulRightNegZero`{8, 24} rna
+:prove prop_fpMulRightNegZero`{8, 24} rtp
+:prove prop_fpMulRightNegZero`{8, 24} rtn
+:prove prop_fpMulRightNegZero`{8, 24} rtz
+"Proving prop_fpMulNegNeg..."
+:prove prop_fpMulNegNeg`{8, 24} rne
+:prove prop_fpMulNegNeg`{8, 24} rna
+:prove prop_fpMulNegNeg`{8, 24} rtp
+:prove prop_fpMulNegNeg`{8, 24} rtn
+:prove prop_fpMulNegNeg`{8, 24} rtz
+"Proving prop_fpMulPosPos..."
+:prove prop_fpMulPosPos`{8, 24} rne
+:prove prop_fpMulPosPos`{8, 24} rna
+:prove prop_fpMulPosPos`{8, 24} rtp
+:prove prop_fpMulPosPos`{8, 24} rtn
+:prove prop_fpMulPosPos`{8, 24} rtz
+"Proving prop_fpMulNegPos..."
+:prove prop_fpMulNegPos`{8, 24} rne
+:prove prop_fpMulNegPos`{8, 24} rna
+:prove prop_fpMulNegPos`{8, 24} rtp
+:prove prop_fpMulNegPos`{8, 24} rtn
+:prove prop_fpMulNegPos`{8, 24} rtz
+"Proving prop_fpMulPosNeg..."
+:prove prop_fpMulPosNeg`{8, 24} rne
+:prove prop_fpMulPosNeg`{8, 24} rna
+:prove prop_fpMulPosNeg`{8, 24} rtp
+:prove prop_fpMulPosNeg`{8, 24} rtn
+:prove prop_fpMulPosNeg`{8, 24} rtz
+"Proving prop_fpMulCommutative..."
+:prove prop_fpMulCommutative`{8, 24} rne
+:prove prop_fpMulCommutative`{8, 24} rna
+:prove prop_fpMulCommutative`{8, 24} rtp
+:prove prop_fpMulCommutative`{8, 24} rtn
+:prove prop_fpMulCommutative`{8, 24} rtz
+"Disproving counterexample_fpMulAssociative..."
+:sat counterexample_fpMulAssociative`{8, 24} rne
+:sat counterexample_fpMulAssociative`{8, 24} rna
+:sat counterexample_fpMulAssociative`{8, 24} rtp
+:sat counterexample_fpMulAssociative`{8, 24} rtn
+:sat counterexample_fpMulAssociative`{8, 24} rtz
+"Disproving counterexample_fpMulDistributive..."
+:sat counterexample_fpMulDistributive`{8, 24} rne
+:sat counterexample_fpMulDistributive`{8, 24} rna
+:sat counterexample_fpMulDistributive`{8, 24} rtp
+:sat counterexample_fpMulDistributive`{8, 24} rtn
+:sat counterexample_fpMulDistributive`{8, 24} rtz
+"Proving prop_fpDivNaN..."
+:prove prop_fpDivNaN`{8, 24} rne
+:prove prop_fpDivNaN`{8, 24} rna
+:prove prop_fpDivNaN`{8, 24} rtp
+:prove prop_fpDivNaN`{8, 24} rtn
+:prove prop_fpDivNaN`{8, 24} rtz
+"Proving prop_fpDivInfInf..."
+:prove prop_fpDivInfInf`{8, 24} rne
+:prove prop_fpDivInfInf`{8, 24} rna
+:prove prop_fpDivInfInf`{8, 24} rtp
+:prove prop_fpDivInfInf`{8, 24} rtn
+:prove prop_fpDivInfInf`{8, 24} rtz
+"Proving prop_fpDivPosInfDividend..."
+:prove prop_fpDivPosInfDividend`{8, 24} rne
+:prove prop_fpDivPosInfDividend`{8, 24} rna
+:prove prop_fpDivPosInfDividend`{8, 24} rtp
+:prove prop_fpDivPosInfDividend`{8, 24} rtn
+:prove prop_fpDivPosInfDividend`{8, 24} rtz
+"Proving prop_fpDivNegInfDividend..."
+:prove prop_fpDivNegInfDividend`{8, 24} rne
+:prove prop_fpDivNegInfDividend`{8, 24} rna
+:prove prop_fpDivNegInfDividend`{8, 24} rtp
+:prove prop_fpDivNegInfDividend`{8, 24} rtn
+:prove prop_fpDivNegInfDividend`{8, 24} rtz
+"Proving prop_fpDivPosInfDivisor..."
+:prove prop_fpDivPosInfDivisor`{8, 24} rne
+:prove prop_fpDivPosInfDivisor`{8, 24} rna
+:prove prop_fpDivPosInfDivisor`{8, 24} rtp
+:prove prop_fpDivPosInfDivisor`{8, 24} rtn
+:prove prop_fpDivPosInfDivisor`{8, 24} rtz
+"Proving prop_fpDivNegInfDivisor..."
+:prove prop_fpDivNegInfDivisor`{8, 24} rne
+:prove prop_fpDivNegInfDivisor`{8, 24} rna
+:prove prop_fpDivNegInfDivisor`{8, 24} rtp
+:prove prop_fpDivNegInfDivisor`{8, 24} rtn
+:prove prop_fpDivNegInfDivisor`{8, 24} rtz
+"Proving prop_fpDivPosZeroDividend..."
+:prove prop_fpDivPosZeroDividend`{8, 24} rne
+:prove prop_fpDivPosZeroDividend`{8, 24} rna
+:prove prop_fpDivPosZeroDividend`{8, 24} rtp
+:prove prop_fpDivPosZeroDividend`{8, 24} rtn
+:prove prop_fpDivPosZeroDividend`{8, 24} rtz
+"Proving prop_fpDivNegZeroDividend..."
+:prove prop_fpDivNegZeroDividend`{8, 24} rne
+:prove prop_fpDivNegZeroDividend`{8, 24} rna
+:prove prop_fpDivNegZeroDividend`{8, 24} rtp
+:prove prop_fpDivNegZeroDividend`{8, 24} rtn
+:prove prop_fpDivNegZeroDividend`{8, 24} rtz
+"Proving prop_fpDivPosZeroDivisor..."
+:prove prop_fpDivPosZeroDivisor`{8, 24} rne
+:prove prop_fpDivPosZeroDivisor`{8, 24} rna
+:prove prop_fpDivPosZeroDivisor`{8, 24} rtp
+:prove prop_fpDivPosZeroDivisor`{8, 24} rtn
+:prove prop_fpDivPosZeroDivisor`{8, 24} rtz
+"Proving prop_fpDivNegZeroDivisor..."
+:prove prop_fpDivNegZeroDivisor`{8, 24} rne
+:prove prop_fpDivNegZeroDivisor`{8, 24} rna
+:prove prop_fpDivNegZeroDivisor`{8, 24} rtp
+:prove prop_fpDivNegZeroDivisor`{8, 24} rtn
+:prove prop_fpDivNegZeroDivisor`{8, 24} rtz
+"Proving prop_fpDivOne..."
+:prove prop_fpDivOne`{8, 24} rne
+:prove prop_fpDivOne`{8, 24} rna
+:prove prop_fpDivOne`{8, 24} rtp
+:prove prop_fpDivOne`{8, 24} rtn
+:prove prop_fpDivOne`{8, 24} rtz
+"Proving prop_fpDivInverse..."
+:prove prop_fpDivInverse`{8, 24} rne
+:prove prop_fpDivInverse`{8, 24} rna
+:prove prop_fpDivInverse`{8, 24} rtp
+:prove prop_fpDivInverse`{8, 24} rtn
+:prove prop_fpDivInverse`{8, 24} rtz
+"Disproving counterexample_fpDivDistributive..."
+:sat counterexample_fpDivDistributive`{8, 24} rne
+:sat counterexample_fpDivDistributive`{8, 24} rna
+:sat counterexample_fpDivDistributive`{8, 24} rtp
+:sat counterexample_fpDivDistributive`{8, 24} rtn
+:sat counterexample_fpDivDistributive`{8, 24} rtz
+"Proving prop_fpFMACommutative..."
+:prove prop_fpFMACommutative`{8, 24} rne
+:prove prop_fpFMACommutative`{8, 24} rna
+:prove prop_fpFMACommutative`{8, 24} rtp
+:prove prop_fpFMACommutative`{8, 24} rtn
+:prove prop_fpFMACommutative`{8, 24} rtz
+"Disproving counterexample_fpFMAAssociative..."
+:sat counterexample_fpFMAAssociative`{8, 24} rne
+:sat counterexample_fpFMAAssociative`{8, 24} rna
+:sat counterexample_fpFMAAssociative`{8, 24} rtp
+:sat counterexample_fpFMAAssociative`{8, 24} rtn
+:sat counterexample_fpFMAAssociative`{8, 24} rtz
+"Disproving counterexample_fpFMAExpand..."
+:sat counterexample_fpFMAExpand`{8, 24} rne
+:sat counterexample_fpFMAExpand`{8, 24} rna
+:sat counterexample_fpFMAExpand`{8, 24} rtp
+:sat counterexample_fpFMAExpand`{8, 24} rtn
+:sat counterexample_fpFMAExpand`{8, 24} rtz
+"Proving prop_fpAbsZero..."
+:prove prop_fpAbsZero`{8, 24}
+"Proving prop_fpAbsPos..."
+:prove prop_fpAbsPos`{8, 24}
+"Proving prop_fpAbsNeg..."
+:prove prop_fpAbsNeg`{8, 24}
+"Proving prop_fpAbsNaN..."
+:prove prop_fpAbsNaN`{8, 24}
+"Proving prop_fpAbsInf..."
+:prove prop_fpAbsInf`{8, 24}
+"Proving prop_fpSqrtNaN..."
+:prove prop_fpSqrtNaN`{8, 24} rne
+:prove prop_fpSqrtNaN`{8, 24} rna
+:prove prop_fpSqrtNaN`{8, 24} rtp
+:prove prop_fpSqrtNaN`{8, 24} rtn
+:prove prop_fpSqrtNaN`{8, 24} rtz
+"Proving prop_fpSqrtPosInf..."
+:prove prop_fpSqrtPosInf`{8, 24} rne
+:prove prop_fpSqrtPosInf`{8, 24} rna
+:prove prop_fpSqrtPosInf`{8, 24} rtp
+:prove prop_fpSqrtPosInf`{8, 24} rtn
+:prove prop_fpSqrtPosInf`{8, 24} rtz
+"Proving prop_fpSqrtPosZero..."
+:prove prop_fpSqrtPosZero`{8, 24} rne
+:prove prop_fpSqrtPosZero`{8, 24} rna
+:prove prop_fpSqrtPosZero`{8, 24} rtp
+:prove prop_fpSqrtPosZero`{8, 24} rtn
+:prove prop_fpSqrtPosZero`{8, 24} rtz
+"Proving prop_fpSqrtNegZero..."
+:prove prop_fpSqrtNegZero`{8, 24} rne
+:prove prop_fpSqrtNegZero`{8, 24} rna
+:prove prop_fpSqrtNegZero`{8, 24} rtp
+:prove prop_fpSqrtNegZero`{8, 24} rtn
+:prove prop_fpSqrtNegZero`{8, 24} rtz
+"Proving prop_fpSqrtNeg..."
+:prove prop_fpSqrtNeg`{8, 24} rne
+:prove prop_fpSqrtNeg`{8, 24} rna
+:prove prop_fpSqrtNeg`{8, 24} rtp
+:prove prop_fpSqrtNeg`{8, 24} rtn
+:prove prop_fpSqrtNeg`{8, 24} rtz
+"Disproving counterexample_fpSqrtMul..."
+:sat counterexample_fpSqrtMul`{8, 24} rne
+:sat counterexample_fpSqrtMul`{8, 24} rna
+:sat counterexample_fpSqrtMul`{8, 24} rtp
+:sat counterexample_fpSqrtMul`{8, 24} rtn
+:sat counterexample_fpSqrtMul`{8, 24} rtz
+"Disproving counterexample_fpSqrtDiv..."
+:sat counterexample_fpSqrtDiv`{8, 24} rne
+:sat counterexample_fpSqrtDiv`{8, 24} rna
+:sat counterexample_fpSqrtDiv`{8, 24} rtp
+:sat counterexample_fpSqrtDiv`{8, 24} rtn
+:sat counterexample_fpSqrtDiv`{8, 24} rtz
+"Disproving counterexample_fpSqrtSquare..."
+:sat counterexample_fpSqrtSquare`{8, 24} rne
+:sat counterexample_fpSqrtSquare`{8, 24} rna
+:sat counterexample_fpSqrtSquare`{8, 24} rtp
+:sat counterexample_fpSqrtSquare`{8, 24} rtn
+:sat counterexample_fpSqrtSquare`{8, 24} rtz
+"Disproving counterexample_fpSqrtSquared..."
+:sat counterexample_fpSqrtSquared`{8, 24} rne
+:sat counterexample_fpSqrtSquared`{8, 24} rna
+:sat counterexample_fpSqrtSquared`{8, 24} rtp
+:sat counterexample_fpSqrtSquared`{8, 24} rtn
+:sat counterexample_fpSqrtSquared`{8, 24} rtz
+"Checking check_fpFromToRational..."
+:check check_fpFromToRational`{8, 24} rne
+:check check_fpFromToRational`{8, 24} rna
+:check check_fpFromToRational`{8, 24} rtp
+:check check_fpFromToRational`{8, 24} rtn
+:check check_fpFromToRational`{8, 24} rtz
+"Proving prop_fpEqNaN..."
+:prove prop_fpEqNaN`{8, 24}
+"Proving prop_fpEqZero..."
+:prove prop_fpEqZero`{8, 24}
+"Proving prop_fpEqReflexive..."
+:prove prop_fpEqReflexive`{8, 24}
+"Proving prop_fpEqSymmetric..."
+:prove prop_fpEqSymmetric`{8, 24}
+"Proving prop_fpEqTransitive..."
+:prove prop_fpEqTransitive`{8, 24}
+"Proving prop_fpCmpNaN..."
+:prove prop_fpCmpNaN`{8, 24}
+"Proving prop_fpCmpZero..."
+:prove prop_fpCmpZero`{8, 24}
+"Proving prop_fpCmpLtIrreflexive..."
+:prove prop_fpCmpLtIrreflexive`{8, 24}
+"Proving prop_fpCmpLtAsymmetric..."
+:prove prop_fpCmpLtAsymmetric`{8, 24}
+"Proving prop_fpCmpLtTransitive..."
+:prove prop_fpCmpLtTransitive`{8, 24}
+"Proving prop_fpCmpLeReflexive..."
+:prove prop_fpCmpLeReflexive`{8, 24}
+"Proving prop_fpCmpLeAntisymmetric..."
+:prove prop_fpCmpLeAntisymmetric`{8, 24}
+"Proving prop_fpCmpLeTransitive..."
+:prove prop_fpCmpLeTransitive`{8, 24}
+"Proving prop_fpCmpLeTotal..."
+:prove prop_fpCmpLeTotal`{8, 24}
+"Proving prop_fpCmpGtCorrect..."
+:prove prop_fpCmpGtCorrect`{8, 24}
+"Proving prop_fpCmpGeCorrect..."
+:prove prop_fpCmpGeCorrect`{8, 24}
+"Proving prop_fpZero..."
+:prove prop_fpZero`{8, 24}
+"Proving prop_fpRingAdd..."
+:prove prop_fpRingAdd`{8, 24}
+"Proving prop_fpRingSub..."
+:prove prop_fpRingSub`{8, 24}
+"Proving prop_fpRingMul..."
+:prove prop_fpRingMul`{8, 24}
+"Proving prop_fpRingNegate..."
+:prove prop_fpRingNegate`{8, 24}
+"Proving prop_fpFieldDiv..."
+:prove prop_fpFieldDiv`{8, 24}
+"Proving prop_fpFieldRecip..."
+:prove prop_fpFieldRecip`{8, 24}
+"Checking check_fpRoundFloorCeiling..."
+:check check_fpRoundFloorCeiling`{8, 24}
+"Checking check_fpRoundCeilingFloor..."
+:check check_fpRoundCeilingFloor`{8, 24}
+"Checking check_fpRoundFloorCorrect..."
+:check check_fpRoundFloorCorrect`{8, 24}
+"Checking check_fpRoundCeilingCorrect..."
+:check check_fpRoundCeilingCorrect`{8, 24}
+"Checking check_fpRoundTruncCeilingFloor..."
+:check check_fpRoundTruncCeilingFloor`{8, 24}
+"Checking check_fpRoundTruncCorrect..."
+:check check_fpRoundTruncCorrect`{8, 24}
+"Checking check_fpRoundAwayTrunc..."
+:check check_fpRoundAwayTrunc`{8, 24}
+"Checking check_fpRoundAwayCorrect..."
+:check check_fpRoundAwayCorrect`{8, 24}
+

--- a/tests/regression/float_properties.icry.stdout
+++ b/tests/regression/float_properties.icry.stdout
@@ -1,0 +1,590 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Float
+Loading module FloatPropertiesGeneric
+"Proving prop_fpNaNIsNaN..."
+Q.E.D.
+"Proving prop_fpNaNIsNotInf..."
+Q.E.D.
+"Proving prop_fpNaNIsNotZero..."
+Q.E.D.
+"Proving prop_fpNaNIsPos..."
+Q.E.D.
+"Proving prop_fpNaNIsNotNormal..."
+Q.E.D.
+"Proving prop_fpNaNIsNotSubnormal..."
+Q.E.D.
+"Proving prop_fpNaNIsQuiet..."
+Q.E.D.
+"Proving prop_fpPosInfIsPos..."
+Q.E.D.
+"Proving prop_fpPosInfIsInf..."
+Q.E.D.
+"Proving prop_fpPosInfIsNotZero..."
+Q.E.D.
+"Proving prop_fpPosInfIsNotNaN..."
+Q.E.D.
+"Proving prop_fpPosInfIsNotNormal..."
+Q.E.D.
+"Proving prop_fpPosInfIsNotSubnormal..."
+Q.E.D.
+"Proving prop_fpNegInfIsNeg..."
+Q.E.D.
+"Proving prop_fpNegInfIsInf..."
+Q.E.D.
+"Proving prop_fpNegInfIsNotZero..."
+Q.E.D.
+"Proving prop_fpNegInfIsNotNaN..."
+Q.E.D.
+"Proving prop_fpNegInfIsNotNormal..."
+Q.E.D.
+"Proving prop_fpNegInfIsNotSubnormal..."
+Q.E.D.
+"Proving prop_fpPosZeroIsPos..."
+Q.E.D.
+"Proving prop_fpPosZeroIsZero..."
+Q.E.D.
+"Proving prop_fpPosZeroIsNotNaN..."
+Q.E.D.
+"Proving prop_fpPosZeroIsNotInf..."
+Q.E.D.
+"Proving prop_fpPosZeroIsNotNormal..."
+Q.E.D.
+"Proving prop_fpPosZeroIsNotSubnormal..."
+Q.E.D.
+"Proving prop_fpNegZeroIsNeg..."
+Q.E.D.
+"Proving prop_fpNegZeroIsZero..."
+Q.E.D.
+"Proving prop_fpNegZeroIsNotNaN..."
+Q.E.D.
+"Proving prop_fpNegZeroIsNotInf..."
+Q.E.D.
+"Proving prop_fpNegZeroIsNotNormal..."
+Q.E.D.
+"Proving prop_fpNegZeroIsNotSubnormal..."
+Q.E.D.
+"Proving prop_fpFromToBits..."
+Q.E.D.
+"Proving prop_fpToFromBits..."
+Q.E.D.
+"Proving prop_fpFromBitsCorrect..."
+Q.E.D.
+"Proving prop_fpFromBitsEq..."
+Q.E.D.
+"Proving prop_fpToBitsCorrect..."
+Q.E.D.
+"Proving prop_fpToBitsEq..."
+Q.E.D.
+"Proving prop_fpLogicalEqNaN..."
+Q.E.D.
+"Proving prop_fpLogicalEqZero..."
+Q.E.D.
+"Proving prop_fpLogicalEqToIeeeEq..."
+Q.E.D.
+"Proving prop_fpIeeeEqToLogicalEq..."
+Q.E.D.
+"Proving prop_fpLogicalEqReflexive..."
+Q.E.D.
+"Proving prop_fpLogicalEqSymmetric..."
+Q.E.D.
+"Proving prop_fpLogicalEqTransitive..."
+Q.E.D.
+"Proving prop_fpIsNegSign..."
+Q.E.D.
+"Proving prop_fpIsNormalCorrect..."
+Q.E.D.
+"Proving prop_fpAddNaN..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddPosNegInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddNegPosInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddLeftInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddRightInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddLeftIdentity..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddRightIdentity..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddCommutative..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddInverse..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Disproving counterexample_fpAddAssociative..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Proving prop_fpSubNaN..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubPosPosInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubNegNegInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubLeftInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubRightInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubZeroLeft..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubZeroRight..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubPosPos..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubNegAdd..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpAddNegSub..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubAnticommutative..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSubSelfInverse..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulNaN..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulZeroInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulInfZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulLeftInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulRightInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulLeftIdentity..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulRightIdentity..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulLeftPosZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulRightPosZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulLeftNegZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulRightNegZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulNegNeg..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulPosPos..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulNegPos..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulPosNeg..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpMulCommutative..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Disproving counterexample_fpMulAssociative..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Disproving counterexample_fpMulDistributive..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Proving prop_fpDivNaN..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivInfInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivPosInfDividend..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivNegInfDividend..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivPosInfDivisor..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivNegInfDivisor..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivPosZeroDividend..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivNegZeroDividend..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivPosZeroDivisor..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivNegZeroDivisor..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivOne..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpDivInverse..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Disproving counterexample_fpDivDistributive..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Proving prop_fpFMACommutative..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Disproving counterexample_fpFMAAssociative..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Disproving counterexample_fpFMAExpand..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Proving prop_fpAbsZero..."
+Q.E.D.
+"Proving prop_fpAbsPos..."
+Q.E.D.
+"Proving prop_fpAbsNeg..."
+Q.E.D.
+"Proving prop_fpAbsNaN..."
+Q.E.D.
+"Proving prop_fpAbsInf..."
+Q.E.D.
+"Proving prop_fpSqrtNaN..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSqrtPosInf..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSqrtPosZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSqrtNegZero..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Proving prop_fpSqrtNeg..."
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+Q.E.D.
+"Disproving counterexample_fpSqrtMul..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Disproving counterexample_fpSqrtDiv..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Disproving counterexample_fpSqrtSquare..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Disproving counterexample_fpSqrtSquared..."
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+Satisfiable
+"Checking check_fpFromToRational..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Proving prop_fpEqNaN..."
+Q.E.D.
+"Proving prop_fpEqZero..."
+Q.E.D.
+"Proving prop_fpEqReflexive..."
+Q.E.D.
+"Proving prop_fpEqSymmetric..."
+Q.E.D.
+"Proving prop_fpEqTransitive..."
+Q.E.D.
+"Proving prop_fpCmpNaN..."
+Q.E.D.
+"Proving prop_fpCmpZero..."
+Q.E.D.
+"Proving prop_fpCmpLtIrreflexive..."
+Q.E.D.
+"Proving prop_fpCmpLtAsymmetric..."
+Q.E.D.
+"Proving prop_fpCmpLtTransitive..."
+Q.E.D.
+"Proving prop_fpCmpLeReflexive..."
+Q.E.D.
+"Proving prop_fpCmpLeAntisymmetric..."
+Q.E.D.
+"Proving prop_fpCmpLeTransitive..."
+Q.E.D.
+"Proving prop_fpCmpLeTotal..."
+Q.E.D.
+"Proving prop_fpCmpGtCorrect..."
+Q.E.D.
+"Proving prop_fpCmpGeCorrect..."
+Q.E.D.
+"Proving prop_fpZero..."
+Q.E.D.
+"Proving prop_fpRingAdd..."
+Q.E.D.
+"Proving prop_fpRingSub..."
+Q.E.D.
+"Proving prop_fpRingMul..."
+Q.E.D.
+"Proving prop_fpRingNegate..."
+Q.E.D.
+"Proving prop_fpFieldDiv..."
+Q.E.D.
+"Proving prop_fpFieldRecip..."
+Q.E.D.
+"Checking check_fpRoundFloorCeiling..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundCeilingFloor..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundFloorCorrect..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundCeilingCorrect..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundTruncCeilingFloor..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundTruncCorrect..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundAwayTrunc..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)
+"Checking check_fpRoundAwayCorrect..."
+Using random testing.
+Testing... Passed 100 tests.
+Expected test coverage: 0.00% (100 of 2^^32 values)


### PR DESCRIPTION
See the comments in `FloatPropertiesGeneric.cry` (the file which defines polymorphic floating-point properties) and `GenFloatProperties.hs` (the script which generates the `.icry` file to test) for more details.

Resolves #2049.