### PR TITLE
Two Cryptol-as-a-library improvements for SAW

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,10 @@
   a valid Cryptol identifier.
   ([#2036](https://github.com/GaloisInc/cryptol/issues/2036))
 
+* Add `pIsNeq` to `Cryptol.TypeCheck.Type`, which recognizes if a Cryptol
+  constraint is headed by a not-equal (`!=`) operator.
+  ([#2038](https://github.com/GaloisInc/cryptol/issues/2038))
+
 # 3.5.0 -- 2026-01-27
 
 ## Administrative changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,12 @@
   incorrect results on concrete values.
   ([#2044](https://github.com/GaloisInc/cryptol/issues/2044))
 
+## API changes
+
+* Add `isValidIdent` to `Cryptol.Parser.LexerUtils`, which checks if a name is
+  a valid Cryptol identifier.
+  ([#2036](https://github.com/GaloisInc/cryptol/issues/2036))
+
 # 3.5.0 -- 2026-01-27
 
 ## Administrative changes

--- a/src/Cryptol/Parser/LexerUtils.hs
+++ b/src/Cryptol/Parser/LexerUtils.hs
@@ -31,6 +31,7 @@ module Cryptol.Parser.LexerUtils
   , numToken
   , fromDigit
   , fnumTokens
+  , isValidIdent
   , selectorToken
   , readDecimal
   , AlexInput(..)
@@ -341,19 +342,26 @@ fnumTokens file pos ds =
   eBase          = if rad == 10 then 10 else 2 :: Rational
 
 
+
+
+-- | Check if a name is a valid Cryptol identifier.
+isValidIdent :: Text -> Bool
+isValidIdent body =
+  case T.uncons body of
+    Just (x, xs) -> id_first x && T.all id_next xs
+    Nothing -> False
+  where
+    id_first x = isAlpha x || x == '_'
+    id_next  x = isAlphaNum x || x == '_' || x == '\''
+
 -- assumes we start with a dot
 selectorToken :: Text -> TokenT
 selectorToken txt
   | Just n <- readDecimal body, n >= 0 = Selector (TupleSelectorTok n)
-  | Just (x,xs) <- T.uncons body
-  , id_first x
-  , T.all id_next xs = Selector (RecordSelectorTok body)
+  | isValidIdent body = Selector (RecordSelectorTok body)
   | otherwise = Err MalformedSelector
-
   where
   body = T.drop 1 txt
-  id_first x = isAlpha x || x == '_'
-  id_next  x = isAlphaNum x || x == '_' || x == '\''
 
 
 readDecimal :: Integral a => Text -> Maybe a

--- a/src/Cryptol/Parser/LexerUtils.hs
+++ b/src/Cryptol/Parser/LexerUtils.hs
@@ -6,7 +6,39 @@
 -- Stability   :  provisional
 -- Portability :  portable
 {-# LANGUAGE OverloadedStrings #-}
-module Cryptol.Parser.LexerUtils where
+module Cryptol.Parser.LexerUtils
+  ( Config(..)
+  , defaultConfig
+  , Action
+  , LexS(..)
+  , startComment
+  , endComment
+  , addToComment
+  , startEndComment
+  , startString
+  , endString
+  , addToString
+  , startChar
+  , endChar
+  , addToChar
+  , mkIdent
+  , mkQualIdent
+  , mkQualOp
+  , emit
+  , emitS
+  , emitFancy
+  , splitQual
+  , numToken
+  , fromDigit
+  , fnumTokens
+  , selectorToken
+  , readDecimal
+  , AlexInput(..)
+  , alexGetByte
+  , Layout(..)
+  , dropWhite
+  , byteForChar
+  ) where
 
 import           Control.Monad(guard)
 import           Data.Char(toLower,generalCategory,isAscii,ord,isSpace,

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -678,6 +678,11 @@ pIsEqual ty = case tNoUser ty of
                 TCon (PC PEqual) [t1,t2] -> Just (t1,t2)
                 _                        -> Nothing
 
+pIsNeq :: Prop -> Maybe (Type,Type)
+pIsNeq ty = case tNoUser ty of
+              TCon (PC PNeq) [t1,t2] -> Just (t1,t2)
+              _                      -> Nothing
+
 pIsZero :: Prop -> Maybe Type
 pIsZero ty = case tNoUser ty of
                TCon (PC PZero) [t1] -> Just t1

--- a/src/Cryptol/TypeCheck/Type.hs
+++ b/src/Cryptol/TypeCheck/Type.hs
@@ -1132,7 +1132,7 @@ ppNominalFull nt =
       ctrs = case ntConstraints nt of
                [] -> mempty
                _  -> parens (commaSep (map ppC (ntConstraints nt))) <+> "=>"
-  
+
 
 
 instance PP Schema where
@@ -1143,15 +1143,15 @@ instance PP (WithNames Schema) where
     withPPCfg $ \cfg ->
     let
       body = ppWithNames ns1 (sType s)
-  
+
       vars = case sVars s of
         [] -> []
         vs -> [nest 1 (braces (commaSepFill (map (ppWithNames ns1) vs)))]
-  
+
       props = case sProps s of
         [] -> []
         ps -> [nest 1 (parens (commaSepFill (map (ppWithNames ns1) ps))) <+> text "=>"]
-  
+
       ns1 = addTNames cfg (sVars s) ns
     in if null (sVars s) && null (sProps s)
         then body
@@ -1414,7 +1414,7 @@ instance PP ModParamNames where
             | not (null (mpnConstraints ps))
             ] ++
            [ pp t | t <- Map.elems (mpnTySyn ps) ] ++
-           map pp (Map.elems (mpnFuns ps)) 
+           map pp (Map.elems (mpnFuns ps))
 
 instance PP ModTParam where
   ppPrec _ p =


### PR DESCRIPTION
This implements two API additions that would be useful for SAW's needs:

* `Cryptol.Parser.LexerUtils.isValidIdentifier`, which checks if a Cryptol name is a valid Cryptol identifier. This fixes #2036.
* `Cryptol.TypeCheck.Type.pIsNeq`, which recognizes is a Cryptol constraint is headed by a not-equal (`!=`) operator. This fixes #2038.