### PR TITLE
Simplify away trivial `Prop`s in numeric constraint guards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,10 @@
   implementation is written in Cryptol.
   ([#2070](https://github.com/GaloisInc/cryptol/issues/2070))
 
+* Fix a bug in which numeric constraint guards that include "trivial"
+  constraints (e.g., `n == n`) could generate ill-typed code.
+  ([#2093](https://github.com/GaloisInc/cryptol/issues/2093))
+
 ## API changes
 
 * Add `isValidIdent` to `Cryptol.Parser.LexerUtils`, which checks if a name is

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,10 @@
   constraint is headed by a not-equal (`!=`) operator.
   ([#2038](https://github.com/GaloisInc/cryptol/issues/2038))
 
+* `Cryptol.TypeCheck.Solver.InfNat.genLog` now takes the log base as the first
+  argument instead of the second argument. This better reflects the intuition
+  that `genLog base x` mirrors the mathematical notation `log_{base}(x)`.
+
 # 3.5.0 -- 2026-01-27
 
 ## Administrative changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,13 @@
 * Add a `notPrime` constraint.
   ([#2089](https://github.com/GaloisInc/cryptol/issues/2089))
 
+* Add the following typechecker simplification rules:
+  * `K1 != K2 ^^ t ~~> t != logBase K2 K1`
+  * `K1 ^^ t >= K2 ~~> t >= logBase K2 K1`
+  * `K1 ^^ t >  K2 ~~> t >  logBase K2 K1`
+  * `K1 >= K2 ^^ t ~~> logBase K2 K1 >= t`
+  * `K1 >  K2 ^^ t ~~> logBase K2 K1 >  t`
+
 ## Bug fixes
 
 * Fix pretty printing of types in errors messages

--- a/src/Cryptol/Backend/Concrete.hs
+++ b/src/Cryptol/Backend/Concrete.hs
@@ -89,7 +89,7 @@ integerToChar :: Integer -> Char
 integerToChar = toEnum . fromInteger
 
 lg2 :: Integer -> Integer
-lg2 i = case genLog i 2 of
+lg2 i = case genLog 2 i of
   Just (i',isExact) | isExact   -> i'
                     | otherwise -> i' + 1
   Nothing                       -> 0
@@ -146,7 +146,7 @@ instance Backend Concrete where
 
   wordLen' _ (BV w _) = w
   {-# INLINE wordLen' #-}
-  
+
   wordAsChar _ (BV _ x) = Just $! integerToChar x
 
   wordBit _ (BV w x) idx = pure $! testBit x (fromInteger (w - 1 - idx))

--- a/src/Cryptol/TypeCheck/Kind.hs
+++ b/src/Cryptol/TypeCheck/Kind.hs
@@ -63,8 +63,7 @@ checkSchema withWild (P.Forall xs ps t mb) =
      -- XXX: We probably shouldn't do this, as we are changing what the
      -- user is doing.  We do it so that things are in a propal normal form,
      -- but we should probably figure out another time to do this.
-     let newPs = concatMap pSplitAnd $ map (simplify mempty)
-                                     $ map tRebuild ps1
+     let newPs = simplifyConstraintProps ps1
      return ( Forall xs1 newPs (tRebuild t1)
             , [ g { goal = tRebuild (goal g) } | g <- gs ]
             )
@@ -81,11 +80,17 @@ checkSchema withWild (P.Forall xs ps t mb) =
     function corresponding guard is checked.
 
   * We also check that there are no wild-cards in the constraints.
+
+  * If any constraints are trivial (e.g., `n == n`), then simplify them away.
+    This ensures that when we apply each auto-generated guard function to proof
+    arguments, we pick the correct number of 'EProofApp's.
 -}
 checkPropGuards :: [Located (P.Prop Name)] -> InferM [Prop]
 checkPropGuards props =
   do (newPs,_gs) <- collectGoals (mapM check props)
-     pure newPs
+     -- Use `simplifyConstraintProps` here for symmetry with `checkSchema`,
+     -- which also simplifies away trivial constraints in type signatures.
+     pure $ simplifyConstraintProps newPs
   where
   check lp =
     inRange (srcRange lp)
@@ -649,3 +654,9 @@ checkKind _ (Just k1) k2
   | k1 /= k2    = do kRecordError (KindMismatch Nothing k1 k2)
                      kNewType TypeErrorPlaceHolder k1
 checkKind t _ _ = return t
+
+-- | Simplify constraints arising from a user-written type signature (see
+-- 'checkSchema') or numeric constraint guards (see 'checkPropGuards').
+simplifyConstraintProps :: [Prop] -> [Prop]
+simplifyConstraintProps =
+  concatMap pSplitAnd . map (simplify mempty) . map tRebuild

--- a/src/Cryptol/TypeCheck/Solver/InfNat.hs
+++ b/src/Cryptol/TypeCheck/Solver/InfNat.hs
@@ -145,7 +145,7 @@ nCeilMod (Nat x) (Nat y)  = Just (Nat (mod (- x) y))
 nLg2 :: Nat' -> Nat'
 nLg2 Inf      = Inf
 nLg2 (Nat 0)  = Nat 0
-nLg2 (Nat n)  = case genLog n 2 of
+nLg2 (Nat n)  = case genLog 2 n of
                   Just (x,exact) | exact     -> Nat x
                                  | otherwise -> Nat (x + 1)
                   Nothing -> panic "Cryptol.TypeCheck.Solver.InfNat.nLg2"
@@ -225,12 +225,12 @@ nLenFromThenTo _ _ _ = Nothing
 -- | Compute the logarithm of a number in the given base, rounded down to the
 -- closest integer.  The boolean indicates if we the result is exact
 -- (i.e., True means no rounding happened, False means we rounded down).
--- The logarithm base is the second argument.
+-- The logarithm base is the first argument.
 genLog :: Integer -> Integer -> Maybe (Integer, Bool)
-genLog x 0    = if x == 1 then Just (0, True) else Nothing
-genLog _ 1    = Nothing
-genLog 0 _    = Nothing
-genLog x base = Just (exactLoop 0 x)
+genLog 0 x    = if x == 1 then Just (0, True) else Nothing
+genLog 1 _    = Nothing
+genLog _ 0    = Nothing
+genLog base x = Just (exactLoop 0 x)
   where
   exactLoop s i
     | i == 1     = (s,True)

--- a/src/Cryptol/TypeCheck/Solver/Numeric.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric.hs
@@ -52,7 +52,11 @@ cryIsEqual ctxt t1 t2 =
 
 -- | Try to solve @t1 /= t2@
 cryIsNotEqual :: Ctxt -> Type -> Type -> Solved
-cryIsNotEqual _i t1 t2 = matchDefault Unsolved (pBin (/=) t1 t2)
+cryIsNotEqual i t1 t2 =
+  matchDefault Unsolved $
+        (pBin (/=) t1 t2)
+    <|> (aNat' t1 >>= tryNeqK i t2)
+    <|> (aNat' t2 >>= tryNeqK i t1)
 
 -- | Try to solve @t1 >= t2@
 cryIsGeq :: Ctxt -> Type -> Type -> Solved
@@ -139,6 +143,25 @@ tryGeqKThan _ ty (Nat n) =
                 Inf   -> [ b =#= tZero ]
                 Nat 0 -> []
                 Nat k -> [ tNum (div n k) >== b ]
+  <|>
+  -- K1 >= K2 ^^ t    ~~> logBase K2 K1 >= t
+  do (rk, b) <- matches ty ((|^|), aNat, __)
+     case genLog n rk of
+       Just (a,True) -> pure $ SolvedIf [ tNum a >== b ]
+       _ -> pure Unsolved
+  <|>
+  -- K1 >= 1 + (K2 ^^ t)    ~~> logBase K2 K1 >= 1 + t
+  --
+  -- Or, equivalently,
+  --
+  -- K1 > K2 ^^ t           ~~> logBase K2 K1 > t
+  do (oneTy,ty') <- anAdd ty
+     oneK <- aNat oneTy
+     guard (oneK == 1)
+     (rk, b) <- matches ty' ((|^|), aNat, __)
+     case genLog n rk of
+       Just (a,True) -> pure $ SolvedIf [ tNum a >== tf2 TCAdd (tNum (1::Int)) b ]
+       _ -> pure Unsolved
 
 -- | Try to solve @t >= K@
 tryGeqThanK :: Ctxt -> Type -> Nat' -> Match Solved
@@ -151,7 +174,21 @@ tryGeqThanK _ t (Nat k) =
      return $ SolvedIf $ if n >= k
                             then []
                             else [ b >== tNum (k - n) ]
-  -- XXX: K1 ^^ n >= K2
+  <|>
+  -- K1 ^^ t >= K2    ~~> t >= logBase K1 K2
+  do (rk, a) <- matches t ((|^|), aNat, __)
+     case genLog k rk of
+       Just (b,True) -> pure $ SolvedIf [ a >== tNum b ]
+       _ ->
+         -- K1 ^^ t >= 1 + K2 ~~> t >= 1 + logBase K1 K2
+         --
+         -- Or, equivalently,
+         --
+         -- K1 ^^ t > K2      ~~> t > logBase K2 K1
+         do guard (k > 0)
+            case genLog (k-1) rk of
+              Just (b,True) -> pure $ SolvedIf [ a >== tNum (1+b) ]
+              _ -> pure Unsolved
 
 
 -- (K >= 2 && K^a >= K^b) => a >= b
@@ -412,6 +449,17 @@ tryEqK ctxt ty lk =
   -- 2  = min (2,y)   --> y >= 2
   -- 10 = min (2,y)   --> impossible
 
+
+-- e.g., 10 = t
+tryNeqK :: Ctxt -> Type -> Nat' -> Match Solved
+tryNeqK _ ty lk =
+
+  -- K1 != K2 ^^ t    ~~> t != logBase K2 K1
+  do (rk, b) <- matches ty ((|^|), aNat, __)
+     return $ case lk of
+                Inf | rk > 1 -> SolvedIf [ b =/= tInf ]
+                Nat n | Just (a,True) <- genLog n rk -> SolvedIf [ b =/= tNum a]
+                _ -> SolvedIf []
 
 -- | K1 * t1 + K2 * t2 + ... = K3 * t3 + K4 * t4 + ...
 tryEqMulConst :: Type -> Type -> Match Solved

--- a/src/Cryptol/TypeCheck/Solver/Numeric.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric.hs
@@ -145,9 +145,10 @@ tryGeqKThan _ ty (Nat n) =
                 Nat k -> [ tNum (div n k) >== b ]
   <|>
   -- K1 >= K2 ^^ t    ~~> logBase K2 K1 >= t
-  do (rk, b) <- matches ty ((|^|), aNat, __)
-     case genLog n rk of
-       Just (a,True) -> pure $ SolvedIf [ tNum a >== b ]
+  do let k1 = n
+     (k2, t) <- matches ty ((|^|), aNat, __)
+     case genLog k1 k2 of
+       Just (logBaseK2K1,True) -> pure $ SolvedIf [ tNum logBaseK2K1 >== t ]
        _ -> pure Unsolved
   <|>
   -- K1 >= 1 + (K2 ^^ t)    ~~> logBase K2 K1 >= 1 + t
@@ -155,12 +156,14 @@ tryGeqKThan _ ty (Nat n) =
   -- Or, equivalently,
   --
   -- K1 > K2 ^^ t           ~~> logBase K2 K1 > t
-  do (oneTy,ty') <- anAdd ty
+  do let k1 = n
+     (oneTy,ty') <- anAdd ty
      oneK <- aNat oneTy
      guard (oneK == 1)
-     (rk, b) <- matches ty' ((|^|), aNat, __)
-     case genLog n rk of
-       Just (a,True) -> pure $ SolvedIf [ tNum a >== tf2 TCAdd (tNum (1::Int)) b ]
+     (k2, t) <- matches ty' ((|^|), aNat, __)
+     case genLog k1 k2 of
+       Just (logBaseK2K1,True) ->
+         pure $ SolvedIf [ tNum logBaseK2K1 >== tf2 TCAdd (tNum oneK) t ]
        _ -> pure Unsolved
 
 -- | Try to solve @t >= K@
@@ -176,22 +179,25 @@ tryGeqThanK _ t (Nat k) =
                             else [ b >== tNum (k - n) ]
   <|>
   -- K1 ^^ t >= K2    ~~> t >= logBase K1 K2
-  do (rk, a) <- matches t ((|^|), aNat, __)
-     case genLog k rk of
+  do (k1, t') <- matches t ((|^|), aNat, __)
+     let k2 = k
+     case genLog k2 k1 of
        -- Only apply the rewrite if logBase returns an exact result.
        -- See Note [Don't weaken inequalities involving logBase].
-       Just (b,True) -> pure $ SolvedIf [ a >== tNum b ]
+       Just (logBaseK1K2,True) -> pure $ SolvedIf [ t' >== tNum logBaseK1K2 ]
        _ ->
          -- K1 ^^ t >= 1 + K2 ~~> t >= 1 + logBase K1 K2
          --
          -- Or, equivalently,
          --
          -- K1 ^^ t > K2      ~~> t > logBase K2 K1
-         do guard (k > 0)
-            case genLog (k-1) rk of
+         do let k2Plus1 = k
+            guard (k2Plus1 > 0)
+            case genLog (k2Plus1-1) k1 of
               -- Only apply the rewrite if logBase returns an exact result.
               -- See Note [Don't weaken inequalities involving logBase].
-              Just (b,True) -> pure $ SolvedIf [ a >== tNum (1+b) ]
+              Just (logBaseK1K2,True) ->
+                pure $ SolvedIf [ t' >== tNum (1+logBaseK1K2) ]
               _ -> pure Unsolved
 
 {-
@@ -428,7 +434,7 @@ tryEqVar ty x =
 
 
 
--- e.g., 10 = t
+-- (K = t) (e.g., 10 = t)
 tryEqK :: Ctxt -> Type -> Nat' -> Match Solved
 tryEqK ctxt ty lk =
 
@@ -481,10 +487,11 @@ tryEqK ctxt ty lk =
 
   <|>
   -- K1 == K2 ^^ t    ~~> t = logBase K2 K1
-  do (rk, b) <- matches ty ((|^|), aNat, __)
+  do (k2, t) <- matches ty ((|^|), aNat, __)
      return $ case lk of
-                Inf | rk > 1 -> SolvedIf [ b =#= tInf ]
-                Nat n | Just (a,True) <- genLog n rk -> SolvedIf [ b =#= tNum a]
+                Inf | k2 > 1 -> SolvedIf [ t =#= tInf ]
+                Nat k1 | Just (logBaseK2K1,True) <- genLog k1 k2 ->
+                  SolvedIf [ t =#= tNum logBaseK2K1]
                 _ -> Unsolvable
 
   -- XXX: Min, Max, etx
@@ -493,15 +500,16 @@ tryEqK ctxt ty lk =
   -- 10 = min (2,y)   --> impossible
 
 
--- e.g., 10 = t
+-- K != t (e.g., 10 = t)
 tryNeqK :: Ctxt -> Type -> Nat' -> Match Solved
 tryNeqK _ ty lk =
 
   -- K1 != K2 ^^ t    ~~> t != logBase K2 K1
-  do (rk, b) <- matches ty ((|^|), aNat, __)
+  do (k2, t) <- matches ty ((|^|), aNat, __)
      return $ case lk of
-                Inf | rk > 1 -> SolvedIf [ b =/= tInf ]
-                Nat n | Just (a,True) <- genLog n rk -> SolvedIf [ b =/= tNum a]
+                Inf | k2 > 1 -> SolvedIf [ t =/= tInf ]
+                Nat k1 | Just (logBaseK2K1,True) <- genLog k1 k2 ->
+                  SolvedIf [ t =/= tNum logBaseK2K1]
                 _ -> SolvedIf []
 
 -- | K1 * t1 + K2 * t2 + ... = K3 * t3 + K4 * t4 + ...

--- a/src/Cryptol/TypeCheck/Solver/Numeric.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric.hs
@@ -178,6 +178,8 @@ tryGeqThanK _ t (Nat k) =
   -- K1 ^^ t >= K2    ~~> t >= logBase K1 K2
   do (rk, a) <- matches t ((|^|), aNat, __)
      case genLog k rk of
+       -- Only apply the rewrite if logBase returns an exact result.
+       -- See Note [Don't weaken inequalities involving logBase].
        Just (b,True) -> pure $ SolvedIf [ a >== tNum b ]
        _ ->
          -- K1 ^^ t >= 1 + K2 ~~> t >= 1 + logBase K1 K2
@@ -187,9 +189,50 @@ tryGeqThanK _ t (Nat k) =
          -- K1 ^^ t > K2      ~~> t > logBase K2 K1
          do guard (k > 0)
             case genLog (k-1) rk of
+              -- Only apply the rewrite if logBase returns an exact result.
+              -- See Note [Don't weaken inequalities involving logBase].
               Just (b,True) -> pure $ SolvedIf [ a >== tNum (1+b) ]
               _ -> pure Unsolved
 
+{-
+Note [Don't weaken inequalities involving logBase]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Consider the logBase(base, x) function, which returns the number y such that
+`x = base^^y`. In most math settings, logBase works over real numbers, but in
+Cryptol, all type-level numeric operators are restricted to natural numbers, so
+Cryptol defines logBase to round down to the nearest natural number if the
+result is inexact (i.e., if logBase would have otherwise returned a real
+number). For instance, this means that:
+
+  logBase 2 2 == 1 (exact result)
+  logBase 2 3 == 1 (inexact result)
+
+Now consider the following rewrites in tryGetThanK:
+
+  K1 ^^ t >= K2    ~~>    t >= logBase K1 K2
+  K1 ^^ t >  K2    ~~>    t >  logBase K1 K2
+
+Cryptol will only apply these rewrites if `logBase K1 K2` return exact results.
+Note that the left-hand sides of the `~~>` rewrites would still imply the
+right-hand sides even if the `logBase` results were inexact, but the resulting
+inequalities would be weaker than before. To see why this can be a problem,
+consider the following function:
+
+  f : {n} (2^^(2^^n) >= 3) => [n]
+  f = [False] # zero
+
+The body of `f` will only typecheck if `n > 0`. Critically, we do /not/ want to
+apply the `K1 ^^ t >= K2 ~~> t >= logBase K1 K2` rewrite above. If we did,
+the following chain of rewrites would occur:
+
+  2^^(2^^n) >= 3    ~~>    2^^n >= 1    (since `logBase 2 3 == 1` with an inexact result)
+  2^^n >= 1         ~~>    n >= 0       (since `logBase 2 1 == 0` with an exact result)
+
+But now Cryptol is left with `n >= 0`, which does not imply `n > 0`! As a
+result, Cryptol cannot typecheck `f`, which is terrible. Moral of the story:
+only apply the rewrites above if `logBase` returns exact results, which
+prevents this sort of constraint weakening.
+-}
 
 -- (K >= 2 && K^a >= K^b) => a >= b
 tryGeqExp :: Ctxt -> Type -> Type -> Match Solved

--- a/src/Cryptol/TypeCheck/Solver/Numeric.hs
+++ b/src/Cryptol/TypeCheck/Solver/Numeric.hs
@@ -147,7 +147,7 @@ tryGeqKThan _ ty (Nat n) =
   -- K1 >= K2 ^^ t    ~~> logBase K2 K1 >= t
   do let k1 = n
      (k2, t) <- matches ty ((|^|), aNat, __)
-     case genLog k1 k2 of
+     case genLog k2 k1 of
        Just (logBaseK2K1,True) -> pure $ SolvedIf [ tNum logBaseK2K1 >== t ]
        _ -> pure Unsolved
   <|>
@@ -161,7 +161,7 @@ tryGeqKThan _ ty (Nat n) =
      oneK <- aNat oneTy
      guard (oneK == 1)
      (k2, t) <- matches ty' ((|^|), aNat, __)
-     case genLog k1 k2 of
+     case genLog k2 k1 of
        Just (logBaseK2K1,True) ->
          pure $ SolvedIf [ tNum logBaseK2K1 >== tf2 TCAdd (tNum oneK) t ]
        _ -> pure Unsolved
@@ -181,7 +181,7 @@ tryGeqThanK _ t (Nat k) =
   -- K1 ^^ t >= K2    ~~> t >= logBase K1 K2
   do (k1, t') <- matches t ((|^|), aNat, __)
      let k2 = k
-     case genLog k2 k1 of
+     case genLog k1 k2 of
        -- Only apply the rewrite if logBase returns an exact result.
        -- See Note [Don't weaken inequalities involving logBase].
        Just (logBaseK1K2,True) -> pure $ SolvedIf [ t' >== tNum logBaseK1K2 ]
@@ -193,7 +193,7 @@ tryGeqThanK _ t (Nat k) =
          -- K1 ^^ t > K2      ~~> t > logBase K2 K1
          do let k2Plus1 = k
             guard (k2Plus1 > 0)
-            case genLog (k2Plus1-1) k1 of
+            case genLog k1 (k2Plus1-1) of
               -- Only apply the rewrite if logBase returns an exact result.
               -- See Note [Don't weaken inequalities involving logBase].
               Just (logBaseK1K2,True) ->
@@ -490,7 +490,7 @@ tryEqK ctxt ty lk =
   do (k2, t) <- matches ty ((|^|), aNat, __)
      return $ case lk of
                 Inf | k2 > 1 -> SolvedIf [ t =#= tInf ]
-                Nat k1 | Just (logBaseK2K1,True) <- genLog k1 k2 ->
+                Nat k1 | Just (logBaseK2K1,True) <- genLog k2 k1 ->
                   SolvedIf [ t =#= tNum logBaseK2K1]
                 _ -> Unsolvable
 
@@ -508,7 +508,7 @@ tryNeqK _ ty lk =
   do (k2, t) <- matches ty ((|^|), aNat, __)
      return $ case lk of
                 Inf | k2 > 1 -> SolvedIf [ t =/= tInf ]
-                Nat k1 | Just (logBaseK2K1,True) <- genLog k1 k2 ->
+                Nat k1 | Just (logBaseK2K1,True) <- genLog k2 k1 ->
                   SolvedIf [ t =/= tNum logBaseK2K1]
                 _ -> SolvedIf []
 

--- a/tests/constraint-guards/trivial-constraints.cry
+++ b/tests/constraint-guards/trivial-constraints.cry
@@ -1,0 +1,18 @@
+f : {n} [n] -> Bit
+f _ | n != n => False
+    | n == n => True
+
+g : {n} [n] -> Bit
+g _ | n != n => False
+    | (n == n, fin n) => False
+    | n == n => True
+
+h : {n} [n] -> Bit
+h _ | (n == n, n != n) => False
+    | n == n => True
+
+i : {n} [n] -> Bit
+i _ | (n == n, n == n) => True
+
+j : {n} [n] -> Bit
+j _ | n == n => True

--- a/tests/constraint-guards/trivial-constraints.icry
+++ b/tests/constraint-guards/trivial-constraints.icry
@@ -1,0 +1,4 @@
+// A regression test for #2093. This ensures that trivial constraints mentioned
+// in numeric constraint guards result in valid code, as checked by coreLint.
+:set coreLint=on
+:l trivial-constraints.cry

--- a/tests/constraint-guards/trivial-constraints.icry.stdout
+++ b/tests/constraint-guards/trivial-constraints.icry.stdout
@@ -1,0 +1,12 @@
+Loading module Cryptol
+Loading module Cryptol
+{n, a, b, c} n == min n n
+{a, n} (fin n) => inf == inf * (1 * (1 * 1))
+{a, n} (fin n) => n / 2 + n /^ 2 == n
+{n, a, b} n == min n n
+{n} (n >= 1, fin n) => (fin n, n >= 1)
+Loading module Main
+{n} n != n
+{n} fin n
+{n} n != n
+{n} n != n

--- a/tests/issues/issue1796.cry
+++ b/tests/issues/issue1796.cry
@@ -1,29 +1,29 @@
 exhaustive1 : {w} [2 ^^ (2 ^^ w)] -> [2 ^^ (2 ^^ w)]
 exhaustive1 x
-  | (2 ^^ (2 ^^ w)) < 2 => x
-  | (2 ^^ (2 ^^ w)) == 2 => ~ x
-  | (2 ^^ (2 ^^ w)) > 2 => x
+  | (2 ^^ (2 ^^ w)) < 2 => x                // Unreachable case
+  | (2 ^^ (2 ^^ w)) == 2 => [False, False]  // Constraint implies (w == 0)
+  | (2 ^^ (2 ^^ w)) > 2 => [True] # zero    // Constraint implies (w > 0)
 
 exhaustive1Reordered1: {w} [2 ^^ (2 ^^ w)] -> [2 ^^ (2 ^^ w)]
 exhaustive1Reordered1 x
-  | (2 ^^ (2 ^^ w)) == 2 => ~ x
-  | (2 ^^ (2 ^^ w)) < 2 => x
-  | (2 ^^ (2 ^^ w)) > 2 => x
+  | (2 ^^ (2 ^^ w)) == 2 => [False, False]  // Constraint implies (w == 0)
+  | (2 ^^ (2 ^^ w)) < 2 => x                // Unreachable case
+  | (2 ^^ (2 ^^ w)) > 2 => [True] # zero    // Constraint implies (w > 0)
 
 exhaustive1Reordered2 : {w} [2 ^^ (2 ^^ w)] -> [2 ^^ (2 ^^ w)]
 exhaustive1Reordered2 x
-  | (2 ^^ (2 ^^ w)) == 2 => ~ x
-  | (2 ^^ (2 ^^ w)) > 2 => x
-  | (2 ^^ (2 ^^ w)) < 2 => x
+  | (2 ^^ (2 ^^ w)) == 2 => [False, False]  // Constraint implies (w == 0)
+  | (2 ^^ (2 ^^ w)) > 2 => [True] # zero    // Constraint implies (w > 0)
+  | (2 ^^ (2 ^^ w)) < 2 => x                // Unreachable case
 
 // Note that `(2 ^^ w) >= 1`, which means that there is no need for a
 // `(2 ^^ w) < 1` guard below.
 exhaustive2 : {w} [2 ^^ w] -> [2 ^^ w]
 exhaustive2 x
-  | (2 ^^ w) == 1 => ~ x
-  | (2 ^^ w) > 1 => x
+  | (2 ^^ w) == 1 => [False]                // Constraint implies (w == 0)
+  | (2 ^^ w) > 1 => [True] # zero           // Constraint implies (w > 0)
 
 exhaustive3 : {w} [2 ^^ (2 ^^ w)] -> [2 ^^ (2 ^^ w)]
 exhaustive3 x
-  | (2 ^^ (2 ^^ w)) == 2 => ~ x
-  | (2 ^^ (2 ^^ w)) > 2 => x
+  | (2 ^^ (2 ^^ w)) == 2 => [False, False]  // Constraint implies (w == 0)
+  | (2 ^^ (2 ^^ w)) > 2 => [True] # zero    // Constraint implies (w > 0)


### PR DESCRIPTION
When typechecking a `Schema`, Cryptol sometimes simplifies away `Prop`s corresponding to "trivial" constraints (e.g., `n == n`). As a result, when desugaring numeric constraint guards, we must also be careful to simplify away trivial constraints that are mentioned in a guard, as the type of the corresponding guard function will not have these constraints in its type signature. This ensures that we apply the correct number of `EProofApp`s.

Fixes #2093.