### PR TITLE
Concrete backend: Fix `fpFromInteger`'s implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,10 @@
   constraints (e.g., `n == n`) could generate ill-typed code.
   ([#2093](https://github.com/GaloisInc/cryptol/issues/2093))
 
+* Fix a bug in which evaluating `fpToBits (fromInteger i : Float e p)` could
+  crash if the float size was smaller than a double-precision float.
+  ([#2108](https://github.com/GaloisInc/cryptol/issues/2108))
+
 ## API changes
 
 * Add `isValidIdent` to `Cryptol.Parser.LexerUtils`, which checks if a name is

--- a/src/Cryptol/Backend/Concrete.hs
+++ b/src/Cryptol/Backend/Concrete.hs
@@ -399,10 +399,11 @@ instance Backend Concrete where
 
   fpFromInteger sym e p r x =
     do r' <- fpRoundMode sym r
+       let opts = FP.fpOpts e p r'
        pure FP.BF { FP.bfExpWidth = e
                   , FP.bfPrecWidth = p
                   , FP.bfValue = FP.fpCheckStatus $
-                                 FP.bfRoundInt r' (FP.bfFromInteger x)
+                                 FP.bfRoundFloat opts (FP.bfFromInteger x)
                   }
   fpToInteger = fpCvtToInteger
 

--- a/tests/issues/issue2108.icry
+++ b/tests/issues/issue2108.icry
@@ -1,0 +1,5 @@
+:m Float
+:set prover=w4-bitwuzla
+fpToBits (fromInteger 4294967295 : Float32)
+:eval fpToBits (fromInteger 4294967295 : Float32)
+:prove fpToBits (fromInteger 4294967295 : Float32) == 0x4f800000

--- a/tests/issues/issue2108.icry.stdout
+++ b/tests/issues/issue2108.icry.stdout
@@ -1,0 +1,6 @@
+Loading module Cryptol
+Loading module Cryptol
+Loading module Float
+0x4f800000
+0x4f800000
+Q.E.D.


### PR DESCRIPTION
After converting the input integer to a float, the concrete backend's implementation of `fpFromInteger` was failing to round the float to the appropriate size. This is unlike the reference implementation, which properly rounded the float using `bfRoundFloat`. We now do the same thing in the concrete backend, thereby fixing #2108.