### PR TITLE
Fix misleading comments and test cases mentioning NaN's sign bit

### DIFF
--- a/lib/Float.cry
+++ b/lib/Float.cry
@@ -98,6 +98,12 @@ fpNegZero = - fpPosZero
 in IEEE interchange format with layout:
 
   (sign : [1]) # (biased_exponent : [e]) # (significand : [p-1])
+
+Note that there are multiple bit patterns which correspond to NaN. If
+'biased_exponent' has all bits set and 'significand' has at least one bit set,
+then 'fpToBits' will return a NaN. On the other hand, calling 'fpFromBits' on
+NaN will always return one particular bit pattern (see the documentation for
+'fpFromBits' for more details).
 */
 primitive
   fpFromBits : {e,p} ValidFloat e p => [e + p] -> Float e p
@@ -106,9 +112,14 @@ primitive
 
   (sign : [1]) # (biased_exponent : [e]) # (significand : [p-1])
 
-NaN is represented as:
-  * positive:           sign        == 0
-  * quiet with no info: significand == 0b1 # 0
+NaN is represented using:
+  * an unset sign bit:     sign            == 0
+  * all exponent bits set: biased_exponent == repeat 1
+  * quiet with no info:    significand     == 0b1 # 0
+
+Note that although NaN uses a 'sign' bit 0, it should not be considered a
+positive number. The IEEE-754 standard does not interpret the sign of a NaN, so
+the sign bit has no mathematical meaning.
 */
 primitive
   fpToBits : {e,p} ValidFloat e p => Float e p -> [e + p]

--- a/tests/regression/FloatPropertiesGeneric.cry
+++ b/tests/regression/FloatPropertiesGeneric.cry
@@ -11,7 +11,13 @@ import Float
 
 ///// Helpers
 
-// `True` if negative, `False` if positive
+// `True` if the sign bit is set, `False` otherwise. If a number's sign bit is
+// set, then that usually implies that the number is negative, and inversely,
+// if a number's sign bit is unset, then that usually implies that the number
+// is positive. The one exception to this rule is NaN, whose sign bit is unset
+// but is considered to be neither a negative nor a positive number. The
+// IEEE-754 standard does not interpret the sign of a NaN, so the sign bit has
+// no mathematical meaning.
 fpSign : {e, p} (ValidFloat e p, p >= 1) => Float e p -> Bit
 fpSign x = head (fpToBits x)
 
@@ -22,7 +28,7 @@ fpSignificand : {e, p} (ValidFloat e p, p >= 1) => Float e p -> [p - 1]
 fpSignificand x = drop`{1 + e} (fpToBits x)
 
 fpIsPos : {e, p} ValidFloat e p => Float e p -> Bit
-fpIsPos x = ~ (fpIsNeg x)
+fpIsPos x = ~ (fpIsNeg x \/ fpIsNaN x)
 
 ///// fpNaN
 
@@ -35,9 +41,9 @@ prop_fpNaNIsNotInf = ~ (fpIsInf (fpNaN`{e, p}))
 prop_fpNaNIsNotZero : {e, p} ValidFloat e p => Bit
 prop_fpNaNIsNotZero = ~ (fpIsZero (fpNaN`{e, p}))
 
-// Cryptol chooses to represent NaN as a positive value.
-prop_fpNaNIsPos : {e, p} ValidFloat e p => Bit
-prop_fpNaNIsPos = fpIsPos (fpNaN`{e, p})
+// Cryptol chooses to represent NaN with a sign bit of 0:
+prop_fpNaNSign : {e, p} (ValidFloat e p, p >= 1) => Bit
+prop_fpNaNSign = ~ (fpSign (fpNaN`{e, p}))
 
 prop_fpNaNIsNotNormal : {e, p} ValidFloat e p => Bit
 prop_fpNaNIsNotNormal = ~ (fpIsNormal (fpNaN`{e, p}))
@@ -206,8 +212,11 @@ prop_fpLogicalEqTransitive x y z = (x =.= y /\ y =.= z) ==> (x =.= z)
 
 ///// fpIsNeg
 
+prop_fpIsPosSign : {e, p} (ValidFloat e p, p >= 1) => Float e p -> Bit
+prop_fpIsPosSign x = fpIsPos x ==> ~ (fpSign x)
+
 prop_fpIsNegSign : {e, p} (ValidFloat e p, p >= 1) => Float e p -> Bit
-prop_fpIsNegSign x = fpIsNeg x == fpSign x
+prop_fpIsNegSign x = fpIsNeg x ==> fpSign x
 
 ///// fpIsNormal
 
@@ -432,34 +441,44 @@ prop_fpMulRightNegZero m x =
   ~ (fpIsNaN x \/ fpIsInf x) ==>
     (fpMul m x fpNegZero =.= if fpIsNeg x then fpPosZero else fpNegZero)
 
+// Special cases:
+//
+// * Infinite/zero: `-inf * -0 =.= -0 * -inf =.= NaN`, and NaN is not
+//   considered to be positive.
 prop_fpMulNegNeg :
   {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
-prop_fpMulNegNeg m x y = (fpIsNeg x /\ fpIsNeg y) ==> fpIsPos (fpMul m x y)
-
-prop_fpMulPosPos :
-  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
-prop_fpMulPosPos m x y = (fpIsPos x /\ fpIsPos y) ==> fpIsPos (fpMul m x y)
+prop_fpMulNegNeg m x y =
+  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y)) ==>
+  (fpIsNeg x /\ fpIsNeg y) ==> fpIsPos (fpMul m x y)
 
 // Special cases:
 //
