### PR TITLE
Set the prop guard flag properly during ExpandPropGuards

### DIFF
--- a/src/Cryptol/Parser/AST.hs
+++ b/src/Cryptol/Parser/AST.hs
@@ -1435,7 +1435,7 @@ instance (Show name, PPName name) => PP (Expr name) where
                                  text "->" </> pp e)
         where
         des = maybe mempty ppNm (funDescrName d)
-        ppNm x = "/*" <.> pp x <.> "*/"
+        ppNm x = "/*" <.> pp x <.> (if funDescrFromPropGuard d then " prop-guard " else mempty) <.> "*/"
 
       EIf e1 e2 e3  -> wrap n 0 $ sep [ text "if"   <+> pp e1
                                       , text "then" <+> pp e2

--- a/src/Cryptol/Parser/ExpandPropGuards.hs
+++ b/src/Cryptol/Parser/ExpandPropGuards.hs
@@ -137,6 +137,7 @@ expandBind bind =
           let updatedDef x =
                 case x of
                   ELocated e1 l -> ELocated (updatedDef e1) l
+                  EWhere e'' ds -> EWhere (updatedDef e'') ds
                   EFun desc xs y
                     | Just {} <- funDescrName desc ->
                       EFun desc { funDescrFromPropGuard = True } xs (updatedDef y)

--- a/tests/issues/issue2090.cry
+++ b/tests/issues/issue2090.cry
@@ -1,0 +1,4 @@
+f : {n} (fin n) => [2*n] -> [n] -> [n]
+f (xs # ys) zs
+  | (n > 0) => xs + zs
+  | () => ys + zs

--- a/tests/issues/issue2090.icry
+++ b/tests/issues/issue2090.icry
@@ -1,0 +1,1 @@
+:load issue2090.cry

--- a/tests/issues/issue2090.icry.stdout
+++ b/tests/issues/issue2090.icry.stdout
@@ -1,0 +1,7 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Main
+[warning] at issue2090.cry:2:9--2:11
+    Unused name: ys
+[warning] at issue2090.cry:2:4--2:6
+    Unused name: xs


### PR DESCRIPTION
The issue was that NoPat can introduce where clauses so we have to look for lambdas through `wehre` as well.

Fixes #2090