-// * Infinite/zero: `-inf * 0 =.= -0 * inf =.= NaN`, and NaN is defined to be
-//   positive.
-// * NaN: `-x * NaN =.= NaN`, and NaN is defined to be positive.
+// * Infinite/zero: `inf * 0 =.= 0 * inf =.= NaN`, and NaN is not considered to
+//   be positive.
+prop_fpMulPosPos :
+  {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
+prop_fpMulPosPos m x y =
+  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y)) ==>
+  (fpIsPos x /\ fpIsPos y) ==> fpIsPos (fpMul m x y)
+
+// Special cases:
+//
+// * Infinite/zero: `-inf * 0 =.= -0 * inf =.= NaN`, and NaN is not considered
+//   to be positive.
 prop_fpMulNegPos :
   {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
 prop_fpMulNegPos m x y =
-  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y) \/ fpIsNaN y) ==>
+  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y)) ==>
     (fpIsNeg x /\ fpIsPos y) ==> fpIsNeg (fpMul m x y)
 
 // Special cases:
 //
-// * Infinite/zero: `inf * -0 =.= 0 * -inf =.= NaN`, and NaN is defined to be
-//   positive.
-// * NaN: `NaN * -inf =.= NaN`, and NaN is defined to be positive.
+// * Infinite/zero: `inf * -0 =.= 0 * -inf =.= NaN`, and NaN is not considered
+//   to be positive.
 prop_fpMulPosNeg :
   {e, p} ValidFloat e p => RoundingMode -> Float e p -> Float e p -> Bit
 prop_fpMulPosNeg m x y =
-  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y) \/ fpIsNaN x) ==>
+  ~ ((fpIsInf x /\ fpIsZero y) \/ (fpIsZero x /\ fpIsInf y)) ==>
     (fpIsPos x /\ fpIsNeg y) ==> fpIsNeg (fpMul m x y)
 
 prop_fpMulCommutative :

--- a/tests/regression/FloatPropertiesGeneric.cry
+++ b/tests/regression/FloatPropertiesGeneric.cry
@@ -41,19 +41,21 @@ prop_fpNaNIsNotInf = ~ (fpIsInf (fpNaN`{e, p}))
 prop_fpNaNIsNotZero : {e, p} ValidFloat e p => Bit
 prop_fpNaNIsNotZero = ~ (fpIsZero (fpNaN`{e, p}))
 
-// Cryptol chooses to represent NaN with a sign bit of 0:
-prop_fpNaNSign : {e, p} (ValidFloat e p, p >= 1) => Bit
-prop_fpNaNSign = ~ (fpSign (fpNaN`{e, p}))
-
 prop_fpNaNIsNotNormal : {e, p} ValidFloat e p => Bit
 prop_fpNaNIsNotNormal = ~ (fpIsNormal (fpNaN`{e, p}))
 
 prop_fpNaNIsNotSubnormal : {e, p} ValidFloat e p => Bit
 prop_fpNaNIsNotSubnormal = ~ (fpIsSubnormal (fpNaN`{e, p}))
 
-// Cryptol chooses to represent NaN as quiet with no info:
-prop_fpNaNIsQuiet : {e, p} (ValidFloat e p, p >= 2) => Bit
-prop_fpNaNIsQuiet = fpSignificand (fpNaN`{e, p}) == (0b1 # 0)
+// IEEE-754 specifies that a NaN value's exponent has all bits set to 1.
+prop_fpNaNExponentAllOneBits : {e, p} (ValidFloat e p, p >= 1) => Bit
+prop_fpNaNExponentAllOneBits = and (fpExponent (fpNaN`{e, p}))
+
+// IEEE-754 specifies that a NaN value's significand has at least one bit set.
+// (If the significand is all zeroes, then the value would be infinite instead
+// of a NaN.)
+prop_fpNaNSignificandAtLeastOneBit : {e, p} (ValidFloat e p, p >= 1) => Bit
+prop_fpNaNSignificandAtLeastOneBit = or (fpSignificand (fpNaN`{e, p}))
 
 ///// fpPosInf
 

--- a/tests/regression/float_properties.icry
+++ b/tests/regression/float_properties.icry
@@ -15,8 +15,8 @@
 :prove prop_fpNaNIsNotInf`{8, 24}
 "Proving prop_fpNaNIsNotZero..."
 :prove prop_fpNaNIsNotZero`{8, 24}
-"Proving prop_fpNaNIsPos..."
-:prove prop_fpNaNIsPos`{8, 24}
+"Proving prop_fpNaNSign..."
+:prove prop_fpNaNSign`{8, 24}
 "Proving prop_fpNaNIsNotNormal..."
 :prove prop_fpNaNIsNotNormal`{8, 24}
 "Proving prop_fpNaNIsNotSubnormal..."
@@ -97,6 +97,8 @@
 :prove prop_fpLogicalEqSymmetric`{8, 24}
 "Proving prop_fpLogicalEqTransitive..."
 :prove prop_fpLogicalEqTransitive`{8, 24}
+"Proving prop_fpIsPosSign..."
+:prove prop_fpIsPosSign`{8, 24}
 "Proving prop_fpIsNegSign..."
 :prove prop_fpIsNegSign`{8, 24}
 "Proving prop_fpIsNormalCorrect..."

--- a/tests/regression/float_properties.icry
+++ b/tests/regression/float_properties.icry
@@ -15,14 +15,14 @@
 :prove prop_fpNaNIsNotInf`{8, 24}
 "Proving prop_fpNaNIsNotZero..."
 :prove prop_fpNaNIsNotZero`{8, 24}
-"Proving prop_fpNaNSign..."
-:prove prop_fpNaNSign`{8, 24}
 "Proving prop_fpNaNIsNotNormal..."
 :prove prop_fpNaNIsNotNormal`{8, 24}
 "Proving prop_fpNaNIsNotSubnormal..."
 :prove prop_fpNaNIsNotSubnormal`{8, 24}
-"Proving prop_fpNaNIsQuiet..."
-:prove prop_fpNaNIsQuiet`{8, 24}
+"Proving prop_fpNaNExponentAllOneBits..."
+:prove prop_fpNaNExponentAllOneBits`{8, 24}
+"Proving prop_fpNaNSignificandAtLeastOneBit..."
+:prove prop_fpNaNSignificandAtLeastOneBit`{8, 24}
 "Proving prop_fpPosInfIsPos..."
 :prove prop_fpPosInfIsPos`{8, 24}
 "Proving prop_fpPosInfIsInf..."

--- a/tests/regression/float_properties.icry.stdout
+++ b/tests/regression/float_properties.icry.stdout
@@ -8,13 +8,13 @@ Q.E.D.
 Q.E.D.
 "Proving prop_fpNaNIsNotZero..."
 Q.E.D.
-"Proving prop_fpNaNSign..."
-Q.E.D.
 "Proving prop_fpNaNIsNotNormal..."
 Q.E.D.
 "Proving prop_fpNaNIsNotSubnormal..."
 Q.E.D.
-"Proving prop_fpNaNIsQuiet..."
+"Proving prop_fpNaNExponentAllOneBits..."
+Q.E.D.
+"Proving prop_fpNaNSignificandAtLeastOneBit..."
 Q.E.D.
 "Proving prop_fpPosInfIsPos..."
 Q.E.D.

--- a/tests/regression/float_properties.icry.stdout
+++ b/tests/regression/float_properties.icry.stdout
@@ -8,7 +8,7 @@ Q.E.D.
 Q.E.D.
 "Proving prop_fpNaNIsNotZero..."
 Q.E.D.
-"Proving prop_fpNaNIsPos..."
+"Proving prop_fpNaNSign..."
 Q.E.D.
 "Proving prop_fpNaNIsNotNormal..."
 Q.E.D.
@@ -89,6 +89,8 @@ Q.E.D.
 "Proving prop_fpLogicalEqSymmetric..."
 Q.E.D.
 "Proving prop_fpLogicalEqTransitive..."
+Q.E.D.
+"Proving prop_fpIsPosSign..."
 Q.E.D.
 "Proving prop_fpIsNegSign..."
 Q.E.D.


### PR DESCRIPTION
NaN's sign bit being 0 should not be miscontrued as the NaN value itself being considered positive.

Fixes #2099.